### PR TITLE
Robustness + VisionData: copy generator when copying dataset

### DIFF
--- a/deepchecks/vision/dataset.py
+++ b/deepchecks/vision/dataset.py
@@ -390,7 +390,7 @@ def get_data_loader_props_to_copy(data_loader):
         props['generator'].set_state(data_loader.generator.get_state())
     # Add batch sampler if exists, else sampler
     if data_loader.batch_sampler is not None:
-        # Can't deepcopy since generator is not pickable, so copying shallowly and then copies also sampler inside
+        # Can't deepcopy since generator is not pickle-able, so copying shallowly and then copies also sampler inside
         batch_sampler = copy(data_loader.batch_sampler)
         batch_sampler.sampler = copy(batch_sampler.sampler)
         # Replace generator instance so the copied dataset will not affect the original

--- a/deepchecks/vision/dataset.py
+++ b/deepchecks/vision/dataset.py
@@ -382,10 +382,23 @@ def get_data_loader_props_to_copy(data_loader):
         'timeout': data_loader.timeout,
         'worker_init_fn': data_loader.worker_init_fn,
         'prefetch_factor': data_loader.prefetch_factor,
-        'persistent_workers': data_loader.persistent_workers
+        'persistent_workers': data_loader.persistent_workers,
+        'generator': torch.Generator()
     }
+    # Copy generator state if exists
+    if data_loader.generator:
+        props['generator'].set_state(data_loader.generator.get_state())
+    # Add batch sampler if exists, else sampler
     if data_loader.batch_sampler is not None:
-        props['batch_sampler'] = data_loader.batch_sampler
+        # Can't deepcopy since generator is not pickable, so copying shallowly and then copies also sampler inside
+        batch_sampler = copy(data_loader.batch_sampler)
+        batch_sampler.sampler = copy(batch_sampler.sampler)
+        # Replace generator instance so the copied dataset will not affect the original
+        batch_sampler.sampler.generator = props['generator']
+        props['batch_sampler'] = batch_sampler
     else:
-        props['sampler'] = data_loader.sampler
+        sampler = copy(data_loader.sampler)
+        # Replace generator instance so the copied dataset will not affect the original
+        sampler.generator = props['generator']
+        props['sampler'] = sampler
     return props

--- a/tests/vision/checks/performance/robustness_report_test.py
+++ b/tests/vision/checks/performance/robustness_report_test.py
@@ -46,8 +46,8 @@ def test_mnist(mnist_dataset_train, trained_mnist):
             'Recall': has_entries(score=close_to(0.986, 0.001), diff=close_to(-0.000, 0.001))
         }),
         'ShiftScaleRotate': has_entries({
-            'Precision': has_entries(score=close_to(0.810, 0.001), diff=close_to(-0.178, 0.001)),
-            'Recall': has_entries(score=close_to(0.788, 0.001), diff=close_to(-0.201, 0.001))
+            'Precision': has_entries(score=close_to(0.804, 0.001), diff=close_to(-0.184, 0.001)),
+            'Recall': has_entries(score=close_to(0.782, 0.001), diff=close_to(-0.207, 0.001))
         }),
     }))
 
@@ -71,8 +71,8 @@ def test_coco_and_condition(coco_train_visiondata, trained_yolov5_object_detecti
     # Assert
     assert_that(result.value, has_entries({
         'HueSaturationValue': has_entries({
-            'AP': has_entries(score=close_to(0.303, 0.001), diff=close_to(-0.064, 0.001)),
-            'AR': has_entries(score=close_to(0.333, 0.001), diff=close_to(-0.090, 0.001))
+            'AP': has_entries(score=close_to(0.327, 0.001), diff=close_to(0.009, 0.001)),
+            'AR': has_entries(score=close_to(0.361, 0.001), diff=close_to(-0.013, 0.001))
         }),
     }))
     assert_that(result.conditions_results, has_items(


### PR DESCRIPTION
I found that until now when copying visiondata, the underlying generator was the same instance, therefore running on one dataset affected the other state, so fixed that and then we'll see if it solves the inconsistency 