### PR TITLE
Remove state copying and setting seed in robustness_report

### DIFF
--- a/deepchecks/vision/checks/performance/robustness_report.py
+++ b/deepchecks/vision/checks/performance/robustness_report.py
@@ -159,7 +159,7 @@ class RobustnessReport(SingleDatasetCheck):
         # Add augmentation in the first place
         aug_dataset.add_augmentation(augmentation_func)
         # Set seed for reproducibility - The order of images is affecting the metrics, since the augmentations are
-        # not fixed (in a certain range), so different order of images will cause the images to be augmeneted a bit
+        # not fixed (in a certain range), so different order of images will cause the images to be augmented a bit
         # different which will lead to different metrics.
         aug_dataset.set_seed(seed)
         return aug_dataset

--- a/deepchecks/vision/checks/performance/robustness_report.py
+++ b/deepchecks/vision/checks/performance/robustness_report.py
@@ -103,7 +103,7 @@ class RobustnessReport(SingleDatasetCheck):
         aug_all_data = {}
         for augmentation_func in augmentations:
             augmentation = augmentation_name(augmentation_func)
-            aug_dataset = self._create_augmented_dataset(dataset, augmentation_func)
+            aug_dataset = self._create_augmented_dataset(dataset, augmentation_func, context.random_state)
             # The metrics have saved state, but they are reset inside `calculate_metrics`
             metrics = self._state['metrics']
             # Return dataframe of (Class, Metric, Value)
@@ -153,11 +153,15 @@ class RobustnessReport(SingleDatasetCheck):
 
         return self.add_condition(f'Metrics degrade by not more than {format_percent(ratio)}', condition)
 
-    def _create_augmented_dataset(self, dataset: VisionData, augmentation_func):
+    def _create_augmented_dataset(self, dataset: VisionData, augmentation_func, seed=None):
         # Create a copy of data loader and the dataset
         aug_dataset: VisionData = dataset.copy()
         # Add augmentation in the first place
         aug_dataset.add_augmentation(augmentation_func)
+        # Set seed for reproducibility - The order of images is affecting the metrics, since the augmentations are
+        # not fixed (in a certain range), so different order of images will cause the images to be augmeneted a bit
+        # different which will lead to different metrics.
+        aug_dataset.set_seed(seed)
         return aug_dataset
 
     def _validate_augmenting_affects(self, transform_handler, dataset: VisionData):

--- a/deepchecks/vision/dataset.py
+++ b/deepchecks/vision/dataset.py
@@ -270,7 +270,7 @@ class VisionData:
     def set_seed(self, seed):
         """Set seed for data loader."""
         generator = self._data.generator
-        if generator is not None:
+        if generator is not None and seed is not None:
             generator.set_state(torch.Generator().manual_seed(seed).get_state())
 
     def validate_shared_label(self, other):
@@ -385,9 +385,6 @@ def get_data_loader_props_to_copy(data_loader):
         'persistent_workers': data_loader.persistent_workers,
         'generator': torch.Generator()
     }
-    # Copy generator state if exists
-    if data_loader.generator:
-        props['generator'].set_state(data_loader.generator.get_state())
     # Add batch sampler if exists, else sampler
     if data_loader.batch_sampler is not None:
         # Can't deepcopy since generator is not pickle-able, so copying shallowly and then copies also sampler inside

--- a/tests/vision/checks/performance/robustness_report_test.py
+++ b/tests/vision/checks/performance/robustness_report_test.py
@@ -42,12 +42,12 @@ def test_mnist(mnist_dataset_train, trained_mnist):
     # Assert
     assert_that(result.value, has_entries({
         'RandomBrightnessContrast': has_entries({
-            'Precision': has_entries(score=close_to(0.984, 0.001), diff=close_to(-0.002, 0.001)),
-            'Recall': has_entries(score=close_to(0.986, 0.001), diff=close_to(-0.000, 0.001))
+            'Precision': has_entries(score=close_to(0.984, 0.001), diff=close_to(-0.001, 0.001)),
+            'Recall': has_entries(score=close_to(0.986, 0.001), diff=close_to(-0.001, 0.001))
         }),
         'ShiftScaleRotate': has_entries({
-            'Precision': has_entries(score=close_to(0.804, 0.001), diff=close_to(-0.184, 0.001)),
-            'Recall': has_entries(score=close_to(0.782, 0.001), diff=close_to(-0.207, 0.001))
+            'Precision': has_entries(score=close_to(0.799, 0.001), diff=close_to(-0.189, 0.001)),
+            'Recall': has_entries(score=close_to(0.783, 0.001), diff=close_to(-0.206, 0.001))
         }),
     }))
 
@@ -71,8 +71,8 @@ def test_coco_and_condition(coco_train_visiondata, trained_yolov5_object_detecti
     # Assert
     assert_that(result.value, has_entries({
         'HueSaturationValue': has_entries({
-            'AP': has_entries(score=close_to(0.327, 0.001), diff=close_to(0.009, 0.001)),
-            'AR': has_entries(score=close_to(0.361, 0.001), diff=close_to(-0.013, 0.001))
+            'AP': has_entries(score=close_to(0.308, 0.001), diff=close_to(-0.051, 0.001)),
+            'AR': has_entries(score=close_to(0.344, 0.001), diff=close_to(-0.060, 0.001))
         }),
     }))
     assert_that(result.conditions_results, has_items(


### PR DESCRIPTION
The generator state copy doesn't work. For some reason, the "get_state()" doesn't return same results in the same point on different envs. 
Removed this copying and add manual seed set in robustness