### PR TITLE
Fixing label drift in vision submodule

### DIFF
--- a/deepchecks/vision/checks/distribution/train_test_label_drift.py
+++ b/deepchecks/vision/checks/distribution/train_test_label_drift.py
@@ -12,6 +12,7 @@
 from copy import copy
 from typing import Dict, Hashable, Callable, Tuple, List, Union, Any
 
+import torch
 from plotly.subplots import make_subplots
 
 from deepchecks import CheckResult, ConditionResult
@@ -309,7 +310,7 @@ def calculate_continuous_histograms_in_batch(batch, hists, continuous_label_meas
 def get_results_on_batch(batch, label_measurement, label_transformer):
     """Calculate transformer result on batch of labels."""
     list_of_arrays = batch[1]
-    calc_res = [label_measurement(label_transformer(arr)) for arr in list_of_arrays]
+    calc_res = [label_measurement(torch.hstack(label_transformer(arr))) for arr in list_of_arrays]
     if len(calc_res) != 0 and isinstance(calc_res[0], list):
         calc_res = [x[0] for x in sum(calc_res, [])]
     return calc_res


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

#### What does this implement/fix? Explain your changes.
Currently, the measurements in the train_test_labe_drift are expecting a tensor, however, the label_formatter should always return a list. Adding stacking to stack all bboxes to a 2d tensor.

#### Any other comments?



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
