### PR TITLE
Fix order of results in vision suite

### DIFF
--- a/deepchecks/vision/base.py
+++ b/deepchecks/vision/base.py
@@ -414,6 +414,8 @@ class Suite(BaseSuite):
                     checks[str(check_idx) + ' - Train'] = check
                 if test_dataset is not None:
                     checks[str(check_idx) + ' - Test'] = check
+            else:
+                raise DeepchecksNotSupportedError(f'Don\'t know to handle check type {type(check)}')
 
         run_train_test_checks = train_dataset is not None and test_dataset is not None
 
@@ -463,14 +465,18 @@ class Suite(BaseSuite):
         for check_idx, result in results.items():
             if isinstance(result, CheckResult):
                 result = finalize_check_result(result, checks[check_idx])
-                result.header = (
-                    f'{result.get_header()} - Train Dataset'
-                    if str(check_idx).endswith(' - Train')
-                    else f'{result.get_header()} - Test Dataset'
-                )
                 results[check_idx] = result
+                # Update header only if both train and test ran
+                if run_train_test_checks:
+                    result.header = (
+                        f'{result.get_header()} - Train Dataset'
+                        if str(check_idx).endswith(' - Train')
+                        else f'{result.get_header()} - Test Dataset'
+                    )
 
-        return SuiteResult(self.name, list(results.values()))
+        # The results are ordered as they ran instead of in the order they were defined, therefore sort by key
+        sorted_result_values = [value for name, value in sorted(results.items(), key=lambda pair: pair[0])]
+        return SuiteResult(self.name, sorted_result_values)
 
     def _update_loop(
         self,

--- a/deepchecks/vision/base.py
+++ b/deepchecks/vision/base.py
@@ -475,7 +475,7 @@ class Suite(BaseSuite):
                     )
 
         # The results are ordered as they ran instead of in the order they were defined, therefore sort by key
-        sorted_result_values = [value for name, value in sorted(results.items(), key=lambda pair: pair[0])]
+        sorted_result_values = [value for name, value in sorted(results.items(), key=lambda pair: str(pair[0]))]
         return SuiteResult(self.name, sorted_result_values)
 
     def _update_loop(

--- a/deepchecks/vision/checks/__init__.py
+++ b/deepchecks/vision/checks/__init__.py
@@ -10,7 +10,7 @@
 #
 """Module importing all vision checks."""
 from .performance import ClassPerformance, MeanAveragePrecisionReport, MeanAverageRecallReport, \
-                         RobustnessReport, ConfusionMatrixReport, SimpleModelComparison
+                         RobustnessReport, ConfusionMatrixReport, SimpleModelComparison, ImageSegmentPerformance
 from .distribution import TrainTestLabelDrift, ImageDatasetDrift, ImagePropertyDrift, TrainTestPredictionDrift
 
 __all__ = [
@@ -23,5 +23,6 @@ __all__ = [
     'TrainTestLabelDrift',
     'ImageDatasetDrift',
     'ImagePropertyDrift',
-    'TrainTestPredictionDrift'
+    'TrainTestPredictionDrift',
+    'ImageSegmentPerformance'
 ]


### PR DESCRIPTION
#### Reference Issues/PRs

resolve #945

#### What does this implement/fix? Explain your changes.

Results in vision suite were in the order the checks ran instead of the order they were defined.