### PR TITLE
dataset mutable properties fix

### DIFF
--- a/deepchecks/base/dataset.py
+++ b/deepchecks/base/dataset.py
@@ -246,12 +246,6 @@ class Dataset:
         if self._label_name in self.features:
             raise DeepchecksValueError(f'label column {self._label_name} can not be a feature column')
 
-        if self._label_name:
-            try:
-                self.check_compatible_labels()
-            except DeepchecksValueError as e:
-                logger.warning(str(e))
-
         if self._datetime_name in self.features:
             raise DeepchecksValueError(f'datetime column {self._datetime_name} can not be a feature column')
 
@@ -712,12 +706,6 @@ class Dataset:
                 value = 'other'
             columns[column] = value
         return columns
-
-    def check_compatible_labels(self):
-        """Check if label column is supported by deepchecks."""
-        labels = self.label_col
-        if labels is None:
-            return
 
     # Validations:
 

--- a/deepchecks/base/dataset.py
+++ b/deepchecks/base/dataset.py
@@ -468,7 +468,7 @@ class Dataset:
                          random_state: int = 42,
                          shuffle: bool = True,
                          stratify: t.Union[t.List, pd.Series, np.ndarray, bool] = False
-                        ) -> t.Tuple[TDataset, TDataset]:
+                         ) -> t.Tuple[TDataset, TDataset]:
         """Split dataset into random train and test datasets.
 
         Args:

--- a/tests/base/dataset_test.py
+++ b/tests/base/dataset_test.py
@@ -80,6 +80,26 @@ def assert_dataset(dataset: Dataset, args):
                 is_(True)
             )
 
+def test_that_mutable_properties_modification_does_not_affect_dataset_state(iris):
+    dataset = Dataset(
+        df=iris,
+        features=[
+            'sepal length (cm)',
+            'sepal width (cm)',
+            'petal length (cm)',
+            'petal width (cm)'
+        ]
+    )
+    
+    features = dataset.features
+    cat_features = dataset.cat_features
+
+    features.append("New value")
+    cat_features.append("New value")
+
+    assert_that("New value" not in dataset.features)
+    assert_that("New value" not in dataset.cat_features)
+
 
 def test_dataset_empty_df(empty_df):
     args = {'df': empty_df}


### PR DESCRIPTION
we should use mutable containers more consciously, especially when we use them to represent an object inner state, an example of something that definitely should not be allowed but it is

```python
ds = Dataset(...)

ds.features # prints 'a', 'b', 'c'
f = dataset.features

# 100 lines below
f.append("new value")

dataset.features # prints 'a', 'b', 'c', 'new value'; dataset state was modified unintentionally
```