### PR TITLE
Remove upgrade from quick start guide so that colab errors don't surface

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -48,7 +48,7 @@ Simply run the following command in a notebook cell
 
 .. code-block:: bash
 
-    !pip install deepchecks -U --user
+    !pip install deepchecks --user
 
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

fixes #570 
