### PR TITLE
Add CheckRunConfig

### DIFF
--- a/deepchecks/base/__init__.py
+++ b/deepchecks/base/__init__.py
@@ -23,7 +23,7 @@ from .check import (
     ModelComparisonBaseCheck,
     ModelComparisonContext
 )
-from .check_context import CheckRunContext
+from .check_context import CheckRunContext, CheckRunConfig
 from .suite import (
     BaseSuite,
     Suite,
@@ -54,5 +54,6 @@ __all__ = [
     'Suite',
     'SuiteResult',
     'ModelComparisonSuite',
-    'CheckRunContext'
+    'CheckRunContext',
+    'CheckRunConfig'
 ]

--- a/deepchecks/base/check.py
+++ b/deepchecks/base/check.py
@@ -31,13 +31,14 @@ from pandas.io.formats.style import Styler
 from plotly.basedatatypes import BaseFigure
 import plotly
 
-from deepchecks.base.check_context import CheckRunContext
+from deepchecks.base.check_context import CheckRunContext, CheckRunConfig
 from deepchecks.base.condition import Condition, ConditionCategory, ConditionResult
 from deepchecks.base.dataset import Dataset
 from deepchecks.base.display_pandas import dataframe_to_html, get_conditions_table
 from deepchecks.utils.strings import get_docs_summary, split_camel_case
 from deepchecks.utils.ipython import is_ipython_display
 from deepchecks.errors import DeepchecksValueError, DeepchecksNotSupportedError
+from deepchecks.utils.typing import BasicModel
 
 
 __all__ = [
@@ -461,10 +462,13 @@ class BaseCheck(metaclass=abc.ABCMeta):
 class SingleDatasetBaseCheck(BaseCheck):
     """Parent class for checks that only use one dataset."""
 
-    def run(self, dataset, model=None) -> CheckResult:
+    def run(self,
+            dataset: Union[Dataset, pd.DataFrame],
+            model: BasicModel = None,
+            config: CheckRunConfig = None) -> CheckResult:
         """Run check."""
         # By default, we initialize a single dataset as the "train"
-        c = CheckRunContext(dataset, model=model)
+        c = CheckRunContext(dataset, model=model, config=config)
         return self.run_logic(c)
 
     @abc.abstractmethod
@@ -479,9 +483,13 @@ class TrainTestBaseCheck(BaseCheck):
     The class checks train dataset and test dataset for model training and test.
     """
 
-    def run(self, train_dataset, test_dataset, model=None) -> CheckResult:
+    def run(self,
+            train_dataset: Union[Dataset, pd.DataFrame],
+            test_dataset: Union[Dataset, pd.DataFrame],
+            model: BasicModel = None,
+            config: CheckRunConfig = None) -> CheckResult:
         """Run check."""
-        c = CheckRunContext(train_dataset, test_dataset, model=model)
+        c = CheckRunContext(train_dataset, test_dataset, model=model, config=config)
         return self.run_logic(c)
 
     @abc.abstractmethod
@@ -493,9 +501,9 @@ class TrainTestBaseCheck(BaseCheck):
 class ModelOnlyBaseCheck(BaseCheck):
     """Parent class for checks that only use a model and no datasets."""
 
-    def run(self, model) -> CheckResult:
+    def run(self, model: BasicModel, config: CheckRunConfig = None) -> CheckResult:
         """Run check."""
-        c = CheckRunContext(model=model)
+        c = CheckRunContext(model=model, config=config)
         return self.run_logic(c)
 
     @abc.abstractmethod

--- a/deepchecks/base/suite.py
+++ b/deepchecks/base/suite.py
@@ -13,7 +13,7 @@
 import abc
 import io
 from collections import OrderedDict
-from typing import Union, List, Optional, Tuple, Any, Container, Mapping, Callable
+from typing import Union, List, Optional, Tuple, Any, Container, Mapping
 
 import pandas as pd
 from IPython.core.display import display_html
@@ -191,11 +191,7 @@ class Suite(BaseSuite):
             train_dataset: Optional[Union[Dataset, pd.DataFrame]] = None,
             test_dataset: Optional[Union[Dataset, pd.DataFrame]] = None,
             model: BasicModel = None,
-            features_importance: pd.Series = None,
-            feature_importance_force_permutation: bool = False,
-            feature_importance_timeout: int = None,
-            scorers: Mapping[str, Union[str, Callable]] = None,
-            scorers_per_class: Mapping[str, Union[str, Callable]] = None
+            config: CheckRunContext = None
     ) -> SuiteResult:
         """Run all checks.
 
@@ -207,30 +203,14 @@ class Suite(BaseSuite):
             object, representing data an estimator predicts on
         model : BasicModel , default None
             A scikit-learn-compatible fitted estimator instance
-        features_importance : pd.Series , default None
-            pass manual features importance
-        feature_importance_force_permutation : bool , default None
-            force calculation of permutation features importance
-        feature_importance_timeout : int , default None
-            timeout in second for the permutation features importance calculation
-        scorers : Mapping[str, Union[str, Callable]] , default None
-            dict of scorers names to scorer sklearn_name/function
-        scorers_per_class : Mapping[str, Union[str, Callable]], default None
-            dict of scorers for classification without averaging of the classes
-            See <a href=
-            "https://scikit-learn.org/stable/modules/model_evaluation.html#from-binary-to-multiclass-and-multilabel">
-            scikit-learn docs</a>
+        config : CheckRunContext, default None
+            global configuration parameters for the checks in the suite
         Returns
         -------
         SuiteResult
             All results by all initialized checks
         """
-        context = CheckRunContext(train_dataset, test_dataset, model,
-                                  features_importance=features_importance,
-                                  feature_importance_force_permutation=feature_importance_force_permutation,
-                                  feature_importance_timeout=feature_importance_timeout,
-                                  scorers=scorers,
-                                  scorers_per_class=scorers_per_class)
+        context = CheckRunContext(train_dataset, test_dataset, model, config=config)
         # Create progress bar
         progress_bar = ProgressBar(self.name, len(self.checks))
 


### PR DESCRIPTION
After @noamzbr suggested to add the parameters to all `run` in the base checks, I decided to try and put everything in a class so we won't copy-paste it in a lot of places. 

pros: no copy-paste
cons: a bit harder to initialize `check.run(ds, model, force_permutation=True)` vs `check.run(ds, model, CheckRunConfig(force_permutation=True)`