### PR TITLE
Various single feature contribution fixes

### DIFF
--- a/deepchecks/core/check_utils/single_feature_contribution_utils.py
+++ b/deepchecks/core/check_utils/single_feature_contribution_utils.py
@@ -21,7 +21,7 @@ import plotly.graph_objects as go
 
 def get_single_feature_contribution(train_df: pd.DataFrame, train_label_name: Optional[Hashable], test_df: pd.DataFrame,
                                     test_label_name: Optional[Hashable], ppscore_params: dict, n_show_top: int,
-                                    random_state: int = 42):
+                                    random_state: int = None):
     """
     Calculate the PPS for train, test and difference for single feature contribution checks.
 
@@ -43,8 +43,8 @@ def get_single_feature_contribution(train_df: pd.DataFrame, train_label_name: Op
             dictionary of additional parameters for the ppscore predictor function
         n_show_top: int
             Number of features to show, sorted by the magnitude of difference in PPS
-        random_state: int, default 42
-        Random state for the ppscore.predictors function
+        random_state: int, default None
+            Random state for the ppscore.predictors function
 
     Returns:
         CheckResult
@@ -110,7 +110,7 @@ def get_single_feature_contribution_per_class(train_df: pd.DataFrame, train_labe
                                               test_label_name: Optional[Hashable], ppscore_params: dict,
                                               n_show_top: int,
                                               min_pps_to_show: float = 0.05,
-                                              random_state: int = 42):
+                                              random_state: int = None):
     """
     Calculate the PPS for train, test and difference for single feature contribution checks per class.
 
@@ -134,7 +134,7 @@ def get_single_feature_contribution_per_class(train_df: pd.DataFrame, train_labe
             Number of features to show, sorted by the magnitude of difference in PPS
         min_pps_to_show: float, default 0.05
             Minimum PPS to show a class in the graph
-        random_state: int, default 42
+        random_state: int, default None
             Random state for the ppscore.predictors function
 
     Returns:

--- a/deepchecks/core/check_utils/single_feature_contribution_utils.py
+++ b/deepchecks/core/check_utils/single_feature_contribution_utils.py
@@ -20,7 +20,8 @@ import plotly.graph_objects as go
 
 
 def get_single_feature_contribution(train_df: pd.DataFrame, train_label_name: Optional[Hashable], test_df: pd.DataFrame,
-                                    test_label_name: Optional[Hashable], ppscore_params: dict, n_show_top: int):
+                                    test_label_name: Optional[Hashable], ppscore_params: dict, n_show_top: int,
+                                    random_state: int = 42):
     """
     Calculate the PPS for train, test and difference for single feature contribution checks.
 
@@ -42,6 +43,8 @@ def get_single_feature_contribution(train_df: pd.DataFrame, train_label_name: Op
             dictionary of additional parameters for the ppscore predictor function
         n_show_top: int
             Number of features to show, sorted by the magnitude of difference in PPS
+        random_state: int, default 42
+        Random state for the ppscore.predictors function
 
     Returns:
         CheckResult
@@ -49,11 +52,11 @@ def get_single_feature_contribution(train_df: pd.DataFrame, train_label_name: Op
             display: bar graph of the PPS of each feature.
     """
     df_pps_train = pps.predictors(df=train_df, y=train_label_name,
-                                  random_seed=42,
+                                  random_seed=random_state,
                                   **ppscore_params)
     df_pps_test = pps.predictors(df=test_df,
                                  y=test_label_name,
-                                 random_seed=42, **ppscore_params)
+                                 random_seed=random_state, **ppscore_params)
 
     s_pps_train = df_pps_train.set_index('x', drop=True)['ppscore']
     s_pps_test = df_pps_test.set_index('x', drop=True)['ppscore']
@@ -106,7 +109,8 @@ def get_single_feature_contribution_per_class(train_df: pd.DataFrame, train_labe
                                               test_df: pd.DataFrame,
                                               test_label_name: Optional[Hashable], ppscore_params: dict,
                                               n_show_top: int,
-                                              min_pps_to_show: float = 0.05):
+                                              min_pps_to_show: float = 0.05,
+                                              random_state: int = 42):
     """
     Calculate the PPS for train, test and difference for single feature contribution checks per class.
 
@@ -130,6 +134,8 @@ def get_single_feature_contribution_per_class(train_df: pd.DataFrame, train_labe
             Number of features to show, sorted by the magnitude of difference in PPS
         min_pps_to_show: float, default 0.05
             Minimum PPS to show a class in the graph
+        random_state: int, default 42
+            Random state for the ppscore.predictors function
 
     Returns:
         CheckResult
@@ -153,11 +159,11 @@ def get_single_feature_contribution_per_class(train_df: pd.DataFrame, train_labe
             lambda x: 1 if x == c else 0)  # pylint: disable=cell-var-from-loop
 
         df_pps_train = pps.predictors(df=train_df_all_vs_one, y=train_label_name,
-                                      random_seed=42,
+                                      random_seed=random_state,
                                       **ppscore_params)
         df_pps_test = pps.predictors(df=test_df_all_vs_one,
                                      y=test_label_name,
-                                     random_seed=42, **ppscore_params)
+                                     random_seed=random_state, **ppscore_params)
 
         s_pps_train = df_pps_train.set_index('x', drop=True)['ppscore']
         s_pps_test = df_pps_test.set_index('x', drop=True)['ppscore']

--- a/deepchecks/tabular/checks/methodology/single_feature_contribution.py
+++ b/deepchecks/tabular/checks/methodology/single_feature_contribution.py
@@ -46,17 +46,21 @@ class SingleFeatureContribution(SingleDatasetCheck):
         dictionary of additional parameters for the ppscore.predictors function
     n_top_features : int , default: 5
         Number of features to show, sorted by the magnitude of difference in PPS
+    random_state : int , default: None
+        Random state for the ppscore.predictors function
     """
 
     def __init__(
         self,
         ppscore_params=None,
         n_top_features: int = 5,
+        random_state: int = None,
         **kwargs
     ):
         super().__init__()
         self.ppscore_params = ppscore_params or {}
         self.n_top_features = n_top_features
+        self.random_state = random_state
 
     def run_logic(self, context: Context, dataset_type: str = 'train') -> CheckResult:
         """Run check.
@@ -81,7 +85,7 @@ class SingleFeatureContribution(SingleDatasetCheck):
         dataset.assert_label()
         relevant_columns = dataset.features + [dataset.label_name]
 
-        df_pps = pps.predictors(df=dataset.data[relevant_columns], y=dataset.label_name, random_seed=42,
+        df_pps = pps.predictors(df=dataset.data[relevant_columns], y=dataset.label_name, random_seed=self.random_state,
                                 **self.ppscore_params)
         df_pps = df_pps.set_index('x', drop=True)
         s_ppscore = df_pps['ppscore']

--- a/deepchecks/tabular/checks/methodology/single_feature_contribution_train_test.py
+++ b/deepchecks/tabular/checks/methodology/single_feature_contribution_train_test.py
@@ -49,12 +49,15 @@ class SingleFeatureContributionTrainTest(TrainTestCheck):
         dictionary of additional parameters for the ppscore predictor function
     n_top_features : int , default: 5
         Number of features to show, sorted by the magnitude of difference in PPS
+    random_state : int , default: None
+        Random state for the ppscore.predictors function
     """
 
-    def __init__(self, ppscore_params=None, n_top_features: int = 5, **kwargs):
+    def __init__(self, ppscore_params=None, n_top_features: int = 5, random_state: int = None, **kwargs):
         super().__init__(**kwargs)
         self.ppscore_params = ppscore_params or {}
         self.n_top_features = n_top_features
+        self.random_state = random_state
 
     def run_logic(self, context: Context) -> CheckResult:
         """Run check.
@@ -99,7 +102,8 @@ class SingleFeatureContributionTrainTest(TrainTestCheck):
                                                              train_dataset.label_name,
                                                              test_dataset.data[relevant_columns],
                                                              test_dataset.label_name, self.ppscore_params,
-                                                             self.n_top_features)
+                                                             self.n_top_features,
+                                                             random_state=self.random_state)
 
         if display:
             display += text

--- a/deepchecks/vision/checks/methodology/simple_feature_contribution.py
+++ b/deepchecks/vision/checks/methodology/simple_feature_contribution.py
@@ -152,7 +152,7 @@ class SimpleFeatureContribution(TrainTestCheck):
 
         # PPS task type is inferred from label dtype. For computer vision tasks, it's safe to assume that unless
         # the label is a float, then the task type is not regression and thus the label is cast to object dtype.
-        if not (is_float_dtype(df_train['target']) or is_float_dtype(df_test['target'])):
+        if not (self.is_float_column(df_train['target']) or self.is_float_column(df_test['target'])):
             df_train['target'] = df_train['target'].astype('object')
             df_test['target'] = df_test['target'].astype('object')
         else:
@@ -197,6 +197,25 @@ class SimpleFeatureContribution(TrainTestCheck):
             display += text
 
         return CheckResult(value=ret_value, display=display, header='Simple Feature Contribution')
+
+    @staticmethod
+    def is_float_column(col: pd.Series) -> bool:
+        """Check if a column must be a float - meaning does it contain fractions.
+
+        Parameters
+        ----------
+        col : pd.Series
+            The column to check.
+
+        Returns
+        -------
+        bool
+            True if the column is float, False otherwise.
+        """
+        if not is_float_dtype(col):
+            return False
+
+        return (col.round() != col).any()
 
     def add_condition_feature_pps_difference_not_greater_than(self: SFC, threshold: float = 0.2) -> SFC:
         """Add new condition.

--- a/deepchecks/vision/checks/methodology/simple_feature_contribution.py
+++ b/deepchecks/vision/checks/methodology/simple_feature_contribution.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from typing import Callable, TypeVar, Hashable, Dict, Union
 
 import pandas as pd
+from pandas.core.dtypes.common import is_float_dtype
 
 from deepchecks import ConditionResult
 from deepchecks.core import CheckResult, DatasetKind
@@ -148,6 +149,15 @@ class SimpleFeatureContribution(TrainTestCheck):
         """
         df_train = pd.DataFrame(self._train_properties)
         df_test = pd.DataFrame(self._test_properties)
+
+        # PPS task type is inferred from label dtype. For computer vision tasks, it's safe to assume that unless
+        # the label is a float, then the task type is not regression and thus the label is cast to object dtype.
+        if not (is_float_dtype(df_train['target']) or is_float_dtype(df_test['target'])):
+            df_train['target'] = df_train['target'].astype('object')
+            df_test['target'] = df_test['target'].astype('object')
+        else:
+            df_train['target'] = df_train['target'].astype('float')
+            df_test['target'] = df_test['target'].astype('float')
 
         text = [
             'The Predictive Power Score (PPS) is used to estimate the ability of an image property (such as brightness)'

--- a/deepchecks/vision/checks/methodology/simple_feature_contribution.py
+++ b/deepchecks/vision/checks/methodology/simple_feature_contribution.py
@@ -152,12 +152,14 @@ class SimpleFeatureContribution(TrainTestCheck):
 
         # PPS task type is inferred from label dtype. For computer vision tasks, it's safe to assume that unless
         # the label is a float, then the task type is not regression and thus the label is cast to object dtype.
-        if not (self.is_float_column(df_train['target']) or self.is_float_column(df_test['target'])):
-            df_train['target'] = df_train['target'].astype('object')
-            df_test['target'] = df_test['target'].astype('object')
-        else:
+        # For the known task types (object detection, classification), classification is always selected.
+        if context.train.task_type == TaskType.OTHER and \
+                (self.is_float_column(df_train['target']) or self.is_float_column(df_test['target'])):
             df_train['target'] = df_train['target'].astype('float')
             df_test['target'] = df_test['target'].astype('float')
+        else:
+            df_train['target'] = df_train['target'].astype('object')
+            df_test['target'] = df_test['target'].astype('object')
 
         text = [
             'The Predictive Power Score (PPS) is used to estimate the ability of an image property (such as brightness)'

--- a/deepchecks/vision/checks/methodology/simple_feature_contribution.py
+++ b/deepchecks/vision/checks/methodology/simple_feature_contribution.py
@@ -71,6 +71,8 @@ class SimpleFeatureContribution(TrainTestCheck):
         label. If True, the conditions will be run per class as well.
     n_top_properties: int, default: 5
         Number of features to show, sorted by the magnitude of difference in PPS
+    random_state: int, default: None
+        Random state for the ppscore.predictors function
     ppscore_params: dict, default: None
         dictionary of additional parameters for the ppscore predictor function
     """
@@ -80,6 +82,7 @@ class SimpleFeatureContribution(TrainTestCheck):
             image_properties: Dict[str, Callable] = None,
             n_top_properties: int = 3,
             per_class: bool = True,
+            random_state: int = None,
             ppscore_params: dict = None,
             **kwargs
     ):
@@ -93,6 +96,7 @@ class SimpleFeatureContribution(TrainTestCheck):
 
         self.per_class = per_class
         self.n_top_properties = n_top_properties
+        self.random_state = random_state
         self.ppscore_params = ppscore_params or {}
 
         self._train_properties = defaultdict(list)
@@ -122,11 +126,11 @@ class SimpleFeatureContribution(TrainTestCheck):
                         continue
                     class_id = int(label[0])
                     imgs += [cropped_img]
-                    target += [class_id]
+                    target += [dataset.label_id_to_name(class_id)]
         else:
             for img, classes_ids in zip(batch.images, dataset.get_classes(batch.labels)):
                 imgs += [img] * len(classes_ids)
-                target += classes_ids
+                target += list(map(dataset.label_id_to_name, classes_ids))
 
         properties['target'] += target
 
@@ -168,14 +172,16 @@ class SimpleFeatureContribution(TrainTestCheck):
                                                                            df_test,
                                                                            'target',
                                                                            self.ppscore_params,
-                                                                           self.n_top_properties)
+                                                                           self.n_top_properties,
+                                                                           random_state=self.random_state)
         else:
             ret_value, display = get_single_feature_contribution(df_train,
                                                                  'target',
                                                                  df_test,
                                                                  'target',
                                                                  self.ppscore_params,
-                                                                 self.n_top_properties)
+                                                                 self.n_top_properties,
+                                                                 random_state=self.random_state)
 
         if display:
             display += text

--- a/deepchecks/vision/suites/__init__.py
+++ b/deepchecks/vision/suites/__init__.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Module contains all prebuilt vision suites."""
-from .default_suites import train_test_validation, model_evaluation, full_suite
+from .default_suites import integrity_validation, train_test_validation, model_evaluation, full_suite
 
 __all__ = ['train_test_validation',
-           'model_evaluation', 'full_suite']
+           'model_evaluation', 'full_suite', 'integrity_validation']

--- a/tests/checks/methodology/single_feature_contribution_test.py
+++ b/tests/checks/methodology/single_feature_contribution_test.py
@@ -44,7 +44,7 @@ def util_generate_second_similar_dataframe_and_expected():
 
 def test_assert_single_feature_contribution():
     df, expected = util_generate_dataframe_and_expected()
-    result = SingleFeatureContribution().run(dataset=Dataset(df, label='label'))
+    result = SingleFeatureContribution(random_state=42).run(dataset=Dataset(df, label='label'))
 
     assert_that(result.value, has_entries(expected))
 
@@ -52,7 +52,7 @@ def test_assert_single_feature_contribution():
 def test_show_top_single_feature_contribution():
     # Arrange
     df, expected = util_generate_dataframe_and_expected()
-    check = SingleFeatureContribution(n_show_top=3)
+    check = SingleFeatureContribution(n_show_top=3, random_state=42)
 
     # Act
     result = check.run(dataset=Dataset(df, label='label'))
@@ -73,23 +73,23 @@ def test_dataset_no_label():
     df, _ = util_generate_dataframe_and_expected()
     df = Dataset(df)
     assert_that(
-        calling(SingleFeatureContribution().run).with_args(dataset=df),
+        calling(SingleFeatureContribution(random_state=42).run).with_args(dataset=df),
         raises(DeepchecksNotSupportedError,
                'There is no label defined to use. Did you pass a DataFrame instead of a Dataset?'))
 
 
 def test_trainval_assert_single_feature_contribution():
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
-    result = SingleFeatureContributionTrainTest().run(train_dataset=Dataset(df, label='label'),
-                                                      test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(random_state=42).run(train_dataset=Dataset(df, label='label'),
+                                                                     test_dataset=Dataset(df2, label='label'))
 
     assert_that(result.value['train-test difference'], has_entries(expected))
 
 
 def test_trainval_show_top_single_feature_contribution():
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
-    result = SingleFeatureContributionTrainTest(n_show_top=3).run(train_dataset=Dataset(df, label='label'),
-                                                                  test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(n_show_top=3, random_state=42).run(
+        train_dataset=Dataset(df, label='label'), test_dataset=Dataset(df2, label='label'))
     assert_that(result.value['train-test difference'], has_length(5))
     assert_that(result.value['train-test difference'], has_entries(expected))
 
@@ -97,7 +97,7 @@ def test_trainval_show_top_single_feature_contribution():
 def test_trainval_dataset_wrong_input():
     wrong = 'wrong_input'
     assert_that(
-        calling(SingleFeatureContributionTrainTest().run).with_args(wrong, wrong),
+        calling(SingleFeatureContributionTrainTest(random_state=42).run).with_args(wrong, wrong),
         raises(
             DeepchecksValueError,
             'non-empty instance of Dataset or DataFrame was expected, instead got str')
@@ -107,7 +107,7 @@ def test_trainval_dataset_wrong_input():
 def test_trainval_dataset_no_label():
     df, df2, _ = util_generate_second_similar_dataframe_and_expected()
     assert_that(
-        calling(SingleFeatureContributionTrainTest().run).with_args(
+        calling(SingleFeatureContributionTrainTest(random_state=42).run).with_args(
             train_dataset=Dataset(df),
             test_dataset=Dataset(df2)),
         raises(
@@ -120,7 +120,7 @@ def test_trainval_dataset_diff_columns():
     df, df2, _ = util_generate_second_similar_dataframe_and_expected()
     df = df.rename({'x2': 'x6'}, axis=1)
     assert_that(
-        calling(SingleFeatureContributionTrainTest().run).with_args(
+        calling(SingleFeatureContributionTrainTest(random_state=42).run).with_args(
             train_dataset=Dataset(df, label='label'),
             test_dataset=Dataset(df2, label='label')),
         raises(
@@ -134,7 +134,7 @@ def test_all_features_pps_upper_bound_condition_that_should_not_pass():
     df, _ = util_generate_dataframe_and_expected()
     dataset = Dataset(df, label="label")
     condition_value = 0.4
-    check = SingleFeatureContribution().add_condition_feature_pps_not_greater_than(condition_value)
+    check = SingleFeatureContribution(random_state=42).add_condition_feature_pps_not_greater_than(condition_value)
 
     # Act
     condition_result, *_ = check.conditions_decision(check.run(dataset))
@@ -152,7 +152,7 @@ def test_all_features_pps_upper_bound_condition_that_should_pass():
     df, expected = util_generate_dataframe_and_expected()
     dataset = Dataset(df, label="label")
     condition_value = 0.9
-    check = SingleFeatureContribution().add_condition_feature_pps_not_greater_than(condition_value)
+    check = SingleFeatureContribution(random_state=42).add_condition_feature_pps_not_greater_than(condition_value)
 
     # Act
     condition_result, *_ = check.conditions_decision(check.run(dataset))
@@ -168,11 +168,12 @@ def test_train_test_condition_pps_difference_pass():
     # Arrange
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
     condition_value = 0.4
-    check = SingleFeatureContributionTrainTest().add_condition_feature_pps_difference_not_greater_than(condition_value)
+    check = SingleFeatureContributionTrainTest(random_state=42
+                                               ).add_condition_feature_pps_difference_not_greater_than(condition_value)
 
     # Act
-    result = SingleFeatureContributionTrainTest().run(train_dataset=Dataset(df, label='label'),
-                                                      test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(random_state=42).run(
+        train_dataset=Dataset(df, label='label'), test_dataset=Dataset(df2, label='label'))
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
@@ -186,11 +187,12 @@ def test_train_test_condition_pps_difference_fail():
     # Arrange
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
     condition_value = 0.01
-    check = SingleFeatureContributionTrainTest().add_condition_feature_pps_difference_not_greater_than(condition_value)
+    check = SingleFeatureContributionTrainTest(random_state=42
+                                               ).add_condition_feature_pps_difference_not_greater_than(condition_value)
 
     # Act
-    result = SingleFeatureContributionTrainTest().run(train_dataset=Dataset(df, label='label'),
-                                                      test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(random_state=42).run(train_dataset=Dataset(df, label='label'),
+                                                                     test_dataset=Dataset(df2, label='label'))
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
@@ -205,11 +207,12 @@ def test_train_test_condition_pps_train_pass():
     # Arrange
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
     condition_value = 0.9
-    check = SingleFeatureContributionTrainTest().add_condition_feature_pps_in_train_not_greater_than(condition_value)
+    check = SingleFeatureContributionTrainTest(random_state=42
+                                               ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
 
     # Act
-    result = SingleFeatureContributionTrainTest().run(train_dataset=Dataset(df, label='label'),
-                                                      test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(random_state=42).run(train_dataset=Dataset(df, label='label'),
+                                                                     test_dataset=Dataset(df2, label='label'))
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
@@ -223,11 +226,12 @@ def test_train_test_condition_pps_train_fail():
     # Arrange
     df, df2, expected = util_generate_second_similar_dataframe_and_expected()
     condition_value = 0.6
-    check = SingleFeatureContributionTrainTest().add_condition_feature_pps_in_train_not_greater_than(condition_value)
+    check = SingleFeatureContributionTrainTest(random_state=42).add_condition_feature_pps_in_train_not_greater_than(
+        condition_value)
 
     # Act
-    result = SingleFeatureContributionTrainTest().run(train_dataset=Dataset(df, label='label'),
-                                                      test_dataset=Dataset(df2, label='label'))
+    result = SingleFeatureContributionTrainTest(random_state=42).run(train_dataset=Dataset(df, label='label'),
+                                                                     test_dataset=Dataset(df2, label='label'))
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
@@ -236,4 +240,3 @@ def test_train_test_condition_pps_train_fail():
         name=f'Train features\' Predictive Power Score is not greater than {condition_value}',
         details='Features in train dataset with PPS above threshold: {\'x2\': \'0.84\'}'
     ))
-

--- a/tests/vision/checks/methodology/simple_feature_contribution_test.py
+++ b/tests/vision/checks/methodology/simple_feature_contribution_test.py
@@ -67,8 +67,8 @@ def test_no_drift_classification(mnist_dataset_train):
 
     # Assert
     assert_that(result.value, has_entries({
-        'train': has_entries({'Brightness': equal_to(0)}),
-        'test': has_entries({'Brightness': equal_to(0)}),
+        'train': has_entries({'Brightness': close_to(0.08, 0.005)}),
+        'test': has_entries({'Brightness': close_to(0.08, 0.005)}),
         'train-test difference': has_entries({'Brightness': equal_to(0)})
     }))
 
@@ -85,9 +85,9 @@ def test_drift_classification(mnist_dataset_train, mnist_dataset_test):
 
     # Assert
     assert_that(result.value, has_entries({
-        'train': has_entries({'Brightness': equal_to(0)}),
-        'test': has_entries({'Brightness': close_to(0.458, 0.001)}),
-        'train-test difference': has_entries({'Brightness': close_to(-0.458, 0.001)})
+        'train': has_entries({'Brightness': close_to(0.08, 0.005)}),
+        'test': has_entries({'Brightness': close_to(0.239, 0.001)}),
+        'train-test difference': has_entries({'Brightness': close_to(-0.159, 0.001)})
     }))
 
 
@@ -119,9 +119,9 @@ def test_drift_object_detection(coco_train_visiondata, coco_test_visiondata):
 
     # Assert
     assert_that(result.value, has_entries({
-        'train': has_entries({'Brightness': close_to(0.38, 0.01)}),
+        'train': has_entries({'Brightness': close_to(0.062, 0.01)}),
         'test': has_entries({'Brightness': equal_to(0)}),
-        'train-test difference': has_entries({'Brightness': close_to(0.38, 0.01)}),
+        'train-test difference': has_entries({'Brightness': close_to(0.062, 0.01)}),
     })
                 )
 
@@ -136,9 +136,9 @@ def test_no_drift_classification_per_class(mnist_dataset_train):
 
     # Assert
     assert_that(result.value, has_entries({
-        'Brightness': has_entries({'train':  has_entries({1: equal_to(0)}),
-                                   'test':  has_entries({1: equal_to(0)}),
-                                   'train-test difference':  has_entries({1: equal_to(0)})}),
+        'Brightness': has_entries({'train':  has_entries({'1': equal_to(0)}),
+                                   'test':  has_entries({'1': equal_to(0)}),
+                                   'train-test difference':  has_entries({'1': equal_to(0)})}),
     }))
 
 
@@ -154,9 +154,9 @@ def test_drift_classification_per_class(mnist_dataset_train, mnist_dataset_test)
 
     # Assert
     assert_that(result.value, has_entries({
-        'Brightness': has_entries({'train':  has_entries({1: equal_to(0)}),
-                                   'test':  has_entries({1: close_to(0.64, 0.01)}),
-                                   'train-test difference':  has_entries({1: close_to(-0.64, 0.01)})}),
+        'Brightness': has_entries({'train':  has_entries({'1': equal_to(0)}),
+                                   'test':  has_entries({'1': close_to(0.64, 0.01)}),
+                                   'train-test difference':  has_entries({'1': close_to(-0.64, 0.01)})}),
     }))
 
 
@@ -170,9 +170,9 @@ def test_no_drift_object_detection_per_class(coco_train_visiondata):
 
     # Assert
     assert_that(result.value, has_entries({
-        'Brightness': has_entries({'train':  has_entries({71: equal_to(0)}),
-                                   'test':  has_entries({71: equal_to(0)}),
-                                   'train-test difference':  has_entries({71: equal_to(0)})}),
+        'Brightness': has_entries({'train':  has_entries({'door': equal_to(0)}),
+                                   'test':  has_entries({'door': equal_to(0)}),
+                                   'train-test difference':  has_entries({'door': equal_to(0)})}),
     }))
 
 
@@ -188,9 +188,9 @@ def test_drift_object_detection_per_class(coco_train_visiondata, coco_test_visio
 
     # Assert
     assert_that(result.value, has_entries({
-        'Brightness': has_entries({'train':  has_entries({71: equal_to(0)}),
-                                   'test':  has_entries({71: close_to(0.335, 0.01)}),
-                                   'train-test difference':  has_entries({71: close_to(-0.335, 0.01)})}),
+        'Brightness': has_entries({'train':  has_entries({'door': equal_to(0)}),
+                                   'test':  has_entries({'door': close_to(0.335, 0.01)}),
+                                   'train-test difference':  has_entries({'door': close_to(-0.335, 0.01)})}),
     }))
 
 
@@ -216,7 +216,7 @@ def test_train_test_condition_pps_train_pass(coco_train_visiondata):
 def test_train_test_condition_pps_train_fail(coco_train_visiondata, coco_test_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
-    condition_value = 0.3
+    condition_value = 0.09
     check = SimpleFeatureContribution(per_class=False, random_state=42
                                       ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
     train = copy(train)
@@ -231,8 +231,7 @@ def test_train_test_condition_pps_train_fail(coco_train_visiondata, coco_test_vi
     assert_that(condition_result, equal_condition_result(
         is_pass=False,
         name=f'Train properties\' Predictive Power Score is not greater than {condition_value}',
-        details='Features in train dataset with PPS above threshold: {\'Brightness\': \'0.38\', '
-                '\'RMS Contrast\': \'0.34\'}'
+        details='Features in train dataset with PPS above threshold: {\'Mean Red Relative Intensity\': \'0.1\'}'
     ))
 
 

--- a/tests/vision/checks/methodology/simple_feature_contribution_test.py
+++ b/tests/vision/checks/methodology/simple_feature_contribution_test.py
@@ -13,6 +13,7 @@ from copy import copy
 
 from hamcrest import assert_that, has_entries, close_to, equal_to
 import numpy as np
+import pandas as pd
 
 from deepchecks.vision.checks import SimpleFeatureContribution
 from deepchecks.vision.utils.transformations import un_normalize_batch
@@ -55,6 +56,23 @@ def get_coco_batch_to_images_with_bias_one_class(label_formatter):
         return ret
 
     return ret_func
+
+
+def test_is_float_column():
+    col = pd.Series([1, 2, 3, 4, 5])
+    assert_that(SimpleFeatureContribution.is_float_column(col), equal_to(False))
+
+    col = pd.Series(['a', 'b', 'c'])
+    assert_that(SimpleFeatureContribution.is_float_column(col), equal_to(False))
+
+    col = pd.Series(['a', 'b', 5.5])
+    assert_that(SimpleFeatureContribution.is_float_column(col), equal_to(False))
+
+    col = pd.Series([1, 2, 3, 4, 5], dtype='float')
+    assert_that(SimpleFeatureContribution.is_float_column(col), equal_to(False))
+
+    col = pd.Series([1, 2, 3, 4, 5.5], dtype='float64')
+    assert_that(SimpleFeatureContribution.is_float_column(col), equal_to(True))
 
 
 def test_no_drift_classification(mnist_dataset_train):

--- a/tests/vision/checks/methodology/simple_feature_contribution_test.py
+++ b/tests/vision/checks/methodology/simple_feature_contribution_test.py
@@ -60,7 +60,7 @@ def get_coco_batch_to_images_with_bias_one_class(label_formatter):
 def test_no_drift_classification(mnist_dataset_train):
     # Arrange
     train, test = mnist_dataset_train, mnist_dataset_train
-    check = SimpleFeatureContribution(per_class=False)
+    check = SimpleFeatureContribution(per_class=False, random_state=42)
 
     # Act
     result = check.run(train, test)
@@ -78,7 +78,7 @@ def test_drift_classification(mnist_dataset_train, mnist_dataset_test):
 
     train, test = mnist_dataset_train, mnist_dataset_test
 
-    check = SimpleFeatureContribution(per_class=False)
+    check = SimpleFeatureContribution(per_class=False, random_state=42)
 
     # Act
     result = check.run(train, test)
@@ -94,7 +94,7 @@ def test_drift_classification(mnist_dataset_train, mnist_dataset_test):
 def test_no_drift_object_detection(coco_train_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_train_visiondata
-    check = SimpleFeatureContribution(per_class=False)
+    check = SimpleFeatureContribution(per_class=False, random_state=42)
 
     # Act
     result = check.run(train, test)
@@ -110,7 +110,7 @@ def test_no_drift_object_detection(coco_train_visiondata):
 def test_drift_object_detection(coco_train_visiondata, coco_test_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
-    check = SimpleFeatureContribution(per_class=False)
+    check = SimpleFeatureContribution(per_class=False, random_state=42)
     train = copy(train)
     train.batch_to_images = get_coco_batch_to_images_with_bias(train.batch_to_labels)
 
@@ -129,7 +129,7 @@ def test_drift_object_detection(coco_train_visiondata, coco_test_visiondata):
 def test_no_drift_classification_per_class(mnist_dataset_train):
     # Arrange
     train, test = mnist_dataset_train, mnist_dataset_train
-    check = SimpleFeatureContribution(per_class=True)
+    check = SimpleFeatureContribution(per_class=True, random_state=42)
 
     # Act
     result = check.run(train, test, n_samples=None)
@@ -147,7 +147,7 @@ def test_drift_classification_per_class(mnist_dataset_train, mnist_dataset_test)
 
     train, test = mnist_dataset_train, mnist_dataset_test
 
-    check = SimpleFeatureContribution(per_class=True)
+    check = SimpleFeatureContribution(per_class=True, random_state=42)
 
     # Act
     result = check.run(train, test, n_samples=None)
@@ -163,7 +163,7 @@ def test_drift_classification_per_class(mnist_dataset_train, mnist_dataset_test)
 def test_no_drift_object_detection_per_class(coco_train_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_train_visiondata
-    check = SimpleFeatureContribution(per_class=True)
+    check = SimpleFeatureContribution(per_class=True, random_state=42)
 
     # Act
     result = check.run(train, test)
@@ -179,7 +179,7 @@ def test_no_drift_object_detection_per_class(coco_train_visiondata):
 def test_drift_object_detection_per_class(coco_train_visiondata, coco_test_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
-    check = SimpleFeatureContribution(per_class=True)
+    check = SimpleFeatureContribution(per_class=True, random_state=42)
     train = copy(train)
     train.batch_to_images = get_coco_batch_to_images_with_bias(train.batch_to_labels)
 
@@ -198,7 +198,7 @@ def test_train_test_condition_pps_train_pass(coco_train_visiondata):
     # Arrange
     train, test = coco_train_visiondata, coco_train_visiondata
     condition_value = 0.3
-    check = SimpleFeatureContribution(per_class=False
+    check = SimpleFeatureContribution(per_class=False, random_state=42
                                       ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
 
     # Act
@@ -217,7 +217,7 @@ def test_train_test_condition_pps_train_fail(coco_train_visiondata, coco_test_vi
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
     condition_value = 0.3
-    check = SimpleFeatureContribution(per_class=False
+    check = SimpleFeatureContribution(per_class=False, random_state=42
                                       ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
     train = copy(train)
     train.batch_to_images = get_coco_batch_to_images_with_bias(train.batch_to_labels)
@@ -240,8 +240,8 @@ def test_train_test_condition_pps_train_pass_per_class(mnist_dataset_train):
     # Arrange
     train, test = mnist_dataset_train, mnist_dataset_train
     condition_value = 0.3
-    check = SimpleFeatureContribution(per_class=True).add_condition_feature_pps_in_train_not_greater_than(
-        condition_value)
+    check = SimpleFeatureContribution(per_class=True, random_state=42
+                                      ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
 
     # Act
     result = check.run(train_dataset=train,
@@ -259,7 +259,7 @@ def test_train_test_condition_pps_train_fail_per_class(coco_train_visiondata, co
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
     condition_value = 0.3
-    check = SimpleFeatureContribution(per_class=True
+    check = SimpleFeatureContribution(per_class=True, random_state=42
                                       ).add_condition_feature_pps_in_train_not_greater_than(condition_value)
     train = copy(train)
     train.batch_to_images = get_coco_batch_to_images_with_bias_one_class(train.batch_to_labels)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Several needed fixes to single/simple feature contribution checks:

1. Expose the random state as a check parameter, as it may have significant influence on the result (PPS trains a model)
2. Make this random state None be default to get more robust results (a single seed may cause the user to get stuck on some noise this check outputted once)
3. Explicitly set the dtype of the label for simple feature contribution. PPS assumes label type based on the dtype of the column, and for the vision package it's reasonable to assume that if there are no actual fractions, the label is always some sort of classification (including detection, segmentation etc). Thus in most cases we need to explicitly cast to 'object' to tell PPS this is a classification label. This changes most test values.