### PR TITLE
explicitly set default timeout for fi calculation

### DIFF
--- a/deepchecks/base/check_context.py
+++ b/deepchecks/base/check_context.py
@@ -166,9 +166,7 @@ class CheckRunContext:
         """Return features importance, or None if not possible."""
         if not self._calculated_importance:
             if self._model and (self._train or self._test):
-                permutation_kwargs = {}
-                if self._feature_importance_timeout:
-                    permutation_kwargs['timeout'] = self._feature_importance_timeout
+                permutation_kwargs = {'timeout': self._feature_importance_timeout}
                 dataset = self.test if self.have_test() else self.train
                 importance, importance_type = calculate_feature_importance_or_none(
                     self._model, dataset, self._feature_importance_force_permutation, permutation_kwargs

--- a/deepchecks/base/check_context.py
+++ b/deepchecks/base/check_context.py
@@ -39,7 +39,7 @@ class CheckRunContext:
         pass manual features importance
     feature_importance_force_permutation : bool , default: False
         force calculation of permutation features importance
-    feature_importance_timeout : int , default: None
+    feature_importance_timeout : int , default: 120
         timeout in second for the permutation features importance calculation
     scorers : Mapping[str, Union[str, Callable]] , default: None
         dict of scorers names to scorer sklearn_name/function
@@ -54,7 +54,7 @@ class CheckRunContext:
                  model_name: str = '',
                  features_importance: pd.Series = None,
                  feature_importance_force_permutation: bool = False,
-                 feature_importance_timeout: int = None,
+                 feature_importance_timeout: int = 120,
                  scorers: Mapping[str, Union[str, Callable]] = None,
                  non_avg_scorers: Mapping[str, Union[str, Callable]] = None
                  ):

--- a/deepchecks/checks/distribution/whole_dataset_drift.py
+++ b/deepchecks/checks/distribution/whole_dataset_drift.py
@@ -138,7 +138,7 @@ class WholeDatasetDrift(TrainTestBaseCheck):
             domain_classifier,
             domain_test_dataset,
             force_permutation=True,
-            permutation_kwargs={'n_repeats': 10, 'random_state': self.random_state}
+            permutation_kwargs={'n_repeats': 10, 'random_state': self.random_state, 'timeout': 120}
         )
 
         fi = fi.sort_values(ascending=False) if fi is not None else None


### PR DESCRIPTION
Small fix - feature importance timeout calculation should be available in context defaults.

