### PR TITLE
[DOC] Typo and grammar fix in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ See the :doc:`When Should You Use Section in the User Guide </user-guide/when_sh
 Example - Validating a Model that Classifies Malicious URLs
 ----------------------------------------------------------------
 The :doc:`following use case </examples/use-cases/phishing_urls>` demonstrates how deepchecks can be used throughout the 
-research phase for model and daketa validation, enabling you to efficiently catch issues at different phases.
+research phase for model and data validation, enabling you to efficiently catch issues at different phases.
 
 
 How Does it Work?


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

#### What does this implement/fix? Explain your changes.

Typo fix: daketa -> data
Grammar fix: They have also wrote -> They also wrote

#### Any other comments?

It seems that simply opening the phishing_urls.ipynb notebook, applying the grammar fix and closing the notebook again also changed the display of the scientific notation of some numbers. This shouldn't have any effect on the analysis.


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
