### PR TITLE
Suggestion: Add assert in vision objects to Batch

### DIFF
--- a/deepchecks/vision/checks/distribution/image_property_drift.py
+++ b/deepchecks/vision/checks/distribution/image_property_drift.py
@@ -70,14 +70,15 @@ class ImagePropertyDrift(TrainTestCheck):
         self.max_num_categories = max_num_categories
         self.classes_to_display = classes_to_display
         self.min_samples = min_samples
-        self._train_properties = defaultdict(list)
-        self._test_properties = defaultdict(list)
+        self._train_properties = None
+        self._test_properties = None
+        self._class_to_string = None
 
     def initialize_run(self, context: Context):
         """Initialize self state, and validate the run context."""
-        context.train.assert_image_formatter_valid()
-        context.test.assert_image_formatter_valid()
         self._class_to_string = context.train.label_id_to_name
+        self._train_properties = defaultdict(list)
+        self._test_properties = defaultdict(list)
 
     def update(
         self,

--- a/deepchecks/vision/context.py
+++ b/deepchecks/vision/context.py
@@ -21,7 +21,7 @@ from deepchecks.vision.vision_data import VisionData, TaskType
 from deepchecks.vision.utils.validation import apply_to_tensor
 from deepchecks.core.errors import (
     DatasetValidationError, DeepchecksNotImplementedError, ModelValidationError,
-    DeepchecksNotSupportedError, DeepchecksValueError
+    DeepchecksNotSupportedError, DeepchecksValueError, ValidationError
 )
 
 
@@ -52,6 +52,7 @@ class Batch:
         """Return labels for the batch, formatted in deepchecks format."""
         if self._labels is None:
             dataset = self._context.get_data_by_kind(self._dataset_kind)
+            dataset.assert_labels_valid()
             self._labels = dataset.batch_to_labels(self._batch)
         return self._labels
 
@@ -60,6 +61,7 @@ class Batch:
         """Return predictions for the batch, formatted in deepchecks format."""
         if self._predictions is None:
             dataset = self._context.get_data_by_kind(self._dataset_kind)
+            self._context.assert_predictions_valid(self._dataset_kind)
             self._predictions = dataset.infer_on_batch(self._batch, self._context.model, self._context.device)
         return self._predictions
 
@@ -68,6 +70,7 @@ class Batch:
         """Return images for the batch, formatted in deepchecks format."""
         if self._images is None:
             dataset = self._context.get_data_by_kind(self._dataset_kind)
+            dataset.assert_images_valid()
             self._images = dataset.batch_to_images(self._batch)
         return self._images
 
@@ -124,22 +127,32 @@ class Context:
             train.validate_shared_label(test)
 
         self._device = torch.device(device) if isinstance(device, str) else (device if device else torch.device('cpu'))
+        self._prediction_formatter_error = {}
 
         if model is not None:
             if not isinstance(model, nn.Module):
                 logger.warning('Model is not a torch.nn.Module. Deepchecks can\'t validate that model is in '
                                'evaluation state.')
-            else:
-                if model.training:
-                    raise DatasetValidationError('Model is not in evaluation state. Please set model training '
-                                                 'parameter to False or run model.eval() before passing it.')
-            for dataset, dataset_type in zip([train, test], ['train', 'test']):
+            elif model.training:
+                raise DatasetValidationError('Model is not in evaluation state. Please set model training '
+                                             'parameter to False or run model.eval() before passing it.')
+
+            for dataset, dataset_type in zip([train, test], [DatasetKind.TRAIN, DatasetKind.TEST]):
                 if dataset is not None:
                     try:
                         dataset.validate_prediction(next(iter(dataset.data_loader)), model, self._device)
+                        msg = None
                     except DeepchecksNotImplementedError:
-                        logger.warning('validate_prediction() was not implemented in %s dataset, '
-                                       'some checks will not run', dataset_type)
+                        msg = f'infer_on_batch() was not implemented in {dataset_type} ' \
+                           f'dataset, some checks will not run'
+                    except ValidationError as ex:
+                        msg = f'batch_to_images() was not implemented correctly in {dataset_type}, the ' \
+                           f'validation has failed with the error: {ex}. To test your prediction formatting use the ' \
+                           f'function `vision_data.validate_prediction(batch, model, device)`'
+
+                    if msg:
+                        self._prediction_formatter_error[dataset_type] = msg
+                        logger.warning(msg)
 
         # The copy does 2 things: Sample n_samples if parameter exists, and shuffle the data.
         # we shuffle because the data in VisionData is set to be sampled in a fixed order (in the init), so if the user
@@ -202,6 +215,11 @@ class Context:
             raise ModelValidationError(
                 f'Check is irrelevant for task of type {self.train.task_type}')
         return True
+
+    def assert_predictions_valid(self, kind: DatasetKind = None):
+        error = self._prediction_formatter_error.get(kind)
+        if error:
+            raise DeepchecksValueError(error)
 
     def get_data_by_kind(self, kind: DatasetKind):
         """Return the relevant VisionData by given kind."""

--- a/deepchecks/vision/context.py
+++ b/deepchecks/vision/context.py
@@ -61,8 +61,10 @@ class Batch:
         """Return predictions for the batch, formatted in deepchecks format."""
         if self._predictions is None:
             dataset = self._context.get_data_by_kind(self._dataset_kind)
+            # Calling model will raise error if model was not given
+            model = self._context.model
             self._context.assert_predictions_valid(self._dataset_kind)
-            self._predictions = dataset.infer_on_batch(self._batch, self._context.model, self._context.device)
+            self._predictions = dataset.infer_on_batch(self._batch, model, self._context.device)
         return self._predictions
 
     @property
@@ -217,6 +219,7 @@ class Context:
         return True
 
     def assert_predictions_valid(self, kind: DatasetKind = None):
+        """Assert that for given DatasetKind the model & dataset infer_on_batch return predictions in right format."""
         error = self._prediction_formatter_error.get(kind)
         if error:
             raise DeepchecksValueError(error)

--- a/deepchecks/vision/detection_data.py
+++ b/deepchecks/vision/detection_data.py
@@ -122,7 +122,7 @@ class DetectionData(VisionData):
     def get_classes(self, batch_labels: List[torch.Tensor]):
         """Get a labels batch and return classes inside it."""
         def get_classes_from_single_label(tensor: torch.Tensor):
-            return list(tensor[:, 0].tolist()) if len(tensor) > 0 else []
+            return list(tensor[:, 0].type(torch.IntTensor).tolist()) if len(tensor) > 0 else []
 
         return [get_classes_from_single_label(x) for x in batch_labels]
 
@@ -134,11 +134,12 @@ class DetectionData(VisionData):
         ----------
         batch
 
-        Returns
+        Raises
         -------
-        Optional[str]
-            None if the label is valid, otherwise a string containing the error message.
-
+        DeepchecksValueError
+            If labels format is invalid
+        DeepchecksNotImplementedError
+            If batch_to_labels not implemented
         """
         labels = self.batch_to_labels(batch)
         if not isinstance(labels, list):
@@ -164,6 +165,13 @@ class DetectionData(VisionData):
             Batch from DataLoader
         model : t.Any
         device : torch.Device
+
+        Raises
+        ------
+        DeepchecksValueError
+            If predictions format is invalid
+        DeepchecksNotImplementedError
+            If infer_on_batch not implemented
         """
         batch_predictions = self.infer_on_batch(batch, model, device)
         if not isinstance(batch_predictions, list):

--- a/deepchecks/vision/utils/validation.py
+++ b/deepchecks/vision/utils/validation.py
@@ -58,7 +58,7 @@ T = t.TypeVar('T')
 def apply_to_tensor(
     x: T,
     fn: t.Callable[[torch.Tensor], torch.Tensor]
-) -> T:
+) -> t.Any:
     """Apply provided function to tensor instances recursivly."""
     if isinstance(x, torch.Tensor):
         return t.cast(T, fn(x))

--- a/deepchecks/vision/vision_data.py
+++ b/deepchecks/vision/vision_data.py
@@ -421,12 +421,12 @@ class VisionData:
         """Return the number of batches in the dataset dataloader."""
         return len(self._data_loader)
 
-    def assert_image_formatter_valid(self):
+    def assert_images_valid(self):
         """Assert the image formatter defined is valid. Else raise exception."""
         if self._image_formatter_error is not None:
             raise DeepchecksValueError(self._image_formatter_error)
 
-    def assert_label_formatter_valid(self):
+    def assert_labels_valid(self):
         """Assert the label formatter defined is valid. Else raise exception."""
         if self._label_formatter_error is not None:
             raise DeepchecksValueError(self._label_formatter_error)

--- a/tests/vision/base/test_custom_task.py
+++ b/tests/vision/base/test_custom_task.py
@@ -25,12 +25,12 @@ def test_empty_vision_data(mnist_data_loader_train):
 
     # Assert
     assert_that(
-        calling(data.assert_image_formatter_valid).with_args(),
+        calling(data.assert_images_valid).with_args(),
         raises(DeepchecksValueError, r'batch_to_images\(\) was not implemented, some checks will not run')
     )
 
     assert_that(
-        calling(data.assert_label_formatter_valid).with_args(),
+        calling(data.assert_labels_valid).with_args(),
         raises(DeepchecksValueError, r'batch_to_labels\(\) was not implemented, some checks will not run')
     )
 

--- a/tests/vision/base/test_vision_data.py
+++ b/tests/vision/base/test_vision_data.py
@@ -304,7 +304,7 @@ def test_get_classes_validation_not_sequence(mnist_data_loader_train):
 
     # Assert
     assert_that(
-        calling(data.assert_label_formatter_valid).with_args(),
+        calling(data.assert_labels_valid).with_args(),
         raises(DeepchecksValueError,
                r'get_classes\(\) was not implemented correctly, the validation has failed with the error: "The classes '
                r'must be a sequence\."\. '
@@ -323,7 +323,7 @@ def test_get_classes_validation_not_contain_sequence(mnist_data_loader_train):
 
     # Assert
     assert_that(
-        calling(data.assert_label_formatter_valid).with_args(),
+        calling(data.assert_labels_valid).with_args(),
         raises(DeepchecksValueError,
                r'get_classes\(\) was not implemented correctly, the validation has failed with the error: "The '
                r'classes sequence must contain as values sequences of ints \(sequence per sample\).". To test your '
@@ -342,7 +342,7 @@ def test_get_classes_validation_not_contain_contain_int(mnist_data_loader_train)
 
     # Assert
     assert_that(
-        calling(data.assert_label_formatter_valid).with_args(),
+        calling(data.assert_labels_valid).with_args(),
         raises(DeepchecksValueError,
                r'get_classes\(\) was not implemented correctly, the validation has failed with the error: "The '
                r'samples sequence must contain only int values.". To test your formatting use the function '


### PR DESCRIPTION
resolve #1058

Problem:
If there are problems with the formatters we want our checks to fail with an informative exception instead of some un-expected one. For example if user did image formatting with transposed shape (channels in start instead of end) then the check will run and will fail with some unknown expected when the image format will not fit what the check is expecting.

Pros of suggested solution:
Seamless assert, no code added in the checks

Cons:
The call to "assert" function is on every call to batch, if we put it in the check's `initialize_run` function it will be called once
