### PR TITLE
disable tqdm globally in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,13 @@ from deepchecks.core.check_result import CheckFailure, CheckResult
 
 from .vision.vision_conftest import * #pylint: disable=wildcard-import, unused-wildcard-import
 
+from tqdm import tqdm
+from functools import partialmethod
+
+# disable tqdm for tests
+tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
+
+
 def get_expected_results_length(suite: BaseSuite, args: Dict):
     num_single = len([c for c in suite.checks.values() if isinstance(c, SingleDatasetBaseCheck)])
     num_others = len(suite.checks.values()) - num_single


### PR DESCRIPTION
#### Reference Issues/PRs

Resolves #1266 


#### What does this implement/fix? Explain your changes.
disable tqdm globally in tests


#### Any other comments?
most test don't output tqdm because there are very small batches. ImageSegmentPerformace always displayed tqdm because n_samples=None



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
