### PR TITLE
Cv2 unit8

### DIFF
--- a/deepchecks/vision/checks/distribution/heatmap_comparison.py
+++ b/deepchecks/vision/checks/distribution/heatmap_comparison.py
@@ -258,7 +258,7 @@ class HeatmapComparison(TrainTestCheck):
             if img.shape[2] == 1:
                 resized_img = img
             elif img.shape[2] == 3:
-                resized_img = cv2.cvtColor(img.astype('float32'), cv2.COLOR_RGB2GRAY)
+                resized_img = cv2.cvtColor(img.astype('uint8'), cv2.COLOR_RGB2GRAY)
             else:
                 raise NotImplementedError('Images must be RGB or grayscale')
 
@@ -266,7 +266,7 @@ class HeatmapComparison(TrainTestCheck):
             if not target_shape:
                 target_shape.append(resized_img.shape[:2][::-1])
             else:
-                resized_img = cv2.resize(resized_img, target_shape[0], interpolation=cv2.INTER_AREA)
+                resized_img = cv2.resize(resized_img.astype('uint8'), target_shape[0], interpolation=cv2.INTER_AREA)
 
             # sum images
             if summed_image is None:

--- a/docs/source/user-guide/vision/classification_tutorial.rst
+++ b/docs/source/user-guide/vision/classification_tutorial.rst
@@ -73,7 +73,7 @@ This dataset is a very small subset of imagenet.
 
     def get_cv2_image(self, image):
         if isinstance(image, PIL.Image.Image):
-            image_np = np.array(image)
+            image_np = np.array(image).astype('uint8')
             return image_np
         elif isinstance(image, np.ndarray):
             return image


### PR DESCRIPTION
cv2 requires either unit8 or float32. This makes sure all uses of cv2 result and use uint8 images.