### PR TITLE
Update tabular drift checks to raise correct error without features

### DIFF
--- a/deepchecks/tabular/checks/distribution/train_test_feature_drift.py
+++ b/deepchecks/tabular/checks/distribution/train_test_feature_drift.py
@@ -105,6 +105,8 @@ class TrainTestFeatureDrift(TrainTestCheck):
         train_dataset: Dataset = context.train
         test_dataset: Dataset = context.test
         features_importance = context.features_importance
+        train_dataset.assert_features()
+        test_dataset.assert_features()
 
         train_dataset = train_dataset.select(
                 self.columns, self.ignore_columns

--- a/deepchecks/tabular/checks/distribution/whole_dataset_drift.py
+++ b/deepchecks/tabular/checks/distribution/whole_dataset_drift.py
@@ -91,7 +91,6 @@ class WholeDatasetDrift(TrainTestCheck):
         """
         train_dataset = context.train
         test_dataset = context.test
-        features = train_dataset.features
         cat_features = train_dataset.cat_features
         numerical_features = train_dataset.numerical_features
 
@@ -104,8 +103,8 @@ class WholeDatasetDrift(TrainTestCheck):
         </span>
         """
 
-        values_dict, displays = run_whole_dataset_drift(train_dataframe=train_dataset.data[features],
-                                                        test_dataframe=test_dataset.data[features],
+        values_dict, displays = run_whole_dataset_drift(train_dataframe=train_dataset.features_columns,
+                                                        test_dataframe=test_dataset.features_columns,
                                                         numerical_features=numerical_features,
                                                         cat_features=cat_features,
                                                         sample_size=sample_size, random_state=self.random_state,


### PR DESCRIPTION
close #1133 

Right now when passing DataFrame we support only integrity checks. any ML-related check which requires to know which columns are features, label, etc, requires to get a Dataset. 

The error raised is:
DeepchecksNotSupportedError: There are no features defined to use. Did you pass a DataFrame instead of a Dataset?

