### PR TITLE
[Refactoring] move `validate_*` methods from  the `Dataclass` to the `BaseCheck` 

### DIFF
--- a/deepchecks/checks/methodology/boosting_overfit.py
+++ b/deepchecks/checks/methodology/boosting_overfit.py
@@ -140,19 +140,20 @@ class BoostingOverfit(TrainTestBaseCheck):
             The metric value on the test dataset.
         """
         return self._boosting_overfit(train_dataset, test_dataset, model=model)
-
+    
     def _boosting_overfit(self, train_dataset: Dataset, test_dataset: Dataset, model) -> CheckResult:
         # Validate params
         if self.metric_name is not None and self.metric is None:
             raise DeepchecksValueError('Can not have metric_name without metric')
         if not isinstance(self.num_steps, int) or self.num_steps < 2:
             raise DeepchecksValueError('num_steps must be an integer larger than 1')
-        Dataset.validate_dataset(train_dataset)
-        Dataset.validate_dataset(test_dataset)
-        train_dataset.validate_label()
-        test_dataset.validate_label()
-        train_dataset.validate_shared_features(test_dataset)
-        train_dataset.validate_shared_label(test_dataset)
+        
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        
+        self.do_datasets_have_label(train_dataset, test_dataset)
+        self.do_datasets_have_features(train_dataset, test_dataset)
+        self.do_datasets_share_same_label(train_dataset, test_dataset)
+        self.do_datasets_share_same_features(train_dataset, test_dataset)
         validate_model(train_dataset, model)
 
         # Get default metric

--- a/deepchecks/checks/methodology/datasets_size_comparison.py
+++ b/deepchecks/checks/methodology/datasets_size_comparison.py
@@ -41,8 +41,7 @@ class DatasetsSizeComparison(TrainTestBaseCheck):
                 if not dataset instances were provided;
                 if datasets are empty;
         """
-        Dataset.validate_dataset(train_dataset)
-        Dataset.validate_dataset(test_dataset)
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
         sizes = {'Train': train_dataset.n_samples, 'Test': test_dataset.n_samples}
         display = pd.DataFrame(sizes, index=['Size'])
         return CheckResult(

--- a/deepchecks/checks/methodology/date_train_test_leakage_duplicates.py
+++ b/deepchecks/checks/methodology/date_train_test_leakage_duplicates.py
@@ -48,14 +48,9 @@ class DateTrainTestLeakageDuplicates(TrainTestBaseCheck):
         return self._date_train_test_leakage_duplicates(train_dataset, test_dataset)
 
     def _date_train_test_leakage_duplicates(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset)
-        test_dataset = Dataset.validate_dataset(test_dataset)
-        train_dataset.validate_date()
-        test_dataset.validate_date()
-
-        train_date = train_dataset.date_col
-        val_date = test_dataset.date_col
-
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        train_date, val_date = self.do_datasets_have_date(train_dataset, test_dataset)
+        
         date_intersection = set(train_date).intersection(val_date)
         if len(date_intersection) > 0:
             leakage_ratio = len(date_intersection) / test_dataset.n_samples

--- a/deepchecks/checks/methodology/date_train_test_leakage_overlap.py
+++ b/deepchecks/checks/methodology/date_train_test_leakage_overlap.py
@@ -38,13 +38,8 @@ class DateTrainTestLeakageOverlap(TrainTestBaseCheck):
         return self._date_train_test_leakage_overlap(train_dataset, test_dataset)
 
     def _date_train_test_leakage_overlap(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset)
-        test_dataset = Dataset.validate_dataset(test_dataset)
-        train_dataset.validate_date()
-        test_dataset.validate_date()
-
-        train_date = train_dataset.date_col
-        val_date = test_dataset.date_col
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        train_date, val_date = self.do_datasets_have_date(train_dataset, test_dataset)
 
         max_train_date = max(train_date)
         dates_leaked = sum(date <= max_train_date for date in val_date)

--- a/deepchecks/checks/methodology/identifier_leakage.py
+++ b/deepchecks/checks/methodology/identifier_leakage.py
@@ -53,8 +53,9 @@ class IdentifierLeakage(SingleDatasetBaseCheck):
         return self._identifier_leakage(dataset)
 
     def _identifier_leakage(self, dataset: Union[pd.DataFrame, Dataset], ppscore_params=None) -> CheckResult:
-        Dataset.validate_dataset(dataset)
-        dataset.validate_label()
+        dataset, *_ = self.are_not_empty_datasets(dataset)
+        self.do_datasets_have_label(dataset)
+        
         ppscore_params = ppscore_params or {}
 
         relevant_columns = list(filter(None, [dataset.date_name, dataset.index_name, dataset.label_name]))

--- a/deepchecks/checks/methodology/index_leakage.py
+++ b/deepchecks/checks/methodology/index_leakage.py
@@ -49,15 +49,10 @@ class IndexTrainTestLeakage(TrainTestBaseCheck):
         return self._index_train_test_leakage(train_dataset, test_dataset)
 
     def _index_train_test_leakage(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset)
-        test_dataset = Dataset.validate_dataset(test_dataset)
-        train_dataset.validate_index()
-        test_dataset.validate_index()
-
-        train_index = train_dataset.index_col
-        val_index = test_dataset.index_col
-
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        train_index, val_index = self.do_datasets_have_index(train_dataset, test_dataset)
         index_intersection = list(set(train_index).intersection(val_index))
+        
         if len(index_intersection) > 0:
             size_in_test = len(index_intersection) / test_dataset.n_samples
             text = f'{size_in_test:.1%} of test data indexes appear in training data'

--- a/deepchecks/checks/methodology/model_inference_time.py
+++ b/deepchecks/checks/methodology/model_inference_time.py
@@ -64,12 +64,11 @@ class ModelInferenceTimeCheck(SingleDatasetBaseCheck):
         dataset: Dataset,
         model: object # TODO: find more precise type for model
     ) -> CheckResult:
-        Dataset.validate_dataset(dataset)
-        Dataset.validate_features(dataset)
+        dataset, *_ = self.are_not_empty_datasets(dataset)
+        df, *_ = self.do_datasets_have_features(dataset)
         validate_model(dataset, model)
 
         prediction_method = model.predict # type: ignore
-        df = t.cast(pd.DataFrame, dataset.features_columns)
 
         number_of_samples = len(df) if len(df) < self.number_of_samples else self.number_of_samples
         df = df.sample(n=number_of_samples, random_state=np.random.randint(number_of_samples))

--- a/deepchecks/checks/methodology/performance_overfit.py
+++ b/deepchecks/checks/methodology/performance_overfit.py
@@ -73,12 +73,12 @@ class TrainTestDifferenceOverfit(TrainTestBaseCheck):
     def _train_test_difference_overfit(self, train_dataset: Dataset, test_dataset: Dataset, model,
                                        ) -> CheckResult:
         # Validate parameters
-        Dataset.validate_dataset(train_dataset)
-        Dataset.validate_dataset(test_dataset)
-        train_dataset.validate_label()
-        test_dataset.validate_label()
-        train_dataset.validate_shared_label(test_dataset)
-        train_dataset.validate_shared_features(test_dataset)
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        
+        self.do_datasets_have_label(train_dataset, test_dataset)
+        self.do_datasets_have_features(train_dataset, test_dataset)
+        self.do_datasets_share_same_label(train_dataset, test_dataset)
+        self.do_datasets_share_same_features(train_dataset, test_dataset)
         validate_model(test_dataset, model)
 
         metrics = get_metrics_list(model, train_dataset, self.alternative_metrics)

--- a/deepchecks/checks/methodology/single_feature_contribution.py
+++ b/deepchecks/checks/methodology/single_feature_contribution.py
@@ -59,11 +59,15 @@ class SingleFeatureContribution(SingleDatasetBaseCheck):
         return self._single_feature_contribution(dataset=dataset)
 
     def _single_feature_contribution(self, dataset: Dataset):
-        Dataset.validate_dataset(dataset)
-        dataset.validate_label()
+        dataset, *_ = self.are_not_empty_datasets(dataset)
+        
+        self.do_datasets_have_label(dataset)
         ppscore_params = self.ppscore_params or {}
-
-        relevant_columns = dataset.features + [dataset.label_name]
+        
+        label_name = t.cast(Hashable, dataset.label_name)
+        features_names = dataset.features
+        relevant_columns = features_names + [label_name]
+        
         df_pps = pps.predictors(df=dataset.data[relevant_columns], y=dataset.label_name, random_seed=42,
                                 **ppscore_params)
         df_pps = df_pps.set_index('x', drop=True)

--- a/deepchecks/checks/methodology/single_feature_contribution_train_validation.py
+++ b/deepchecks/checks/methodology/single_feature_contribution_train_validation.py
@@ -61,14 +61,17 @@ class SingleFeatureContributionTrainTest(TrainTestBaseCheck):
                                                             test_dataset=test_dataset)
 
     def _single_feature_contribution_train_test(self, train_dataset: Dataset, test_dataset: Dataset):
-        train_dataset = Dataset.validate_dataset(train_dataset)
-        train_dataset.validate_label()
-        test_dataset = Dataset.validate_dataset(test_dataset)
-        test_dataset.validate_label()
-        features_names = train_dataset.validate_shared_features(test_dataset)
-        label_name = train_dataset.validate_shared_label(test_dataset)
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        
+        self.do_datasets_have_label(train_dataset, test_dataset)
+        self.do_datasets_have_features(train_dataset, test_dataset)
+        self.do_datasets_share_same_label(train_dataset, test_dataset)
+        self.do_datasets_share_same_features(train_dataset, test_dataset)
+        
         ppscore_params = self.ppscore_params or {}
-
+        label_name = t.cast(Hashable, train_dataset.label_name)
+        features_names = train_dataset.features
+        
         relevant_columns = features_names + [label_name]
         df_pps_train = pps.predictors(df=train_dataset.data[relevant_columns], y=train_dataset.label_name,
                                       random_seed=42,

--- a/deepchecks/checks/methodology/train_test_samples_mix.py
+++ b/deepchecks/checks/methodology/train_test_samples_mix.py
@@ -88,12 +88,13 @@ class TrainTestSamplesMix(TrainTestBaseCheck):
         return self._data_sample_leakage_report(test_dataset=test_dataset, train_dataset=train_dataset)
 
     def _data_sample_leakage_report(self, test_dataset: Dataset, train_dataset: Dataset):
-        test_dataset = Dataset.validate_dataset_or_dataframe(test_dataset)
-        train_dataset = Dataset.validate_dataset_or_dataframe(train_dataset)
-        test_dataset.validate_shared_features(train_dataset)
+        train_dataset, test_dataset = self.are_not_empty_datasets(train_dataset, test_dataset)
+        
+        self.do_datasets_have_features(train_dataset, test_dataset)
+        self.do_datasets_share_same_features(train_dataset, test_dataset)
 
         columns = train_dataset.features
-        if train_dataset.label_name:
+        if train_dataset.label_name is not None:
             columns = columns + [train_dataset.label_name]
 
         train_f = train_dataset.data.copy()

--- a/deepchecks/checks/methodology/unused_features.py
+++ b/deepchecks/checks/methodology/unused_features.py
@@ -114,11 +114,11 @@ class UnusedFeatures(TrainTestBaseCheck):
             dataset = train_dataset
         else:
             raise DeepchecksValueError('Either train_dataset or test_dataset must be supplied')
-        Dataset.validate_dataset(dataset)
-        dataset.validate_label()
-        dataset.validate_label()
+        
+        dataset, *_ = self.are_not_empty_datasets(dataset)
+        
+        self.do_datasets_have_label(dataset)
         validate_model(dataset, model)
-
         feature_importance = calculate_feature_importance(model, dataset, random_state=self.random_state)
 
         # Calculate normalized variance per feature based on PCA decomposition

--- a/deepchecks/utils/typing.py
+++ b/deepchecks/utils/typing.py
@@ -9,6 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Type definitions."""
+from typing import Any
 from typing_extensions import Protocol, runtime_checkable
 
 
@@ -21,13 +22,13 @@ class Hashable(Protocol):
 
     def __hash__(self) -> int: # pylint: disable=invalid-hash-returned, noqa: D105
         ...
-    def __le__(self, value) -> bool: # noqa: D105
+    def __le__(self, __x: Any) -> bool: # noqa: D105
         ...
-    def __lt__(self, value) -> bool: # noqa: D105
+    def __lt__(self, __x: Any) -> bool: # noqa: D105
         ...
-    def __ge__(self, value) -> bool: # noqa: D105
+    def __ge__(self, __x: Any) -> bool: # noqa: D105
         ...
-    def __gt__(self, value) -> bool: # noqa: D105
+    def __gt__(self, __x: Any) -> bool: # noqa: D105
         ...
-    def __eq__(self, value) -> bool: # noqa: D105
+    def __eq__(self, __x: Any) -> bool: # noqa: D105
         ...


### PR DESCRIPTION
Purpose of the PR:
- move validation methods (methods that start with `validate_`) from `Dataset` class to the `BaseCheck` class

Reasoning:
- despite the fact that it looks like a totally logical to define all those methods within the Dataset class, I think they are not needed there
- hardcoded messages like `Check requires ...` make them totally unrelevant to the Dataset context, and also make them`s unusable anywhere except check instance context
- they are used only by checks

list of changes (not full):
- I moved validation methods from the `Dataset` class to the `BaseCheck` class
- I modified those methods signature to make them easier to use
- I added the next `classmethod`s to the Dataset class: 
   + `share_same_label(*datasets) -> bool`
   + `share_same_categorical_features(*datasets) -> bool`
   + `share_same_features(*datasets) -> bool`
- I renamed `Dataset.filter_columns_with_validation` to `Dataset.select`
- I added the next functions to the `deepchecks.utils.validation module`:
   + `ensure_dataset(obj: object, error_message: Optional[str] = None) -> base.Dataset`
   + `ensure_not_empty_dataset(obj: object, error_messages: Optional[t.Dict[str, str]] = None) -> base.Dataset`
   + `ensure_dataframe(obj: object, error_message: Optional[str] = None) -> pd.DataFrame`
   + `ensure_not_empty_dataframe(obj: object, error_messages: Optional[t.Dict[str, str]] = None) -> pd.DataFrame`

Note: This PR is not finished, before fixing all checks and making sure that all tests pass, I would like to hear your thoughts and comments