### PR TITLE
downgrade requirements so that it doesn't trigger colab conflict error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ category-encoders>=2.3.0
 # Category encoder depends on old statsmodels version which raises pandas warning. until dependency in category-encoders
 # is updated, explicitly add it here
 statsmodels>=0.11.0
-scipy>=1.5.0
+scipy>=1.4.1
 dataclasses>=0.6; python_version < '3.7'
 plotly>=5.5.0
-matplotlib>=3.3.3
+matplotlib>=3.2.2


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #570 

#### What does this implement/fix? Explain your changes.

Upgrading scipy and matplotlib causes google colab to raise error on internal conflict that exist in their kernel. 
set the minimum version to the versions in colab
