### PR TITLE
Removed name of check from exceptions

### DIFF
--- a/deepchecks/base/dataset.py
+++ b/deepchecks/base/dataset.py
@@ -516,7 +516,7 @@ class Dataset:
 
     # Validations:
 
-    def validate_label(self, check_name: str):
+    def validate_label(self):
         """
         Throws error if dataset does not have a label.
 
@@ -528,10 +528,10 @@ class Dataset:
 
         """
         if self.label_name is None:
-            raise DeepchecksValueError(f'Check {check_name} requires dataset to have a label column')
+            raise DeepchecksValueError('Check requires dataset to have a label column')
         self.check_compatible_labels()
 
-    def validate_features(self, check_name: str):
+    def validate_features(self):
         """
         Throws error if dataset does not have a features columns.
 
@@ -542,9 +542,9 @@ class Dataset:
             DeepchecksValueError: if dataset does not have features columns.
         """
         if not self._features:
-            raise DeepchecksValueError(f'Check {check_name} requires dataset to have features columns!')
+            raise DeepchecksValueError('Check requires dataset to have features columns!')
 
-    def validate_date(self, check_name: str):
+    def validate_date(self):
         """
         Throws error if dataset does not have a date column.
 
@@ -556,9 +556,9 @@ class Dataset:
 
         """
         if self.date_name is None:
-            raise DeepchecksValueError(f'Check {check_name} requires dataset to have a date column')
+            raise DeepchecksValueError('Check requires dataset to have a date column')
 
-    def validate_index(self, check_name: str):
+    def validate_index(self):
         """
         Throws error if dataset does not have an index column / does not use dataframe index as index.
 
@@ -570,7 +570,7 @@ class Dataset:
 
         """
         if self.index_name is None:
-            raise DeepchecksValueError(f'Check {check_name} requires dataset to have an index column')
+            raise DeepchecksValueError('Check requires dataset to have an index column')
 
     def filter_columns_with_validation(
         self: TDataset,
@@ -595,7 +595,7 @@ class Dataset:
         else:
             return self.copy(new_data)
 
-    def validate_shared_features(self, other, check_name: str) -> t.List[Hashable]:
+    def validate_shared_features(self, other) -> t.List[Hashable]:
         """
         Return the list of shared features if both datasets have the same feature column names. Else, raise error.
 
@@ -610,13 +610,13 @@ class Dataset:
             DeepchecksValueError if datasets don't have the same features
 
         """
-        Dataset.validate_dataset(other, check_name)
+        Dataset.validate_dataset(other)
         if sorted(self.features) == sorted(other.features):
             return self.features
         else:
-            raise DeepchecksValueError(f'Check {check_name} requires datasets to share the same features')
+            raise DeepchecksValueError('Check requires datasets to share the same features')
 
-    def validate_shared_categorical_features(self, other, check_name: str) -> t.List[Hashable]:
+    def validate_shared_categorical_features(self, other) -> t.List[Hashable]:
         """
         Return list of categorical features if both datasets have the same categorical features. Else, raise error.
 
@@ -630,16 +630,16 @@ class Dataset:
         Raises:
             DeepchecksValueError if datasets don't have the same features
         """
-        Dataset.validate_dataset(other, check_name)
+        Dataset.validate_dataset(other)
         if sorted(self.cat_features) == sorted(other.cat_features):
             return self.cat_features
         else:
-            raise DeepchecksValueError(f'Check {check_name} requires datasets to share '
+            raise DeepchecksValueError('Check requires datasets to share '
                                        'the same categorical features. Possible reason is that some columns were'
                                        'inferred incorrectly as categorical features. To fix this, manually edit the '
                                        'categorical features using Dataset(cat_features=<list_of_features>')
 
-    def validate_shared_label(self, other, check_name: str) -> Hashable:
+    def validate_shared_label(self, other) -> Hashable:
         """Verify presence of shared labels.
 
         Return the list of shared features if both datasets have the same
@@ -655,14 +655,14 @@ class Dataset:
         Raises:
             DeepchecksValueError if datasets don't have the same label
         """
-        Dataset.validate_dataset(other, check_name)
+        Dataset.validate_dataset(other)
         if (
             self.label_name is not None and other.label_name is not None
             and self.label_name == other.label_name
         ):
             return t.cast(Hashable, self.label_name)
         else:
-            raise DeepchecksValueError(f'Check {check_name} requires datasets to share the same label')
+            raise DeepchecksValueError('Check requires datasets to share the same label')
 
     @classmethod
     def validate_dataset_or_dataframe(cls, obj) -> 'Dataset':
@@ -684,11 +684,11 @@ class Dataset:
                 raise DeepchecksValueError('dataset cannot be empty')
             return Dataset(obj)
         else:
-            raise DeepchecksValueError(f'dataset must be of type DataFrame or Dataset. instead got: '
+            raise DeepchecksValueError('dataset must be of type DataFrame or Dataset. instead got: '
                                        f'{type(obj).__name__}')
 
     @classmethod
-    def validate_dataset(cls, obj, check_name: str) -> 'Dataset':
+    def validate_dataset(cls, obj) -> 'Dataset':
         """Throws error if object is not deepchecks Dataset and returns the object if deepchecks Dataset.
 
         Args:
@@ -699,10 +699,10 @@ class Dataset:
             (Dataset): object that is deepchecks dataset
         """
         if not isinstance(obj, Dataset):
-            raise DeepchecksValueError(f'Check {check_name} requires dataset to be of type Dataset. instead got: '
+            raise DeepchecksValueError('Check requires dataset to be of type Dataset. instead got: '
                                        f'{type(obj).__name__}')
         if len(obj.data) == 0:
-            raise DeepchecksValueError(f'Check {check_name} required a non-empty dataset')
+            raise DeepchecksValueError('Check requires a non-empty dataset')
 
         return obj
 

--- a/deepchecks/checks/distribution/train_test_drift.py
+++ b/deepchecks/checks/distribution/train_test_drift.py
@@ -216,8 +216,8 @@ class TrainTestDrift(TrainTestBaseCheck):
         train_dataset = train_dataset.filter_columns_with_validation(self.columns, self.ignore_columns)
         test_dataset = test_dataset.filter_columns_with_validation(self.columns, self.ignore_columns)
 
-        features = train_dataset.validate_shared_features(test_dataset, self.__class__.__name__)
-        cat_features = train_dataset.validate_shared_categorical_features(test_dataset, self.__class__.__name__)
+        features = train_dataset.validate_shared_features(test_dataset)
+        cat_features = train_dataset.validate_shared_categorical_features(test_dataset)
 
         values_dict = OrderedDict()
         displays_dict = OrderedDict()

--- a/deepchecks/checks/distribution/trust_score_comparison.py
+++ b/deepchecks/checks/distribution/trust_score_comparison.py
@@ -105,9 +105,9 @@ class TrustScoreComparison(TrainTestBaseCheck):
         model_type = task_type_check(model, test_dataset)
 
         # Baseline must have label so we must get it as Dataset.
-        Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        train_dataset.validate_label(self.__class__.__name__)
-        train_dataset.validate_shared_features(test_dataset, self.__class__.__name__)
+        Dataset.validate_dataset(train_dataset)
+        train_dataset.validate_label()
+        train_dataset.validate_shared_features(test_dataset)
 
         if test_dataset.n_samples < self.min_test_samples:
             msg = ('Number of samples in test dataset have not passed the minimum. you can change '

--- a/deepchecks/checks/integrity/dominant_frequency_change.py
+++ b/deepchecks/checks/integrity/dominant_frequency_change.py
@@ -111,7 +111,7 @@ class DominantFrequencyChange(CompareDatasetsBaseCheck):
         """
         baseline_dataset = Dataset.validate_dataset_or_dataframe(baseline_dataset)
         dataset = Dataset.validate_dataset_or_dataframe(dataset)
-        dataset.validate_shared_features(baseline_dataset, self.__class__.__name__)
+        dataset.validate_shared_features(baseline_dataset)
 
         columns = baseline_dataset.features
 

--- a/deepchecks/checks/integrity/label_ambiguity.py
+++ b/deepchecks/checks/integrity/label_ambiguity.py
@@ -56,10 +56,9 @@ class LabelAmbiguity(SingleDatasetBaseCheck):
         Returns:
           (CheckResult): percentage of ambiguous samples and display of the top n_to_show most ambiguous.
         """
-        check_name = type(self).__name__
-        dataset: Dataset = Dataset.validate_dataset(dataset, check_name)
+        dataset: Dataset = Dataset.validate_dataset(dataset)
         dataset = dataset.filter_columns_with_validation(self.columns, self.ignore_columns)
-        dataset.validate_label(check_name)
+        dataset.validate_label()
 
         label_col = dataset.label_name
 

--- a/deepchecks/checks/integrity/new_category.py
+++ b/deepchecks/checks/integrity/new_category.py
@@ -53,7 +53,7 @@ class CategoryMismatchTrainTest(TrainTestBaseCheck):
             displays a dataframe that shows columns with new categories
         """
         return self._new_category_train_test(train_dataset=train_dataset,
-                                                   test_dataset=test_dataset)
+                                             test_dataset=test_dataset)
 
     def _new_category_train_test(self, train_dataset: Dataset, test_dataset: Dataset):
         """Run check.
@@ -73,8 +73,8 @@ class CategoryMismatchTrainTest(TrainTestBaseCheck):
         test_dataset = Dataset.validate_dataset_or_dataframe(test_dataset)
         train_dataset = Dataset.validate_dataset_or_dataframe(train_dataset)
 
-        features = test_dataset.validate_shared_features(train_dataset, self.__class__.__name__)
-        cat_features = train_dataset.validate_shared_categorical_features(test_dataset, self.__class__.__name__)
+        features = test_dataset.validate_shared_features(train_dataset)
+        cat_features = train_dataset.validate_shared_categorical_features(test_dataset)
 
         test_dataset = test_dataset.filter_columns_with_validation(self.columns, self.ignore_columns)
         train_dataset = train_dataset.filter_columns_with_validation(self.columns, self.ignore_columns)

--- a/deepchecks/checks/integrity/new_label.py
+++ b/deepchecks/checks/integrity/new_label.py
@@ -47,11 +47,11 @@ class NewLabelTrainTest(TrainTestBaseCheck):
     def _new_label_train_test(self, train_dataset: Dataset, test_dataset: Dataset):
         test_dataset = Dataset.validate_dataset_or_dataframe(test_dataset)
         train_dataset = Dataset.validate_dataset_or_dataframe(train_dataset)
-        test_dataset.validate_label(self.__class__.__name__)
-        train_dataset.validate_label(self.__class__.__name__)
-        test_dataset.validate_shared_label(train_dataset, self.__class__.__name__)
+        test_dataset.validate_label()
+        train_dataset.validate_label()
+        test_dataset.validate_shared_label(train_dataset)
 
-        label_column = train_dataset.validate_shared_label(test_dataset, self.__class__.__name__)
+        label_column = train_dataset.validate_shared_label(test_dataset)
 
         n_test_samples = test_dataset.n_samples
 

--- a/deepchecks/checks/methodology/boosting_overfit.py
+++ b/deepchecks/checks/methodology/boosting_overfit.py
@@ -147,12 +147,12 @@ class BoostingOverfit(TrainTestBaseCheck):
             raise DeepchecksValueError('Can not have metric_name without metric')
         if not isinstance(self.num_steps, int) or self.num_steps < 2:
             raise DeepchecksValueError('num_steps must be an integer larger than 1')
-        Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        Dataset.validate_dataset(test_dataset, self.__class__.__name__)
-        train_dataset.validate_label(self.__class__.__name__)
-        test_dataset.validate_label(self.__class__.__name__)
-        train_dataset.validate_shared_features(test_dataset, self.__class__.__name__)
-        train_dataset.validate_shared_label(test_dataset, self.__class__.__name__)
+        Dataset.validate_dataset(train_dataset)
+        Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_label()
+        test_dataset.validate_label()
+        train_dataset.validate_shared_features(test_dataset)
+        train_dataset.validate_shared_label(test_dataset)
         validate_model(train_dataset, model)
 
         # Get default metric

--- a/deepchecks/checks/methodology/datasets_size_comparison.py
+++ b/deepchecks/checks/methodology/datasets_size_comparison.py
@@ -41,9 +41,8 @@ class DatasetsSizeComparison(TrainTestBaseCheck):
                 if not dataset instances were provided;
                 if datasets are empty;
         """
-        check_name = type(self).__name__
-        Dataset.validate_dataset(train_dataset, check_name)
-        Dataset.validate_dataset(test_dataset, check_name)
+        Dataset.validate_dataset(train_dataset)
+        Dataset.validate_dataset(test_dataset)
         sizes = {'Train': train_dataset.n_samples, 'Test': test_dataset.n_samples}
         display = pd.DataFrame(sizes, index=['Size'])
         return CheckResult(

--- a/deepchecks/checks/methodology/date_train_test_leakage_duplicates.py
+++ b/deepchecks/checks/methodology/date_train_test_leakage_duplicates.py
@@ -48,10 +48,10 @@ class DateTrainTestLeakageDuplicates(TrainTestBaseCheck):
         return self._date_train_test_leakage_duplicates(train_dataset, test_dataset)
 
     def _date_train_test_leakage_duplicates(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        test_dataset = Dataset.validate_dataset(test_dataset, self.__class__.__name__)
-        train_dataset.validate_date(self.__class__.__name__)
-        test_dataset.validate_date(self.__class__.__name__)
+        train_dataset = Dataset.validate_dataset(train_dataset)
+        test_dataset = Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_date()
+        test_dataset.validate_date()
 
         train_date = train_dataset.date_col
         val_date = test_dataset.date_col

--- a/deepchecks/checks/methodology/date_train_test_leakage_overlap.py
+++ b/deepchecks/checks/methodology/date_train_test_leakage_overlap.py
@@ -38,10 +38,10 @@ class DateTrainTestLeakageOverlap(TrainTestBaseCheck):
         return self._date_train_test_leakage_overlap(train_dataset, test_dataset)
 
     def _date_train_test_leakage_overlap(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        test_dataset = Dataset.validate_dataset(test_dataset, self.__class__.__name__)
-        train_dataset.validate_date(self.__class__.__name__)
-        test_dataset.validate_date(self.__class__.__name__)
+        train_dataset = Dataset.validate_dataset(train_dataset)
+        test_dataset = Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_date()
+        test_dataset.validate_date()
 
         train_date = train_dataset.date_col
         val_date = test_dataset.date_col

--- a/deepchecks/checks/methodology/identifier_leakage.py
+++ b/deepchecks/checks/methodology/identifier_leakage.py
@@ -53,8 +53,8 @@ class IdentifierLeakage(SingleDatasetBaseCheck):
         return self._identifier_leakage(dataset)
 
     def _identifier_leakage(self, dataset: Union[pd.DataFrame, Dataset], ppscore_params=None) -> CheckResult:
-        Dataset.validate_dataset(dataset, self.__class__.__name__)
-        dataset.validate_label(self.__class__.__name__)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
         ppscore_params = ppscore_params or {}
 
         relevant_columns = list(filter(None, [dataset.date_name, dataset.index_name, dataset.label_name]))

--- a/deepchecks/checks/methodology/index_leakage.py
+++ b/deepchecks/checks/methodology/index_leakage.py
@@ -49,10 +49,10 @@ class IndexTrainTestLeakage(TrainTestBaseCheck):
         return self._index_train_test_leakage(train_dataset, test_dataset)
 
     def _index_train_test_leakage(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        test_dataset = Dataset.validate_dataset(test_dataset, self.__class__.__name__)
-        train_dataset.validate_index(self.__class__.__name__)
-        test_dataset.validate_index(self.__class__.__name__)
+        train_dataset = Dataset.validate_dataset(train_dataset)
+        test_dataset = Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_index()
+        test_dataset.validate_index()
 
         train_index = train_dataset.index_col
         val_index = test_dataset.index_col

--- a/deepchecks/checks/methodology/model_inference_time.py
+++ b/deepchecks/checks/methodology/model_inference_time.py
@@ -64,9 +64,8 @@ class ModelInferenceTimeCheck(SingleDatasetBaseCheck):
         dataset: Dataset,
         model: object # TODO: find more precise type for model
     ) -> CheckResult:
-        check_name = type(self).__name__
-        Dataset.validate_dataset(dataset, check_name)
-        Dataset.validate_features(dataset, check_name)
+        Dataset.validate_dataset(dataset)
+        Dataset.validate_features(dataset)
         validate_model(dataset, model)
 
         prediction_method = model.predict # type: ignore

--- a/deepchecks/checks/methodology/performance_overfit.py
+++ b/deepchecks/checks/methodology/performance_overfit.py
@@ -73,13 +73,12 @@ class TrainTestDifferenceOverfit(TrainTestBaseCheck):
     def _train_test_difference_overfit(self, train_dataset: Dataset, test_dataset: Dataset, model,
                                        ) -> CheckResult:
         # Validate parameters
-        func_name = self.__class__.__name__
-        Dataset.validate_dataset(train_dataset, func_name)
-        Dataset.validate_dataset(test_dataset, func_name)
-        train_dataset.validate_label(func_name)
-        test_dataset.validate_label(func_name)
-        train_dataset.validate_shared_label(test_dataset, func_name)
-        train_dataset.validate_shared_features(test_dataset, func_name)
+        Dataset.validate_dataset(train_dataset)
+        Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_label()
+        test_dataset.validate_label()
+        train_dataset.validate_shared_label(test_dataset)
+        train_dataset.validate_shared_features(test_dataset)
         validate_model(test_dataset, model)
 
         metrics = get_metrics_list(model, train_dataset, self.alternative_metrics)

--- a/deepchecks/checks/methodology/single_feature_contribution.py
+++ b/deepchecks/checks/methodology/single_feature_contribution.py
@@ -59,9 +59,8 @@ class SingleFeatureContribution(SingleDatasetBaseCheck):
         return self._single_feature_contribution(dataset=dataset)
 
     def _single_feature_contribution(self, dataset: Dataset):
-        check_name = self.__class__.__name__
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
         ppscore_params = self.ppscore_params or {}
 
         relevant_columns = dataset.features + [dataset.label_name]

--- a/deepchecks/checks/methodology/single_feature_contribution_train_validation.py
+++ b/deepchecks/checks/methodology/single_feature_contribution_train_validation.py
@@ -61,12 +61,12 @@ class SingleFeatureContributionTrainTest(TrainTestBaseCheck):
                                                             test_dataset=test_dataset)
 
     def _single_feature_contribution_train_test(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset, self.__class__.__name__)
-        train_dataset.validate_label(self.__class__.__name__)
-        test_dataset = Dataset.validate_dataset(test_dataset, self.__class__.__name__)
-        test_dataset.validate_label(self.__class__.__name__)
-        features_names = train_dataset.validate_shared_features(test_dataset, self.__class__.__name__)
-        label_name = train_dataset.validate_shared_label(test_dataset, self.__class__.__name__)
+        train_dataset = Dataset.validate_dataset(train_dataset)
+        train_dataset.validate_label()
+        test_dataset = Dataset.validate_dataset(test_dataset)
+        test_dataset.validate_label()
+        features_names = train_dataset.validate_shared_features(test_dataset)
+        label_name = train_dataset.validate_shared_label(test_dataset)
         ppscore_params = self.ppscore_params or {}
 
         relevant_columns = features_names + [label_name]

--- a/deepchecks/checks/methodology/train_test_samples_mix.py
+++ b/deepchecks/checks/methodology/train_test_samples_mix.py
@@ -90,7 +90,7 @@ class TrainTestSamplesMix(TrainTestBaseCheck):
     def _data_sample_leakage_report(self, test_dataset: Dataset, train_dataset: Dataset):
         test_dataset = Dataset.validate_dataset_or_dataframe(test_dataset)
         train_dataset = Dataset.validate_dataset_or_dataframe(train_dataset)
-        test_dataset.validate_shared_features(train_dataset, self.__class__.__name__)
+        test_dataset.validate_shared_features(train_dataset)
 
         columns = train_dataset.features
         if train_dataset.label_name:

--- a/deepchecks/checks/methodology/unused_features.py
+++ b/deepchecks/checks/methodology/unused_features.py
@@ -108,16 +108,15 @@ class UnusedFeatures(TrainTestBaseCheck):
             DeepchecksValueError: If neither train_dataset nor test_dataset exist, or either of the dataset objects are
                                   not a Dataset instance with a label.
         """
-        func_name = self.__class__.__name__
         if test_dataset:
             dataset = test_dataset
         elif train_dataset:
             dataset = train_dataset
         else:
             raise DeepchecksValueError('Either train_dataset or test_dataset must be supplied')
-        Dataset.validate_dataset(dataset, func_name)
-        dataset.validate_label(func_name)
-        dataset.validate_label(func_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        dataset.validate_label()
         validate_model(dataset, model)
 
         feature_importance = calculate_feature_importance(model, dataset, random_state=self.random_state)

--- a/deepchecks/checks/performance/calibration_metric.py
+++ b/deepchecks/checks/performance/calibration_metric.py
@@ -38,10 +38,9 @@ class CalibrationMetric(SingleDatasetBaseCheck):
         return self._calibration_metric(dataset, model)
 
     def _calibration_metric(self, dataset: Dataset, model):
-        check_name = self.__class__.__name__
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
-        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY], check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY])
 
         ds_x = dataset.features_columns
         ds_y = dataset.label_col

--- a/deepchecks/checks/performance/class_performance_imbalance.py
+++ b/deepchecks/checks/performance/class_performance_imbalance.py
@@ -105,13 +105,12 @@ class ClassPerformanceImbalance(SingleDatasetBaseCheck):
         dataset: Dataset,
         model: t.Any # TODO: find more precise type for model
     ) -> CheckResult:
-        check_name = type(self).__name__
         expected_model_types = [ModelType.BINARY, ModelType.MULTICLASS]
 
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
-        dataset.validate_features(check_name)
-        task_type_validation(model, dataset, expected_model_types, check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        dataset.validate_features()
+        task_type_validation(model, dataset, expected_model_types)
 
         labels = t.cast(pd.Series, dataset.label_col)
         features = t.cast(pd.DataFrame, dataset.features_columns)

--- a/deepchecks/checks/performance/confusion_matrix_report.py
+++ b/deepchecks/checks/performance/confusion_matrix_report.py
@@ -39,10 +39,9 @@ class ConfusionMatrixReport(SingleDatasetBaseCheck):
         return self._confusion_matrix_report(dataset, model)
 
     def _confusion_matrix_report(self, dataset: Dataset, model):
-        check_name = self.__class__.__name__
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
-        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY], check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY])
 
         label = dataset.label_name
         ds_x = dataset.data[dataset.features]

--- a/deepchecks/checks/performance/performance_report.py
+++ b/deepchecks/checks/performance/performance_report.py
@@ -44,8 +44,8 @@ class PerformanceReport(SingleDatasetBaseCheck):
         return self._performance_report(dataset, model)
 
     def _performance_report(self, dataset: Dataset, model):
-        Dataset.validate_dataset(dataset, self.__class__.__name__)
-        dataset.validate_label(self.__class__.__name__)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
         validate_model(dataset, model)
 
         # Get default metrics if no alternative, or validate alternatives

--- a/deepchecks/checks/performance/regression_error_distribution.py
+++ b/deepchecks/checks/performance/regression_error_distribution.py
@@ -50,10 +50,9 @@ class RegressionErrorDistribution(SingleDatasetBaseCheck):
         return self._regression_error_distribution(dataset, model)
 
     def _regression_error_distribution(self, dataset: Dataset, model: BaseEstimator):
-        check_name = self.__class__.__name__
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
-        task_type_validation(model, dataset, [ModelType.REGRESSION], check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        task_type_validation(model, dataset, [ModelType.REGRESSION])
 
         y_test = dataset.label_col
         y_pred = model.predict(dataset.features_columns)

--- a/deepchecks/checks/performance/roc_report.py
+++ b/deepchecks/checks/performance/roc_report.py
@@ -51,10 +51,9 @@ class RocReport(SingleDatasetBaseCheck):
         return self._roc_report(dataset, model)
 
     def _roc_report(self, dataset: Dataset, model):
-        check_name = self.__class__.__name__
-        Dataset.validate_dataset(dataset, check_name)
-        dataset.validate_label(check_name)
-        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY], check_name)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
+        task_type_validation(model, dataset, [ModelType.MULTICLASS, ModelType.BINARY])
 
         label = dataset.label_name
         ds_x = dataset.data[dataset.features]

--- a/deepchecks/checks/performance/segment_performance.py
+++ b/deepchecks/checks/performance/segment_performance.py
@@ -72,8 +72,8 @@ class SegmentPerformance(SingleDatasetBaseCheck):
             model (BaseEstimator): A scikit-learn-compatible fitted estimator instance.
         """
         # Validations
-        Dataset.validate_dataset(dataset, self.__class__.__name__)
-        dataset.validate_label(self.__class__.__name__)
+        Dataset.validate_dataset(dataset)
+        dataset.validate_label()
         validate_model(dataset, model)
 
         if self.feature_1 is None or self.feature_2 is None:

--- a/deepchecks/checks/performance/simple_model_comparison.py
+++ b/deepchecks/checks/performance/simple_model_comparison.py
@@ -149,11 +149,10 @@ class SimpleModelComparison(TrainTestBaseCheck):
         return simple_metric, pred_metric, metric_name
 
     def _simple_model_comparison(self, train_dataset: Dataset, test_dataset: Dataset, model):
-        func_name = self.__class__.__name__
-        Dataset.validate_dataset(train_dataset, func_name)
-        Dataset.validate_dataset(test_dataset, func_name)
-        train_dataset.validate_label(func_name)
-        test_dataset.validate_label(func_name)
+        Dataset.validate_dataset(train_dataset)
+        Dataset.validate_dataset(test_dataset)
+        train_dataset.validate_label()
+        test_dataset.validate_label()
         validate_model(test_dataset, model)
 
         simple_metric, pred_metric, metric_name = self._find_score(train_dataset, test_dataset,

--- a/deepchecks/utils/features.py
+++ b/deepchecks/utils/features.py
@@ -114,7 +114,7 @@ def _calc_importance(
     n_samples: int = 10000
 ) -> pd.Series:
     """Calculate permutation feature importance. Return nonzero value only when std doesn't mask signal."""
-    dataset.validate_label('_calc_importance')
+    dataset.validate_label()
     n_samples = min(n_samples, dataset.n_samples)
     dataset_sample_idx = dataset.label_col.sample(n_samples).index
     r = permutation_importance(model, dataset.features_columns.loc[dataset_sample_idx, :],

--- a/deepchecks/utils/metrics.py
+++ b/deepchecks/utils/metrics.py
@@ -86,7 +86,7 @@ def task_type_check(
         TaskType enum corresponding to the model and dataset
     """
     validation.model_type_validation(model)
-    dataset.validate_label(task_type_check.__name__)
+    dataset.validate_label()
 
     if not hasattr(model, 'predict_proba'):
         return ModelType.REGRESSION
@@ -110,8 +110,7 @@ def task_type_check(
 def task_type_validation(
     model: t.Union[ClassifierMixin, RegressorMixin],
     dataset: 'base.Dataset',
-    expected_types: t.Sequence[ModelType],
-    check_name: str = None
+    expected_types: t.Sequence[ModelType]
 ):
     """Validate task type (regression, binary, multiclass) according to model object and label column.
 
@@ -126,9 +125,8 @@ def task_type_validation(
     """
     task_type = task_type_check(model, dataset)
     if not task_type in expected_types:
-        prefix = f'Check {check_name} ' if check_name else ''
         raise errors.DeepchecksValueError(
-            f'{prefix}Expected model to be a type from {[e.value for e in expected_types]}, '
+            f'Expected model to be a type from {[e.value for e in expected_types]}, '
             f'but received model of type: {task_type.value}'
         )
 

--- a/tests/base/dataset_test.py
+++ b/tests/base/dataset_test.py
@@ -325,35 +325,35 @@ def test_dataset_no_index_col(iris):
 
 def test_dataset_validate_label(iris):
     dataset = Dataset(iris, label='target')
-    dataset.validate_label('test')
+    dataset.validate_label()
 
 
 def test_dataset_validate_no_label(iris):
     dataset = Dataset(iris)
-    assert_that(calling(dataset.validate_label).with_args('test'),
-                raises(DeepchecksValueError, 'Check test requires dataset to have a label column'))
+    assert_that(calling(dataset.validate_label),
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_dataset_validate_date(iris):
     dataset = Dataset(iris, date='target')
-    dataset.validate_date('test')
+    dataset.validate_date()
 
 
 def test_dataset_validate_no_date(iris):
     dataset = Dataset(iris)
-    assert_that(calling(dataset.validate_date).with_args('test'),
-                raises(DeepchecksValueError, 'Check test requires dataset to have a date column'))
+    assert_that(calling(dataset.validate_date),
+                raises(DeepchecksValueError, 'Check requires dataset to have a date column'))
 
 
 def test_dataset_validate_index(iris):
     dataset = Dataset(iris, index='target')
-    dataset.validate_index('test')
+    dataset.validate_index()
 
 
 def test_dataset_validate_no_index(iris):
     dataset = Dataset(iris)
-    assert_that(calling(dataset.validate_index).with_args('test'),
-                raises(DeepchecksValueError, 'Check test requires dataset to have an index column'))
+    assert_that(calling(dataset.validate_index),
+                raises(DeepchecksValueError, 'Check requires dataset to have an index column'))
 
 
 def test_dataset_filter_columns_with_validation(iris):
@@ -376,31 +376,31 @@ def test_dataset_filter_columns_with_validation_same_table(iris):
 
 def test_dataset_validate_shared_features(diabetes):
     train, val = diabetes
-    assert_that(train.validate_shared_features(val, 'test'), is_(val.features))
+    assert_that(train.validate_shared_features(val), is_(val.features))
 
 
 def test_dataset_validate_shared_features_fail(diabetes, iris_dataset):
     train = diabetes[0]
-    assert_that(calling(train.validate_shared_features).with_args(iris_dataset, 'test'),
-                raises(DeepchecksValueError, 'Check test requires datasets to share the same features'))
+    assert_that(calling(train.validate_shared_features).with_args(iris_dataset),
+                raises(DeepchecksValueError, 'Check requires datasets to share the same features'))
 
 
 def test_dataset_validate_shared_label(diabetes):
     train, val = diabetes
-    assert_that(train.validate_shared_label(val, 'test'), is_(val.label_name))
+    assert_that(train.validate_shared_label(val), is_(val.label_name))
 
 
 def test_dataset_validate_shared_labels_fail(diabetes, iris_dataset):
     train = diabetes[0]
-    assert_that(calling(train.validate_shared_label).with_args(iris_dataset, 'test'),
-                raises(DeepchecksValueError, 'Check test requires datasets to share the same label'))
+    assert_that(calling(train.validate_shared_label).with_args(iris_dataset),
+                raises(DeepchecksValueError, 'Check requires datasets to share the same label'))
 
 
 def test_dataset_shared_categorical_features(diabetes_df, iris):
     diabetes_dataset = Dataset(diabetes_df)
     iris_dataset = Dataset(iris)
-    assert_that(calling(diabetes_dataset.validate_shared_categorical_features).with_args(iris_dataset, 'test'),
-                raises(DeepchecksValueError, 'Check test requires datasets to share'
+    assert_that(calling(diabetes_dataset.validate_shared_categorical_features).with_args(iris_dataset),
+                raises(DeepchecksValueError, 'Check requires datasets to share'
                                            ' the same categorical features'))
 
 
@@ -419,13 +419,13 @@ def test_validate_dataset_or_dataframe(iris):
 
 
 def test_validate_dataset_empty_df(empty_df):
-    assert_that(calling(Dataset.validate_dataset).with_args(Dataset(empty_df), 'test_function'),
-                raises(DeepchecksValueError, 'Check test_function required a non-empty dataset'))
+    assert_that(calling(Dataset.validate_dataset).with_args(Dataset(empty_df)),
+                raises(DeepchecksValueError, 'Check requires a non-empty dataset'))
 
 
 def test_validate_dataset_not_dataset():
-    assert_that(calling(Dataset.validate_dataset).with_args('not_dataset', 'test_function'),
-                raises(DeepchecksValueError, 'Check test_function requires dataset to be of type Dataset. instead got:'
+    assert_that(calling(Dataset.validate_dataset).with_args('not_dataset'),
+                raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got:'
                                            ' str'))
 
 

--- a/tests/checks/methodology/date_leakage_test.py
+++ b/tests/checks/methodology/date_leakage_test.py
@@ -105,24 +105,20 @@ def test_dataset_wrong_input():
     x = 'wrong_input'
     assert_that(
         calling(DateTrainTestLeakageDuplicates().run).with_args(x, x),
-        raises(DeepchecksValueError, 'Check DateTrainTestLeakageDuplicates '
-                                   'requires dataset to be of type Dataset. instead got: str'))
+        raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got: str'))
     assert_that(
         calling(DateTrainTestLeakageOverlap().run).with_args(x, x),
-        raises(DeepchecksValueError, 'Check DateTrainTestLeakageOverlap '
-                                   'requires dataset to be of type Dataset. instead got: str'))
+        raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_index():
     ds = dataset_from_dict({'col1': [1, 2, 3, 4, 10, 11]})
     assert_that(
         calling(DateTrainTestLeakageDuplicates().run).with_args(ds, ds),
-        raises(DeepchecksValueError, 'Check DateTrainTestLeakageDuplicates '
-                                   'requires dataset to have a date column'))
+        raises(DeepchecksValueError, 'Check requires dataset to have a date column'))
     assert_that(
         calling(DateTrainTestLeakageOverlap().run).with_args(ds, ds),
-        raises(DeepchecksValueError, 'Check DateTrainTestLeakageOverlap '
-                                   'requires dataset to have a date column'))
+        raises(DeepchecksValueError, 'Check requires dataset to have a date column'))
 
 def test_dates_from_val_before_train():
     train_ds = dataset_from_dict({'col1': [

--- a/tests/checks/methodology/identifier_leakage_test.py
+++ b/tests/checks/methodology/identifier_leakage_test.py
@@ -41,8 +41,7 @@ def test_dataset_wrong_input():
     wrong = 'wrong_input'
     assert_that(
         calling(IdentifierLeakage().run).with_args(wrong),
-        raises(DeepchecksValueError, 'Check IdentifierLeakage requires dataset to be of type Dataset. '
-                                   'instead got: str'))
+        raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label():
@@ -50,7 +49,7 @@ def test_dataset_no_label():
     df = Dataset(df)
     assert_that(
         calling(IdentifierLeakage().run).with_args(dataset=df),
-        raises(DeepchecksValueError, 'Check IdentifierLeakage requires dataset to have a label column'))
+        raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_dataset_only_label():

--- a/tests/checks/methodology/index_train_val_leakage_test.py
+++ b/tests/checks/methodology/index_train_val_leakage_test.py
@@ -51,15 +51,14 @@ def test_dataset_wrong_input():
     x = 'wrong_input'
     assert_that(
         calling(IndexTrainTestLeakage().run).with_args(x, x),
-        raises(DeepchecksValueError, 'Check IndexTrainTestLeakage requires dataset to be of type Dataset. '
-                                   'instead got: str'))
+        raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_index():
     ds = dataset_from_dict({'col1': [1, 2, 3, 4, 10, 11]})
     assert_that(
         calling(IndexTrainTestLeakage().run).with_args(ds, ds),
-        raises(DeepchecksValueError, 'Check IndexTrainTestLeakage requires dataset to have an index column'))
+        raises(DeepchecksValueError, 'Check requires dataset to have an index column'))
 
 
 def test_nan():

--- a/tests/checks/methodology/performance_overfit_test.py
+++ b/tests/checks/methodology/performance_overfit_test.py
@@ -25,8 +25,7 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(TrainTestDifferenceOverfit().run).with_args(bad_dataset, None, None),
                 raises(DeepchecksValueError,
-                       'Check TrainTestDifferenceOverfit requires dataset to be of type Dataset. instead '
-                       'got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_model_wrong_input(iris_labeled_dataset):
@@ -41,8 +40,7 @@ def test_model_wrong_input(iris_labeled_dataset):
 def test_dataset_no_label(iris_dataset):
     # Assert
     assert_that(calling(TrainTestDifferenceOverfit().run).with_args(iris_dataset, iris_dataset, None),
-                raises(DeepchecksValueError, 'Check TrainTestDifferenceOverfit requires dataset to have a '
-                                           'label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_dataset_no_shared_label(iris_labeled_dataset):
@@ -50,7 +48,7 @@ def test_dataset_no_shared_label(iris_labeled_dataset):
     iris_dataset_2 = Dataset(iris_labeled_dataset.data, label='sepal length (cm)')
     assert_that(calling(TrainTestDifferenceOverfit().run).with_args(iris_labeled_dataset, iris_dataset_2, None),
                 raises(DeepchecksValueError,
-                       'Check TrainTestDifferenceOverfit requires datasets to share the same label'))
+                       'Check requires datasets to share the same label'))
 
 
 def test_dataset_no_shared_features(iris_labeled_dataset):
@@ -63,7 +61,7 @@ def test_dataset_no_shared_features(iris_labeled_dataset):
     # Assert
     assert_that(calling(TrainTestDifferenceOverfit().run).with_args(iris_labeled_dataset, iris_dataset_2, None),
                 raises(DeepchecksValueError,
-                       'Check TrainTestDifferenceOverfit requires datasets to share the same features'))
+                       'Check requires datasets to share the same features'))
 
 
 def test_no_diff(iris_split_dataset_and_model):

--- a/tests/checks/methodology/single_feature_contribution_test.py
+++ b/tests/checks/methodology/single_feature_contribution_test.py
@@ -66,8 +66,7 @@ def test_dataset_wrong_input():
     wrong = 'wrong_input'
     assert_that(
         calling(SingleFeatureContribution().run).with_args(wrong),
-        raises(DeepchecksValueError, 'Check SingleFeatureContribution requires dataset to be of type Dataset. '
-                                     'instead got: str'))
+        raises(DeepchecksValueError, 'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label():
@@ -75,7 +74,7 @@ def test_dataset_no_label():
     df = Dataset(df)
     assert_that(
         calling(SingleFeatureContribution().run).with_args(dataset=df),
-        raises(DeepchecksValueError, 'Check SingleFeatureContribution requires dataset to have a label column'))
+        raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_trainval_assert_single_feature_contribution():
@@ -99,8 +98,7 @@ def test_trainval_dataset_wrong_input():
     assert_that(
         calling(SingleFeatureContributionTrainTest().run).with_args(wrong, wrong),
         raises(DeepchecksValueError,
-               'Check SingleFeatureContributionTrainTest requires dataset to be of type Dataset. '
-               'instead got: str'))
+               'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_trainval_dataset_no_label():
@@ -109,7 +107,7 @@ def test_trainval_dataset_no_label():
         calling(SingleFeatureContributionTrainTest().run).with_args(train_dataset=Dataset(df),
                                                                     test_dataset=Dataset(df2)),
         raises(DeepchecksValueError,
-               'Check SingleFeatureContributionTrainTest requires dataset to have a label column'))
+               'Check requires dataset to have a label column'))
 
 
 def test_trainval_dataset_diff_columns():
@@ -120,7 +118,7 @@ def test_trainval_dataset_diff_columns():
             .with_args(train_dataset=Dataset(df, label='label'),
                        test_dataset=Dataset(df2, label='label')),
         raises(DeepchecksValueError,
-               'Check SingleFeatureContributionTrainTest requires datasets to share the same features'))
+               'Check requires datasets to share the same features'))
 
 
 def test_all_features_pps_upper_bound_condition_that_should_not_pass():

--- a/tests/checks/performance/calibration_metric_test.py
+++ b/tests/checks/performance/calibration_metric_test.py
@@ -19,20 +19,20 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(CalibrationMetric().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check CalibrationMetric requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(iris_dataset, iris_adaboost):
     # Assert
     assert_that(calling(CalibrationMetric().run).with_args(iris_dataset, iris_adaboost),
-                raises(DeepchecksValueError, 'Check CalibrationMetric requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_regresion_model(diabetes_split_dataset_and_model):
     # Assert
     train, _, clf = diabetes_split_dataset_and_model
     assert_that(calling(CalibrationMetric().run).with_args(train, clf),
-                raises(DeepchecksValueError, r'Check CalibrationMetric Expected model to be a type from'
+                raises(DeepchecksValueError, r'Expected model to be a type from'
                                            r' \[\'multiclass\', \'binary\'\], but received model of type: regression'))
 
 

--- a/tests/checks/performance/confusion_matrix_report_test.py
+++ b/tests/checks/performance/confusion_matrix_report_test.py
@@ -20,20 +20,20 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(ConfusionMatrixReport().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check ConfusionMatrixReport requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(iris_dataset, iris_adaboost):
     # Assert
     assert_that(calling(ConfusionMatrixReport().run).with_args(iris_dataset, iris_adaboost),
-                raises(DeepchecksValueError, 'Check ConfusionMatrixReport requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_regresion_model(diabetes_split_dataset_and_model):
     # Assert
     train, _, clf = diabetes_split_dataset_and_model
     assert_that(calling(ConfusionMatrixReport().run).with_args(train, clf),
-                raises(DeepchecksValueError, r'Check ConfusionMatrixReport Expected model to be a type from'
+                raises(DeepchecksValueError, r'Expected model to be a type from'
                                            r' \[\'multiclass\', \'binary\'\], but received model of type: regression'))
 
 

--- a/tests/checks/performance/performance_report_test.py
+++ b/tests/checks/performance/performance_report_test.py
@@ -25,13 +25,13 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(PerformanceReport().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check PerformanceReport requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(iris_dataset, iris_adaboost):
     # Assert
     assert_that(calling(PerformanceReport().run).with_args(iris_dataset, iris_adaboost),
-                raises(DeepchecksValueError, 'Check PerformanceReport requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_classification(iris_labeled_dataset, iris_adaboost):

--- a/tests/checks/performance/regression_error_distribution_test.py
+++ b/tests/checks/performance/regression_error_distribution_test.py
@@ -22,20 +22,20 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(RegressionErrorDistribution().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check RegressionErrorDistribution requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(diabetes_df, diabetes_model):
     # Assert
     assert_that(calling(RegressionErrorDistribution().run).with_args(Dataset(diabetes_df), diabetes_model),
-                raises(DeepchecksValueError, 'Check RegressionErrorDistribution requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_multiclass_model(iris_split_dataset_and_model):
     # Assert
     _, test, clf = iris_split_dataset_and_model
     assert_that(calling(RegressionErrorDistribution().run).with_args(test, clf),
-                raises(DeepchecksValueError, r'Check RegressionErrorDistribution Expected model to be a type from'
+                raises(DeepchecksValueError, r'Expected model to be a type from'
                                            r' \[\'regression\'\], but received model of type: multiclass'))
 
 

--- a/tests/checks/performance/roc_report_test.py
+++ b/tests/checks/performance/roc_report_test.py
@@ -26,20 +26,20 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(RocReport().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check RocReport requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(iris_dataset, iris_adaboost):
     # Assert
     assert_that(calling(RocReport().run).with_args(iris_dataset, iris_adaboost),
-                raises(DeepchecksValueError, 'Check RocReport requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_regresion_model(diabetes_split_dataset_and_model):
     # Assert
     train, _, clf = diabetes_split_dataset_and_model
     assert_that(calling(RocReport().run).with_args(train, clf),
-                raises(DeepchecksValueError, r'Check RocReport Expected model to be a type from'
+                raises(DeepchecksValueError, r'Expected model to be a type from'
                                            r' \[\'multiclass\', \'binary\'\], but received model of type: regression'))
 
 

--- a/tests/checks/performance/segment_performance_test.py
+++ b/tests/checks/performance/segment_performance_test.py
@@ -20,13 +20,13 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(SegmentPerformance().run).with_args(bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check SegmentPerformance requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_dataset_no_label(iris_dataset, iris_adaboost):
     # Assert
     assert_that(calling(SegmentPerformance().run).with_args(iris_dataset, iris_adaboost),
-                raises(DeepchecksValueError, 'Check SegmentPerformance requires dataset to have a label column'))
+                raises(DeepchecksValueError, 'Check requires dataset to have a label column'))
 
 
 def test_segment_performance_diabetes(diabetes_split_dataset_and_model):

--- a/tests/checks/performance/simple_model_comparison_test.py
+++ b/tests/checks/performance/simple_model_comparison_test.py
@@ -22,7 +22,7 @@ def test_dataset_wrong_input():
     # Act & Assert
     assert_that(calling(SimpleModelComparison().run).with_args(bad_dataset, bad_dataset, None),
                 raises(DeepchecksValueError,
-                       'Check SimpleModelComparison requires dataset to be of type Dataset. instead got: str'))
+                       'Check requires dataset to be of type Dataset. instead got: str'))
 
 
 def test_classification_random(iris_split_dataset_and_model):


### PR DESCRIPTION
It's redundant, in a suite we will see the check name in the table, and when running single check you knows what you ran