### PR TITLE
custom metrics reuse bug

### DIFF
--- a/deepchecks/vision/checks/performance/image_segment_performance.py
+++ b/deepchecks/vision/checks/performance/image_segment_performance.py
@@ -12,7 +12,6 @@
 import math
 import typing as t
 from collections import defaultdict, Counter
-from copy import copy
 
 import numpy as np
 import pandas as pd

--- a/deepchecks/vision/checks/performance/image_segment_performance.py
+++ b/deepchecks/vision/checks/performance/image_segment_performance.py
@@ -278,9 +278,17 @@ def _add_to_fitting_bin(bins: t.List[t.Dict], property_value, label, prediction)
         if single_bin['start'] <= property_value < single_bin['stop']:
             single_bin['count'] += 1
             for metric in single_bin['metrics'].values():
-                # Since this is a single prediction and label need to wrap in tensor
-                metric.update((torch.unsqueeze(prediction, 0), torch.unsqueeze(label, 0)))
+                # Since this is a single prediction and label need to wrap in tensor/label, in order to pass the
+                # expected shape to the metric
+                metric.update((_wrap_torch_or_list(prediction), _wrap_torch_or_list(label)))
             return
+
+
+def _wrap_torch_or_list(value):
+    """Unsqueeze the value if it is a tensor or wrap in list otherwise."""
+    if isinstance(value, torch.Tensor):
+        return torch.unsqueeze(value, 0)
+    return [value]
 
 
 def _range_string(start, stop, precision):

--- a/deepchecks/vision/checks/performance/image_segment_performance.py
+++ b/deepchecks/vision/checks/performance/image_segment_performance.py
@@ -82,7 +82,6 @@ class ImageSegmentPerformance(SingleDatasetCheck):
 
     def update(self, context: Context, batch: Batch, dataset_kind: DatasetKind):
         """Update the bins by the image properties."""
-        dataset = context.get_data_by_kind(dataset_kind)
         images = batch.images
         predictions = batch.predictions
         labels = batch.labels
@@ -106,7 +105,7 @@ class ImageSegmentPerformance(SingleDatasetCheck):
             # Check if enough data to infer bins
             if len(samples_for_bin) >= self.number_of_samples_to_infer_bins:
                 # Create the bins and metrics, and divide all cached data into the bins
-                self._state['bins'] = self._create_bins_and_metrics(samples_for_bin, dataset)
+                self._state['bins'] = self._create_bins_and_metrics(samples_for_bin)
                 # Remove the samples cache which are no longer needed (free the memory)
                 del samples_for_bin
 
@@ -123,7 +122,7 @@ class ImageSegmentPerformance(SingleDatasetCheck):
         # In case there are fewer samples than 'number_of_samples_to_infer_bins' then bins were not calculated
         if self._state['bins'] is None:
             # Create the bins and metrics
-            bins = self._create_bins_and_metrics(self._state['samples_for_binning'], dataset)
+            bins = self._create_bins_and_metrics(self._state['samples_for_binning'])
         else:
             bins = self._state['bins']
 
@@ -183,7 +182,7 @@ class ImageSegmentPerformance(SingleDatasetCheck):
 
         return CheckResult(value=dict(result_value), display=fig)
 
-    def _create_bins_and_metrics(self, batch_data: t.List[t.Tuple], dataset):
+    def _create_bins_and_metrics(self, batch_data: t.List[t.Tuple]):
         """Return dict of bins for each property in format \
         {property_name: [{start: val, stop: val, count: x, metrics: {name: metric...}}, ...], ...}."""
         # For X bins we need to have (X - 1) quantile bounds (open bounds from left and right)

--- a/deepchecks/vision/metrics_utils/metrics.py
+++ b/deepchecks/vision/metrics_utils/metrics.py
@@ -10,7 +10,6 @@
 #
 """Module for defining metrics for the vision module."""
 import typing as t
-from copy import copy
 
 import numpy as np
 import pandas as pd
@@ -68,13 +67,12 @@ def get_scorers_list(
     task_type = dataset.task_type
 
     if alternative_scorers:
-        scorers = {}
-        for name, met in alternative_scorers.items():
+        for _, met in alternative_scorers.items():
             # Validate that each alternative scorer is a correct type
             if not isinstance(met, Metric):
                 raise DeepchecksValueError('alternative_scorers should contain metrics of type ignite.Metric')
             met.reset()
-            scorers[name] = copy(met)
+        return alternative_scorers
     elif task_type == TaskType.CLASSIFICATION:
         scorers = get_default_classification_scorers()
     elif task_type == TaskType.OBJECT_DETECTION:

--- a/deepchecks/vision/metrics_utils/metrics.py
+++ b/deepchecks/vision/metrics_utils/metrics.py
@@ -10,6 +10,7 @@
 #
 """Module for defining metrics for the vision module."""
 import typing as t
+from copy import copy
 
 import numpy as np
 import pandas as pd
@@ -67,12 +68,16 @@ def get_scorers_list(
     task_type = dataset.task_type
 
     if alternative_scorers:
-        for _, met in alternative_scorers.items():
+        # For alternative scorers we create a copy since in suites we are running in parallel, so we can't use the same
+        # instance for several checks.
+        scorers = {}
+        for name, met in alternative_scorers.items():
             # Validate that each alternative scorer is a correct type
             if not isinstance(met, Metric):
                 raise DeepchecksValueError('alternative_scorers should contain metrics of type ignite.Metric')
             met.reset()
-        return alternative_scorers
+            scorers[name] = copy(met)
+        return scorers
     elif task_type == TaskType.CLASSIFICATION:
         scorers = get_default_classification_scorers()
     elif task_type == TaskType.OBJECT_DETECTION:

--- a/deepchecks/vision/metrics_utils/metrics.py
+++ b/deepchecks/vision/metrics_utils/metrics.py
@@ -10,6 +10,7 @@
 #
 """Module for defining metrics for the vision module."""
 import typing as t
+from copy import copy
 
 import numpy as np
 import pandas as pd
@@ -67,11 +68,13 @@ def get_scorers_list(
     task_type = dataset.task_type
 
     if alternative_scorers:
-        # Validate that each alternative scorer is a correct type
-        for _, met in alternative_scorers.items():
+        scorers = {}
+        for name, met in alternative_scorers.items():
+            # Validate that each alternative scorer is a correct type
             if not isinstance(met, Metric):
                 raise DeepchecksValueError('alternative_scorers should contain metrics of type ignite.Metric')
-        scorers = alternative_scorers
+            met.reset()
+            scorers[name] = copy(met)
     elif task_type == TaskType.CLASSIFICATION:
         scorers = get_default_classification_scorers()
     elif task_type == TaskType.OBJECT_DETECTION:

--- a/tests/vision/checks/performance/class_performance_test.py
+++ b/tests/vision/checks/performance/class_performance_test.py
@@ -99,8 +99,8 @@ def test_mnist_alt(mnist_dataset_train, mnist_dataset_test, mock_trained_mnist, 
     r_row = result.value.loc[result.value['Metric'] == 'r'].sort_values(by='Value', ascending=False).iloc[0]
     # Assert
     assert_that(len(result.value), equal_to(8))
-    assert_that(p_row['Value'], close_to(0.975, 0.001))
-    assert_that(r_row['Value'], close_to(0.985, 0.001))
+    assert_that(p_row['Value'], close_to(.984, 0.001))
+    assert_that(r_row['Value'], close_to(0.988, 0.001))
 
 
 def test_coco_best(coco_train_visiondata, coco_test_visiondata, mock_trained_yolov5_object_detection, device):

--- a/tests/vision/checks/performance/robustness_report_test.py
+++ b/tests/vision/checks/performance/robustness_report_test.py
@@ -65,8 +65,8 @@ def test_coco_and_condition(coco_train_visiondata, mock_trained_yolov5_object_de
     # Assert
     assert_that(result.value, has_entries({
         'Hue Saturation Value': has_entries({
-            'AP': has_entries(score=close_to(0.348, 0.001), diff=close_to(-0.107, 0.001)),
-            'AR': has_entries(score=close_to(0.376, 0.001), diff=close_to(-0.092, 0.001))
+            'AP': has_entries(score=close_to(0.348, 0.01), diff=close_to(-0.104, 0.01)),
+            'AR': has_entries(score=close_to(0.376, 0.01), diff=close_to(-0.075, 0.01))
         }),
     }))
     assert_that(result.conditions_results, has_items(


### PR DESCRIPTION
#### Reference Issues/PRs

When alternative_metrics are given the same instance is used without duplication for all the checks in a suite. since we are running in parallel this makes the same instance to be used multiple times in different checks. Added copy of the metrics objects to prevent this

