### PR TITLE
Make image drift tests consistent

### DIFF
--- a/deepchecks/vision/datasets/classification/mnist.py
+++ b/deepchecks/vision/datasets/classification/mnist.py
@@ -88,7 +88,8 @@ def load_dataset(
         ),
         batch_size=batch_size,
         shuffle=shuffle,
-        pin_memory=pin_memory
+        pin_memory=pin_memory,
+        generator=torch.Generator()
     )
 
     if object_type == 'DataLoader':

--- a/deepchecks/vision/datasets/detection/coco.py
+++ b/deepchecks/vision/datasets/detection/coco.py
@@ -20,6 +20,7 @@ import numpy as np
 import torch
 import albumentations as A
 from PIL import Image
+from cv2 import cv2
 from torch import nn
 from torch.utils.data import DataLoader
 from torchvision.datasets import VisionDataset
@@ -55,7 +56,7 @@ def load_dataset(
         train: bool = True,
         batch_size: int = 32,
         num_workers: int = 0,
-        shuffle: bool = False,
+        shuffle: bool = True,
         pin_memory: bool = True,
         object_type: Literal['VisionData', 'DataLoader'] = 'DataLoader'
 ) -> t.Union[DataLoader, vision.VisionData]:
@@ -107,6 +108,7 @@ def load_dataset(
         num_workers=num_workers,
         collate_fn=batch_collate,
         pin_memory=pin_memory,
+        generator=torch.Generator()
     )
 
     if object_type == 'DataLoader':
@@ -189,7 +191,9 @@ class CocoDataset(VisionDataset):
 
     def __getitem__(self, idx: int) -> t.Tuple[Image.Image, np.ndarray]:
         """Get the image and label at the given index."""
-        img = Image.open(self.images[idx]).convert('RGB')
+        # open image using openCV2, since opening with Pillow give slightly different results based on Pillow version
+        opencv_image = cv2.imread(str(self.images[idx]))
+        img = Image.fromarray(cv2.cvtColor(opencv_image, cv2.COLOR_BGR2RGB))
         label_file = self.labels[idx]
 
         if label_file is not None:

--- a/deepchecks/vision/datasets/detection/coco.py
+++ b/deepchecks/vision/datasets/detection/coco.py
@@ -191,7 +191,7 @@ class CocoDataset(VisionDataset):
 
     def __getitem__(self, idx: int) -> t.Tuple[Image.Image, np.ndarray]:
         """Get the image and label at the given index."""
-        # open image using openCV2, since opening with Pillow give slightly different results based on Pillow version
+        # open image using cv2, since opening with Pillow give slightly different results based on Pillow version
         opencv_image = cv2.imread(str(self.images[idx]))
         img = Image.fromarray(cv2.cvtColor(opencv_image, cv2.COLOR_BGR2RGB))
         label_file = self.labels[idx]

--- a/makefile
+++ b/makefile
@@ -208,7 +208,7 @@ docstring: dev-requirements
 
 
 test: requirements dev-requirements
-	$(PYTEST) $(args) $(TESTDIR)
+	$(PYTEST) $(args) $(TESTDIR)/vision/checks/distribution/image_dataset_drift_test.py
 
 
 test-win:

--- a/makefile
+++ b/makefile
@@ -208,7 +208,7 @@ docstring: dev-requirements
 
 
 test: requirements dev-requirements
-	$(PYTEST) $(args) $(TESTDIR)/vision/checks/distribution/image_dataset_drift_test.py
+	$(PYTEST) $(args) $(TESTDIR)
 
 
 test-win:

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -64,3 +64,4 @@ pred
 formatters
 formatter
 imgs
+cv2

--- a/tests/vision/checks/distribution/image_dataset_drift_test.py
+++ b/tests/vision/checks/distribution/image_dataset_drift_test.py
@@ -37,13 +37,15 @@ def test_no_drift_grayscale(mnist_dataset_train):
     # Arrange
     train, test = mnist_dataset_train, mnist_dataset_train
     check = ImageDatasetDrift()
+    train.set_seed(42)
+    test.set_seed(42)
 
     # Act
     result = check.run(train, test)
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.48, 0.01),
+        'domain_classifier_auc': close_to(0.484, 0.001),
         'domain_classifier_drift_score': equal_to(0),
         'domain_classifier_feature_importance': has_entries({
             'brightness': equal_to(0),
@@ -53,22 +55,23 @@ def test_no_drift_grayscale(mnist_dataset_train):
             'normalized_green_mean': equal_to(0),
             'normalized_blue_mean': equal_to(0),
         })
-    })
-                )
+    }))
 
 
 def test_drift_grayscale(mnist_dataset_train, mnist_dataset_test):
     # Arrange
     train, test = mnist_dataset_train, mnist_dataset_test
     check = ImageDatasetDrift()
+    train.set_seed(42)
+    test.set_seed(42)
 
     # Act
     result = check.run(train, test)
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.51, 0.01),
-        'domain_classifier_drift_score': close_to(0.017, 0.01),
+        'domain_classifier_auc': close_to(0.524, 0.001),
+        'domain_classifier_drift_score': close_to(0.048, 0.001),
         'domain_classifier_feature_importance': has_entries({
             'brightness': equal_to(1),
             'aspect_ratio': equal_to(0),
@@ -77,8 +80,7 @@ def test_drift_grayscale(mnist_dataset_train, mnist_dataset_test):
             'normalized_green_mean': equal_to(0),
             'normalized_blue_mean': equal_to(0),
         })
-    })
-                )
+    }))
 
 
 def test_no_drift_rgb(coco_train_dataloader, coco_test_dataloader):
@@ -87,6 +89,8 @@ def test_no_drift_rgb(coco_train_dataloader, coco_test_dataloader):
                        label_formatter=DetectionLabelFormatter())
     test = VisionData(coco_test_dataloader, image_formatter=ImageFormatter(pil_formatter),
                       label_formatter=DetectionLabelFormatter())
+    train.set_seed(42)
+    test.set_seed(42)
 
     check = ImageDatasetDrift()
 
@@ -95,18 +99,17 @@ def test_no_drift_rgb(coco_train_dataloader, coco_test_dataloader):
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.29, 0.01),
+        'domain_classifier_auc': close_to(0.494, 0.001),
         'domain_classifier_drift_score': equal_to(0),
         'domain_classifier_feature_importance': has_entries({
-            'brightness': equal_to(0),
+            'brightness': equal_to(1),
             'aspect_ratio': equal_to(0),
             'area': equal_to(0),
             'normalized_red_mean': equal_to(0),
             'normalized_green_mean': equal_to(0),
             'normalized_blue_mean': equal_to(0),
         })
-    })
-                )
+    }))
 
 
 def test_with_drift_rgb(coco_train_dataloader, coco_test_dataloader):
@@ -115,6 +118,8 @@ def test_with_drift_rgb(coco_train_dataloader, coco_test_dataloader):
                        label_formatter=DetectionLabelFormatter())
     test = VisionData(coco_test_dataloader, image_formatter=ImageFormatter(pil_formatter),
                       label_formatter=DetectionLabelFormatter())
+    train.set_seed(42)
+    test.set_seed(42)
 
     check = ImageDatasetDrift()
 
@@ -123,15 +128,14 @@ def test_with_drift_rgb(coco_train_dataloader, coco_test_dataloader):
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.619, 0.001),
-        'domain_classifier_drift_score': close_to(0.239, 0.001),
+        'domain_classifier_auc': close_to(0.572, 0.001),
+        'domain_classifier_drift_score': close_to(0.144, 0.001),
         'domain_classifier_feature_importance': has_entries({
-            'brightness': close_to(0.62, 0.01),
+            'brightness': close_to(1, 0.01),
             'aspect_ratio': equal_to(0),
             'area': equal_to(0),
-            'normalized_red_mean': close_to(0.06, 0.01),
-            'normalized_green_mean': close_to(0.15, 0.01),
-            'normalized_blue_mean': close_to(0.15, 0.01),
+            'normalized_red_mean': close_to(0, 0.01),
+            'normalized_green_mean': close_to(0, 0.01),
+            'normalized_blue_mean': close_to(0, 0.01),
         })
-    })
-                )
+    }))

--- a/tests/vision/checks/distribution/image_dataset_drift_test.py
+++ b/tests/vision/checks/distribution/image_dataset_drift_test.py
@@ -9,10 +9,9 @@
 # ----------------------------------------------------------------------------
 #
 """Test functions of the VISION train test label drift."""
-from hamcrest import assert_that, has_entries, close_to, equal_to, raises, calling
+from hamcrest import assert_that, has_entries, close_to, equal_to
 
 import numpy as np
-from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.vision import VisionData
 from deepchecks.vision.checks import ImageDatasetDrift
 from deepchecks.vision.utils import ImageFormatter, DetectionLabelFormatter
@@ -45,10 +44,10 @@ def test_no_drift_grayscale(mnist_dataset_train):
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.484, 0.001),
+        'domain_classifier_auc': close_to(0.494, 0.001),
         'domain_classifier_drift_score': equal_to(0),
         'domain_classifier_feature_importance': has_entries({
-            'brightness': equal_to(0),
+            'brightness': equal_to(1),
             'aspect_ratio': equal_to(0),
             'area': equal_to(0),
             'normalized_red_mean': equal_to(0),
@@ -70,8 +69,8 @@ def test_drift_grayscale(mnist_dataset_train, mnist_dataset_test):
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.524, 0.001),
-        'domain_classifier_drift_score': close_to(0.048, 0.001),
+        'domain_classifier_auc': close_to(0.509, 0.001),
+        'domain_classifier_drift_score': close_to(0.019, 0.001),
         'domain_classifier_feature_importance': has_entries({
             'brightness': equal_to(1),
             'aspect_ratio': equal_to(0),
@@ -128,8 +127,8 @@ def test_with_drift_rgb(coco_train_dataloader, coco_test_dataloader):
 
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.572, 0.001),
-        'domain_classifier_drift_score': close_to(0.144, 0.001),
+        'domain_classifier_auc': close_to(0.747, 0.001),
+        'domain_classifier_drift_score': close_to(0.494, 0.001),
         'domain_classifier_feature_importance': has_entries({
             'brightness': close_to(1, 0.01),
             'aspect_ratio': equal_to(0),

--- a/tests/vision/checks/distribution/train_test_label_drift_test.py
+++ b/tests/vision/checks/distribution/train_test_label_drift_test.py
@@ -99,6 +99,8 @@ def test_with_drift_object_detection(coco_train_visiondata, coco_test_visiondata
 def test_with_drift_object_detection_changed_num_samples(coco_train_visiondata, coco_test_visiondata):
     # Arrange
     check = TrainTestLabelDrift(min_sample_size=32)
+    coco_train_visiondata.set_seed(1)
+    coco_test_visiondata.set_seed(1)
 
     # Act
     result = check.run(coco_train_visiondata, coco_test_visiondata)
@@ -109,10 +111,10 @@ def test_with_drift_object_detection_changed_num_samples(coco_train_visiondata, 
             {'Drift score': close_to(0.44, 0.01),
              'Method': equal_to('PSI')}
         ), 'Bounding box area (in pixels)': has_entries(
-            {'Drift score': close_to(0.012, 0.001),
+            {'Drift score': close_to(0.013, 0.001),
              'Method': equal_to('Earth Mover\'s Distance')}
         ), 'Number of bounding boxes per image': has_entries(
-            {'Drift score': close_to(0.034, 0.001),
+            {'Drift score': close_to(0.058, 0.001),
              'Method': equal_to('Earth Mover\'s Distance')}
         )
         }

--- a/tests/vision/vision_conftest.py
+++ b/tests/vision/vision_conftest.py
@@ -47,27 +47,23 @@ __all__ = ['mnist_data_loader_train',
 
 @pytest.fixture(scope='session')
 def mnist_data_loader_train():
-    torch.manual_seed(42)
     return load_mnist_dataset(train=True, object_type='DataLoader')
 
 
 @pytest.fixture(scope='session')
 def mnist_dataset_train():
     """Return MNist dataset as VisionData object."""
-    torch.manual_seed(42)
     return load_mnist_dataset(train=True, object_type='VisionData')
 
 
 @pytest.fixture(scope='session')
 def mnist_data_loader_test():
-    torch.manual_seed(42)
     return load_mnist_dataset(train=False, object_type='DataLoader')
 
 
 @pytest.fixture(scope='session')
 def mnist_dataset_test():
     """Return MNist dataset as VisionData object."""
-    torch.manual_seed(42)
     return load_mnist_dataset(train=False, object_type='VisionData')
 
 


### PR DESCRIPTION
1. changed the loading of images in coco from Pillow to cv2
2. Added set_seed method on VisionData. we technically can just load without shuffle, but for MNIST I'm not sure if it's sorted, and it's better to be consistent in the way we work with the 2 datasets (mnist and coco)