### PR TITLE
Changing alternative_metrics to Dict

### DIFF
--- a/deepchecks/vision/checks/performance/class_performance.py
+++ b/deepchecks/vision/checks/performance/class_performance.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Module containing class performance check."""
-from typing import TypeVar, List, Any
+from typing import TypeVar, List, Any, Dict
 
 import pandas as pd
 import plotly.express as px
@@ -33,8 +33,9 @@ class ClassPerformance(TrainTestCheck):
 
     Parameters
     ----------
-    alternative_metrics : List[Metric], default: None
-        A list of ignite.Metric objects whose score should be used. If None are given, use the default metrics.
+    alternative_metrics : Dict[str, Metric], default: None
+        A dictionary of metrics, where the key is the metric name and the value is an ignite.Metric object whose score
+        should be used. If None are given, use the default metrics.
     n_to_show : int, default: 20
         Number of classes to show in the report. If None, show all classes.
     show_only : str, default: 'largest'
@@ -53,7 +54,7 @@ class ClassPerformance(TrainTestCheck):
     """
 
     def __init__(self,
-                 alternative_metrics: List[Metric] = None,
+                 alternative_metrics: Dict[str, Metric] = None,
                  n_to_show: int = 20,
                  show_only: str = 'largest',
                  metric_to_show_by: str = None,

--- a/deepchecks/vision/checks/performance/robustness_report.py
+++ b/deepchecks/vision/checks/performance/robustness_report.py
@@ -12,7 +12,7 @@
 from collections import defaultdict
 
 import imgaug
-from typing import TypeVar, List, Optional, Any, Sized
+from typing import TypeVar, List, Optional, Any, Sized, Dict
 import albumentations
 import numpy as np
 
@@ -45,17 +45,18 @@ class RobustnessReport(SingleDatasetCheck):
 
     Parameters
     ----------
-        alternative_metrics : List[Metric], default: None
-            A list of ignite.Metric objects whose score should be used. If None are given, use the default metrics.
-        augmentations : List, default: None
-            A list of augmentations to test on the data. If none are given default augmentations are used.
-            Supported augmentations are of albumentations and imgaug.
-        random_state : int, default: 42
-            A random state seed to make the check reproducible.
+    alternative_metrics : Dict[str, Metric], default: None
+        A dictionary of metrics, where the key is the metric name and the value is an ignite.Metric object whose score
+        should be used. If None are given, use the default metrics.
+    augmentations : List, default: None
+        A list of augmentations to test on the data. If none are given default augmentations are used.
+        Supported augmentations are of albumentations and imgaug.
+    random_state : int, default: 42
+        A random state seed to make the check reproducible.
     """
 
     def __init__(self,
-                 alternative_metrics: Optional[List[Metric]] = None,
+                 alternative_metrics: Optional[Dict[str, Metric]] = None,
                  augmentations: List = None,
                  random_state: int = 42):
         super().__init__()

--- a/deepchecks/vision/checks/performance/simple_model_comparison.py
+++ b/deepchecks/vision/checks/performance/simple_model_comparison.py
@@ -53,8 +53,9 @@ class SimpleModelComparison(TrainTestCheck):
           parametrized by the empirical class prior probabilities.
         * 'uniform' : Generates predictions uniformly at random from the list of unique classes observed in y,
           i.e. each class has equal probability. The predicted class is chosen randomly.
-    alternative_metrics : List[Metric], default: None
-            A list of ignite.Metric objects whose score should be used. If None are given, use the default metrics.
+    alternative_metrics : Dict[str, Metric], default: None
+        A dictionary of metrics, where the key is the metric name and the value is an ignite.Metric object whose score
+        should be used. If None are given, use the default metrics.
     n_to_show : int, default: 20
         Number of classes to show in the report. If None, show all classes.
     show_only : str, default: 'largest'
@@ -77,7 +78,7 @@ class SimpleModelComparison(TrainTestCheck):
 
     def __init__(self,
                  strategy: str = 'most_frequent',
-                 alternative_metrics: List[Metric] = None,
+                 alternative_metrics: Dict[str, Metric] = None,
                  n_to_show: int = 20,
                  show_only: str = 'largest',
                  metric_to_show_by: str = None,

--- a/tests/vision/utils_tests/metrics_test.py
+++ b/tests/vision/utils_tests/metrics_test.py
@@ -19,14 +19,16 @@ from deepchecks.vision import VisionData
 
 
 def test_default_ap_ignite_complient(coco_test_visiondata: VisionData, trained_yolov5_object_detection):
-    res = calculate_metrics({'AveragePrecision': AveragePrecision()}, coco_test_visiondata, trained_yolov5_object_detection,
+    res = calculate_metrics({'AveragePrecision': AveragePrecision()},
+                            coco_test_visiondata, trained_yolov5_object_detection,
                             prediction_formatter=DetectionPredictionFormatter(yolo_prediction_formatter))
     assert_that(res.keys(), has_length(1))
     assert_that(res['AveragePrecision'], has_length(59))
 
 
 def test_ar_ignite_complient(coco_test_visiondata: VisionData, trained_yolov5_object_detection):
-    res = calculate_metrics({'AveragePrecision': AveragePrecision(return_option=1)}, coco_test_visiondata, trained_yolov5_object_detection,
+    res = calculate_metrics({'AveragePrecision': AveragePrecision(return_option=1)},
+                            coco_test_visiondata, trained_yolov5_object_detection,
                             prediction_formatter=DetectionPredictionFormatter(yolo_prediction_formatter))
     assert_that(res.keys(), has_length(1))
     assert_that(res['AveragePrecision'], has_length(59))

--- a/tests/vision/utils_tests/metrics_test.py
+++ b/tests/vision/utils_tests/metrics_test.py
@@ -19,14 +19,14 @@ from deepchecks.vision import VisionData
 
 
 def test_default_ap_ignite_complient(coco_test_visiondata: VisionData, trained_yolov5_object_detection):
-    res = calculate_metrics([AveragePrecision()], coco_test_visiondata, trained_yolov5_object_detection,
+    res = calculate_metrics({'AveragePrecision': AveragePrecision()}, coco_test_visiondata, trained_yolov5_object_detection,
                             prediction_formatter=DetectionPredictionFormatter(yolo_prediction_formatter))
     assert_that(res.keys(), has_length(1))
     assert_that(res['AveragePrecision'], has_length(59))
 
 
 def test_ar_ignite_complient(coco_test_visiondata: VisionData, trained_yolov5_object_detection):
-    res = calculate_metrics([AveragePrecision(return_option=1)], coco_test_visiondata, trained_yolov5_object_detection,
+    res = calculate_metrics({'AveragePrecision': AveragePrecision(return_option=1)}, coco_test_visiondata, trained_yolov5_object_detection,
                             prediction_formatter=DetectionPredictionFormatter(yolo_prediction_formatter))
     assert_that(res.keys(), has_length(1))
     assert_that(res['AveragePrecision'], has_length(59))


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #895 


#### What does this implement/fix? Explain your changes.
Modifying `alternative_metrics` to be a Dict[str, Metric], instead of a list

#### Any other comments?



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
