### PR TITLE
change x axis name to column name instead of value in drift graphs

### DIFF
--- a/deepchecks/core/check_utils/whole_dataset_drift_utils.py
+++ b/deepchecks/core/check_utils/whole_dataset_drift_utils.py
@@ -169,6 +169,7 @@ def display_dist(train_column: pd.Series, test_column: pd.Series, fi_ser: pd.Ser
     traces, xaxis_layout, yaxis_layout = \
         feature_distribution_traces(train_column.dropna(),
                                     test_column.dropna(),
+                                    column_name,
                                     is_categorical=column_name in cat_features,
                                     max_num_categories=max_num_categories)
 

--- a/deepchecks/tabular/checks/distribution/train_test_feature_drift.py
+++ b/deepchecks/tabular/checks/distribution/train_test_feature_drift.py
@@ -124,8 +124,9 @@ class TrainTestFeatureDrift(TrainTestCheck):
             value, method, display = calc_drift_and_plot(
                 train_column=train_dataset.data[column],
                 test_column=test_dataset.data[column],
-                plot_title=plot_title,
+                value_name=column,
                 column_type='categorical' if column in train_dataset.cat_features else 'numerical',
+                plot_title=plot_title,
                 max_num_categories=self.max_num_categories
             )
             values_dict[column] = {

--- a/deepchecks/tabular/checks/distribution/train_test_label_drift.py
+++ b/deepchecks/tabular/checks/distribution/train_test_label_drift.py
@@ -62,7 +62,7 @@ class TrainTestLabelDrift(TrainTestCheck):
         drift_score, method, display = calc_drift_and_plot(
             train_column=train_dataset.label_col,
             test_column=test_dataset.label_col,
-            plot_title=train_dataset.label_name,
+            value_name=train_dataset.label_name,
             column_type='categorical' if train_dataset.label_type == 'classification_label' else 'numerical',
             max_num_categories=self.max_num_categories
         )

--- a/deepchecks/tabular/checks/distribution/trust_score_comparison.py
+++ b/deepchecks/tabular/checks/distribution/trust_score_comparison.py
@@ -224,9 +224,8 @@ def _validate_parameters(k_filter, alpha, max_number_categories, min_test_sample
 
 def _display_plot(train_trust_scores, test_trust_scores, percent_to_cut):
     """Display a distribution comparison plot for the given columns."""
-    traces, xaxis, yaxis = feature_distribution_traces(train_trust_scores, test_trust_scores,
+    traces, xaxis, yaxis = feature_distribution_traces(train_trust_scores, test_trust_scores, 'Trust Score',
                                                        quantile_cut=percent_to_cut)
-    xaxis['title'] = 'Trust Score'
 
     figure = go.Figure(layout=go.Layout(
         title='Trust Score Distribution',

--- a/deepchecks/utils/distribution/drift.py
+++ b/deepchecks/utils/distribution/drift.py
@@ -10,7 +10,7 @@
 #
 """Common utilities for distribution checks."""
 
-from typing import Tuple, Union, Hashable, Callable
+from typing import Tuple, Union, Hashable, Callable, Optional
 
 from scipy.stats import wasserstein_distance
 import numpy as np
@@ -96,8 +96,9 @@ def earth_movers_distance(dist1: Union[np.ndarray, pd.Series], dist2: Union[np.n
     return wasserstein_distance(dist1, dist2)
 
 
-def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, plot_title: Hashable,
-                        column_type: str, max_num_categories: int = 10) -> Tuple[float, str, Callable]:
+def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, value_name: Hashable,
+                        column_type: str, plot_title: Optional[str] = None,
+                        max_num_categories: int = 10) -> Tuple[float, str, Callable]:
     """
     Calculate drift score per column.
 
@@ -107,10 +108,12 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, plot_ti
         column from train dataset
     test_column : pd.Series
         same column from test dataset
-    plot_title : Hashable
+    value_name : Hashable
         title of plot
     column_type : str
         type of column (either "numerical" or "categorical")
+    plot_title : str or None
+        if None use value_name as title otherwise use this.
     max_num_categories : int , default: 10
         Max number of allowed categories. If there are more, they are binned into an "Other" category.
     Returns
@@ -132,7 +135,7 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, plot_ti
         score = earth_movers_distance(dist1=train_dist, dist2=test_dist)
 
         bar_traces, bar_x_axis, bar_y_axis = drift_score_bar_traces(score)
-        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist)
+        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist, value_name)
 
     elif column_type == 'categorical':
         scorer_name = 'PSI'
@@ -141,7 +144,7 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, plot_ti
         score = psi(expected_percents=expected_percents, actual_percents=actual_percents)
 
         bar_traces, bar_x_axis, bar_y_axis = drift_score_bar_traces(score, bar_max=1)
-        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist, is_categorical=True,
+        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist, value_name, is_categorical=True,
                                                                             max_num_categories=max_num_categories)
     else:
         # Should never reach here
@@ -153,6 +156,9 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, plot_ti
 
     fig.add_traces(bar_traces, rows=[1] * len(bar_traces), cols=[1] * len(bar_traces))
     fig.add_traces(dist_traces, rows=[2] * len(dist_traces), cols=[1] * len(dist_traces))
+
+    if not plot_title:
+        plot_title = value_name
 
     shared_layout = go.Layout(
         xaxis=bar_x_axis,

--- a/deepchecks/utils/distribution/drift.py
+++ b/deepchecks/utils/distribution/drift.py
@@ -144,7 +144,8 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, value_n
         score = psi(expected_percents=expected_percents, actual_percents=actual_percents)
 
         bar_traces, bar_x_axis, bar_y_axis = drift_score_bar_traces(score, bar_max=1)
-        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist, value_name, is_categorical=True,
+        dist_traces, dist_x_axis, dist_y_axis = feature_distribution_traces(train_dist, test_dist, value_name,
+                                                                            is_categorical=True,
                                                                             max_num_categories=max_num_categories)
     else:
         # Should never reach here

--- a/deepchecks/utils/distribution/drift.py
+++ b/deepchecks/utils/distribution/drift.py
@@ -109,7 +109,7 @@ def calc_drift_and_plot(train_column: pd.Series, test_column: pd.Series, value_n
     test_column : pd.Series
         same column from test dataset
     value_name : Hashable
-        title of plot
+        title of the x axis, if plot_title is None then also the title of the whole plot.
     column_type : str
         type of column (either "numerical" or "categorical")
     plot_title : str or None

--- a/deepchecks/utils/distribution/plot.py
+++ b/deepchecks/utils/distribution/plot.py
@@ -114,6 +114,7 @@ def drift_score_bar_traces(drift_score: float, bar_max: float = None) -> Tuple[L
 
 def feature_distribution_traces(train_column,
                                 test_column,
+                                column_name,
                                 is_categorical: bool = False,
                                 max_num_categories: int = 10,
                                 quantile_cut: float = 0.02) -> Tuple[List[Union[go.Bar, go.Scatter]], Dict, Dict]:
@@ -208,7 +209,7 @@ def feature_distribution_traces(train_column,
 
         xaxis_layout = dict(fixedrange=False,
                             range=x_range_to_show,
-                            title='Value')
+                            title=column_name)
         yaxis_layout = dict(title='Probability Density', fixedrange=True)
 
     return traces, xaxis_layout, yaxis_layout

--- a/deepchecks/utils/distribution/plot.py
+++ b/deepchecks/utils/distribution/plot.py
@@ -126,6 +126,8 @@ def feature_distribution_traces(train_column,
         Train data used to trace distribution.
     test_column
         Test data used to trace distribution.
+    column_name
+        The name of the column values on the x axis.
     is_categorical : bool , default: False
         State if column is categorical.
     max_num_categories : int , default: 10

--- a/deepchecks/vision/checks/distribution/image_property_drift.py
+++ b/deepchecks/vision/checks/distribution/image_property_drift.py
@@ -151,7 +151,7 @@ class ImagePropertyDrift(TrainTestCheck):
             score, _, figure = calc_drift_and_plot(
                 train_column=df_train[property_name],
                 test_column=df_test[property_name],
-                plot_title=property_name,
+                value_name=property_name,
                 column_type=image_properties.get_column_type(single_property['output_type']),
                 max_num_categories=self.max_num_categories
             )

--- a/deepchecks/vision/checks/distribution/train_test_label_drift.py
+++ b/deepchecks/vision/checks/distribution/train_test_label_drift.py
@@ -149,7 +149,7 @@ class TrainTestLabelDrift(TrainTestCheck):
             value, method, display = calc_drift_and_plot(
                 train_column=pd.Series(self._train_label_properties[name]),
                 test_column=pd.Series(self._test_label_properties[name]),
-                plot_title=name,
+                value_name=name,
                 column_type=get_column_type(output_type),
                 max_num_categories=self.max_num_categories
             )

--- a/deepchecks/vision/checks/distribution/train_test_prediction_drift.py
+++ b/deepchecks/vision/checks/distribution/train_test_prediction_drift.py
@@ -146,7 +146,7 @@ class TrainTestPredictionDrift(TrainTestCheck):
             value, method, display = calc_drift_and_plot(
                 train_column=pd.Series(self._train_prediction_properties[name]),
                 test_column=pd.Series(self._test_prediction_properties[name]),
-                plot_title=name,
+                value_name=name,
                 column_type=get_column_type(output_type),
                 max_num_categories=self.max_num_categories
             )


### PR DESCRIPTION
#### Reference Issues/PRs

part of #1015 


#### What does this implement/fix? Explain your changes.

Renames the X-axis of distribution graphs from "value" to the `column name`