### PR TITLE
pipeline model can also no be of type BaseEstimator

### DIFF
--- a/deepchecks/utils/model.py
+++ b/deepchecks/utils/model.py
@@ -14,8 +14,6 @@ from typing import Union
 from sklearn.pipeline import Pipeline
 from sklearn.base import BaseEstimator
 
-from deepchecks.errors import DeepchecksValueError
-
 
 __all__ = ['get_model_of_pipeline']
 
@@ -29,9 +27,6 @@ def get_model_of_pipeline(model: Union[Pipeline, BaseEstimator]):
         the inner BaseEstimator of the Pipeline or itself
     """
     if isinstance(model, Pipeline):
-        # get feature importance from last model in pipeline
-        internal_estimator_list = [x[1] for x in model.steps if isinstance(x[1], BaseEstimator)]
-        if internal_estimator_list:
-            return internal_estimator_list[-1]
-        raise DeepchecksValueError('Received a pipeline without an sklearn compatible model')
+        # get model type from last step in pipeline
+        return model.steps[-1][1]
     return model

--- a/deepchecks/utils/validation.py
+++ b/deepchecks/utils/validation.py
@@ -16,6 +16,7 @@ import sklearn
 
 from deepchecks import base  # pylint: disable=unused-import, is used in type annotations
 from deepchecks import errors
+from deepchecks.utils.model import get_model_of_pipeline
 from deepchecks.utils.typing import Hashable
 
 
@@ -30,6 +31,8 @@ def model_type_validation(model: t.Any):
     """
     supported_by_class_name = ('CatBoostClassifier', 'CatBoostRegressor')
     supported_by_class_instance = (sklearn.base.BaseEstimator,)
+    model = get_model_of_pipeline(model)
+
     if (
         not isinstance(model, supported_by_class_instance)
         and model.__class__.__name__ not in supported_by_class_name


### PR DESCRIPTION
resolves #425 

the last step in the pipeline must be an estimator, but doesn't have to inherit from sklearn BaseEstimator