### PR TITLE
Robustness images sampled using classes_indices

### DIFF
--- a/deepchecks/vision/base_checks.py
+++ b/deepchecks/vision/base_checks.py
@@ -52,6 +52,7 @@ class SingleDatasetCheck(SingleDatasetBaseCheck):
     ) -> CheckResult:
         """Run check."""
         assert self.context_type is not None
+        # Context is copying the data object, then not using the original after the init
         context: Context = self.context_type(dataset,
                                              model=model,
                                              device=device,
@@ -59,10 +60,10 @@ class SingleDatasetCheck(SingleDatasetBaseCheck):
 
         self.initialize_run(context, DatasetKind.TRAIN)
 
-        dataset.init_cache()
-        for batch in dataset:
+        context.train.init_cache()
+        for batch in context.train:
             batch = Batch(batch, context, DatasetKind.TRAIN)
-            dataset.update_cache(batch.labels)
+            context.train.update_cache(batch.labels)
             self.update(context, batch, DatasetKind.TRAIN)
 
         return self.finalize_check_result(self.compute(context, DatasetKind.TRAIN))
@@ -98,6 +99,7 @@ class TrainTestCheck(TrainTestBaseCheck):
     ) -> CheckResult:
         """Run check."""
         assert self.context_type is not None
+        # Context is copying the data object, then not using the original after the init
         context: Context = self.context_type(train_dataset,
                                              test_dataset,
                                              model=model,

--- a/deepchecks/vision/vision_data.py
+++ b/deepchecks/vision/vision_data.py
@@ -72,7 +72,7 @@ class VisionData:
         self._transform_field = transform_field
         self._warned_labels = set()
         self._has_images = False
-        self._last_index = len(self.data_loader.batch_sampler.sampler)
+        self._last_index = len(self._sampler)
 
         try:
             self.validate_image_data(next(iter(self._data_loader)))
@@ -279,12 +279,13 @@ class VisionData:
             random_state used for the psuedo-random actions (sampling and shuffling)
         """
         new_vision_data = copy(self)
-        new_vision_data._data_loader = self._get_data_loader_copy(self.data_loader,
-                                                                  shuffle=shuffle,
-                                                                  random_state=random_state,
-                                                                  n_samples=n_samples)
+        copied_data_loader, copied_sampler = self._get_data_loader_copy(
+            self.data_loader, shuffle=shuffle, random_state=random_state, n_samples=n_samples
+        )
+        new_vision_data._data_loader = copied_data_loader
+        new_vision_data._sampler = copied_sampler
         # If new data is sampled, then needs to re-calculate cache
-        if n_samples:
+        if n_samples and self.classes_indices is not None:
             new_vision_data.init_cache()
             for batch in new_vision_data:
                 new_vision_data.update_cache(self.batch_to_labels(batch))
@@ -408,7 +409,7 @@ class VisionData:
 
         props = VisionData._get_data_loader_props(data_loader)
         props['batch_sampler'] = new_batch_sampler
-        return data_loader.__class__(**props)
+        return data_loader.__class__(**props), sampler
 
     @staticmethod
     def _get_data_loader_props(data_loader: DataLoader):


### PR DESCRIPTION
#### Reference Issues/PRs

resolve #1019 

#### What does this implement/fix? Explain your changes.

1. Fix bug in the copy of VisionData which led to incorrect indices order.
2. Use the "classes_indices" to get images from the datasets instead of iterating and searching for a given class (which also solves the problem of using same dataset for both train & test since the `classes_indices` contains only indices taken from the batch_sampler of the data loader)
