### PR TITLE
Nb/documentation and autocasting pixels

### DIFF
--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -66,7 +66,7 @@ class Batch:
         if self._images is None:
             dataset = self._context.get_data_by_kind(self._dataset_kind)
             dataset.assert_images_valid()
-            self._images = dataset.batch_to_images(self._batch)
+            self._images = [image.astype('uint8') for image in dataset.batch_to_images(self._batch)]
         return self._images
 
     def __getitem__(self, index: int):

--- a/deepchecks/vision/checks/performance/image_segment_performance.py
+++ b/deepchecks/vision/checks/performance/image_segment_performance.py
@@ -42,7 +42,7 @@ class ImageSegmentPerformance(SingleDatasetCheck):
         Each property is dictionary with keys 'name' (str), 'method' (Callable) and 'output_type' (str),
         representing attributes of said method. 'output_type' must be one of 'continuous'/'discrete'
     alternative_metrics : Dict[str, Metric], default: None
-        A dictionary of metrics, where the key is the metric name and the value is an ignite.Metric object whose score
+        A dictionary of metrics, where the key is the metric name and the value is an ignite. Metric object whose score
         should be used. If None are given, use the default metrics.
     number_of_bins: int, default : 5
         Maximum number of bins to segment a single property into.

--- a/deepchecks/vision/vision_data.py
+++ b/deepchecks/vision/vision_data.py
@@ -404,8 +404,8 @@ class VisionData:
         sample_min = np.min(sample)
         sample_max = np.max(sample)
         if sample_min < 0 or sample_max > 255 or sample_max <= 1:
-            raise ValidationError(f'Image data found to be in range [{sample_min}, {sample_max}] instead of expected '
-                                  f'range [0, 255].')
+            raise ValidationError(f'Image data should be in uint8 format(integers between 0 and 255). '
+                                  f'Found values in range [{sample_min}, {sample_max}].')
 
     def validate_get_classes(self, batch):
         """Validate that the get_classes function returns data in the correct format.

--- a/docs/source/user-guide/vision/data-classes/DetectionData.rst
+++ b/docs/source/user-guide/vision/data-classes/DetectionData.rst
@@ -4,7 +4,7 @@
 The Object Detection Data Class
 ===============================
 
-The DetectionData is a :doc:`data class </user-guide/vision/data-classes/index>` designated for object detection tasks.
+The DetectionData is a :doc:`data class </user-guide/vision/data-classes/index>` designed for object detection tasks.
 It is a subclass of the :class:`~deepchecks.vision.VisionData` class and is used to load and preprocess data for object
 detection related checks.
 

--- a/docs/source/user-guide/vision/data-classes/DetectionData.rst
+++ b/docs/source/user-guide/vision/data-classes/DetectionData.rst
@@ -23,7 +23,7 @@ The accepted label format for is a a list of length N containing tensors of shap
 of samples within a batch, B is the number of bounding boxes in the sample and each bounding box is represented by 5 values:
 ``(class_id, x_min, y_min, w, h)``.
 
-    x_min and y_min are the coordinates (in pixels) of the **lower left corner** of the bounding box, w
+    x_min and y_min are the coordinates (in pixels) of the **top left corner** of the bounding box, w
     and h are the width and height of the bounding box (in pixels) and class_id is the class id of the prediction.
 
 For example, for a sample with 2 bounding boxes, the label format may be:

--- a/docs/source/user-guide/vision/data-classes/DetectionData.rst
+++ b/docs/source/user-guide/vision/data-classes/DetectionData.rst
@@ -36,7 +36,7 @@ The accepted prediction format is a list of length N containing tensors of shape
 of images, B is the number of bounding boxes detected in the sample and each bounding box is represented by 6
 values: ``[x_min, y_min, w, h, confidence, class_id]``.
 
-    x_min,y_min,w and h represent the bounding box location as before, confidence is the confidence score given by the model to
+    x_min,y_min,w and h represent the bounding box location as above, confidence is the confidence score given by the model to
     bounding box and class_id is the class id predicted by the model.
 
 For example, for a sample with 2 bounding boxes, the prediction format may be:
@@ -91,8 +91,8 @@ each box arrives in the format: ``(class_id, x_min, y_min, x_max, y_max)``. Addi
 
             Parameters
             ----------
-            batch : torch.Tensor (N, B, 5)
-                The batch of bounding boxes to convert.
+            batch : tuple
+                The batch of data, containing images and bounding boxes.
 
             Returns
             -------
@@ -102,10 +102,11 @@ each box arrives in the format: ``(class_id, x_min, y_min, x_max, y_max)``. Addi
 
             # each bbox in the labels is (class_id, x, y, x, y). convert to (class_id, x, y, w, h)
             bboxes = []
-            for image in batch[1]:
-                bboxes_in_image = [torch.cat((bbox[0], bbox[1:3], bbox[4:] - bbox[1:3]), dim=0) for bbox in image]
-                if len(bboxes_in_image) != 0:
-                    bboxes.append(torch.stack(bboxes_in_image))
+            for bboxes_single_image in batch[1]:
+                formatted_bboxes = [torch.cat((bbox[0], bbox[1:3], bbox[4:] - bbox[1:3]), dim=0)
+                                    for bbox in bboxes_single_image]
+                if len(formatted_bboxes) != 0:
+                    bboxes.append(torch.stack(formatted_bboxes))
             return bboxes
 
         def infer_on_batch(self, batch, model, device):

--- a/docs/source/user-guide/vision/data-classes/DetectionData.rst
+++ b/docs/source/user-guide/vision/data-classes/DetectionData.rst
@@ -5,7 +5,7 @@ The Object Detection Data Class
 ===============================
 
 The DetectionData is a :doc:`data class </user-guide/vision/data-classes/index>` designed for object detection tasks.
-It is a subclass of the :class:`~deepchecks.vision.VisionData` class and is used to load and preprocess data for object
+It is a subclass of the :class:`~deepchecks.vision.VisionData` class and is used to help deepchecks load and interact with object detection data using a well defined format.
 detection related checks.
 
 For more info, please visit the API reference page: :class:`~deepchecks.vision.DetectionData`

--- a/docs/source/user-guide/vision/data-classes/DetectionData.rst
+++ b/docs/source/user-guide/vision/data-classes/DetectionData.rst
@@ -128,7 +128,7 @@ each box arrives in the format: ``(class_id, x_min, y_min, x_max, y_max)``. Addi
             """
 
             return_list = []
-            predictions = model(batch[0])
+            predictions = model.to(device)(batch[0])
 
             # yolo Detections objects have List[torch.Tensor(B,6)] output where each bbox is
             #(x_min, y_min, x_max, y_max, confidence, class_id).

--- a/tests/vision/checks/distribution/image_dataset_drift_test.py
+++ b/tests/vision/checks/distribution/image_dataset_drift_test.py
@@ -58,11 +58,11 @@ def test_drift_grayscale(mnist_dataset_train, mnist_dataset_test, device):
     result = check.run(train, test, random_state=42, device=device, n_samples=None)
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.516, 0.001),
-        'domain_classifier_drift_score': close_to(0.033, 0.001),
+        'domain_classifier_auc': close_to(0.5146, 0.001),
+        'domain_classifier_drift_score': close_to(0.029, 0.001),
         'domain_classifier_feature_importance': has_entries({
-            'RMS Contrast': close_to(0.965, 0.001),
-            'Brightness': close_to(0.034, 0.001),
+            'RMS Contrast': close_to(1, 0.001),
+            'Brightness': close_to(0, 0.001),
             'Aspect Ratio': equal_to(0),
             'Area': equal_to(0),
             'Mean Red Relative Intensity': equal_to(0),

--- a/tests/vision/checks/distribution/image_dataset_drift_test.py
+++ b/tests/vision/checks/distribution/image_dataset_drift_test.py
@@ -110,8 +110,8 @@ def test_with_drift_rgb(coco_train_dataloader, coco_test_dataloader, device):
     result = check.run(train, test, random_state=42, device=device)
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(1, 0.001),
-        'domain_classifier_drift_score': close_to(1, 0.001),
+        'domain_classifier_auc': close_to(0.908, 0.001),
+        'domain_classifier_drift_score': close_to(0.815, 0.001),
         'domain_classifier_feature_importance': has_entries({
             'Brightness': close_to(1, 0.001),
             'Aspect Ratio': equal_to(0),

--- a/tests/vision/checks/distribution/image_property_outliers_test.py
+++ b/tests/vision/checks/distribution/image_property_outliers_test.py
@@ -65,9 +65,9 @@ def test_image_property_outliers_check_mnist(mnist_dataset_train, device):
     assert_that(result, is_correct_image_property_outliers_result())
     assert_that(result.value, has_entries({
         'Brightness': has_entries({
-            'indices': has_length(610),
-            'lower_limit': close_to(6.487, .001),
-            'upper_limit': close_to(62.650, .001)
+            'indices': has_length(609),
+            'lower_limit': close_to(6.45, .01),
+            'upper_limit': close_to(62.37, .01)
         }),
         'Mean Red Relative Intensity': instance_of(str),
         'Mean Green Relative Intensity': instance_of(str),

--- a/tests/vision/checks/methodology/simple_feature_contribution_test.py
+++ b/tests/vision/checks/methodology/simple_feature_contribution_test.py
@@ -104,8 +104,8 @@ def test_drift_classification(mnist_dataset_train, mnist_dataset_test):
     # Assert
     assert_that(result.value, has_entries({
         'train': has_entries({'Brightness': close_to(0.08, 0.005)}),
-        'test': has_entries({'Brightness': close_to(0.239, 0.001)}),
-        'train-test difference': has_entries({'Brightness': close_to(-0.159, 0.001)})
+        'test': has_entries({'Brightness': close_to(0.234, 0.001)}),
+        'train-test difference': has_entries({'Brightness': close_to(-0.153, 0.001)})
     }))
 
 
@@ -173,8 +173,8 @@ def test_drift_classification_per_class(mnist_dataset_train, mnist_dataset_test)
     # Assert
     assert_that(result.value, has_entries({
         'Brightness': has_entries({'train':  has_entries({'1': equal_to(0)}),
-                                   'test':  has_entries({'1': close_to(0.64, 0.01)}),
-                                   'train-test difference':  has_entries({'1': close_to(-0.64, 0.01)})}),
+                                   'test':  has_entries({'1': close_to(0.659, 0.01)}),
+                                   'train-test difference':  has_entries({'1': close_to(-0.659, 0.01)})}),
     }))
 
 

--- a/tests/vision/checks/performance/vision_model_error_analysis_test.py
+++ b/tests/vision/checks/performance/vision_model_error_analysis_test.py
@@ -26,7 +26,7 @@ def test_classification(mnist_dataset_train, mock_trained_mnist, device):
                        device=device, n_samples=None)
     # Assert
     assert_that(len(result.value['feature_segments']), equal_to(2))
-    assert_that(result.value['feature_segments']['Brightness']['segment1']['n_samples'], equal_to(254))
+    assert_that(result.value['feature_segments']['Brightness']['segment1']['n_samples'], equal_to(251))
 
 
 def test_detection(coco_train_visiondata, coco_test_visiondata, mock_trained_yolov5_object_detection, device):

--- a/tests/vision/utils_tests/formatters_test.py
+++ b/tests/vision/utils_tests/formatters_test.py
@@ -92,12 +92,10 @@ def test_data_formatter_large_values():
             return batch * 300
 
     batch = next(iter(numpy_shape_dataloader((10, 10, 3))))
-    sample_min = float(76500)
-    sample_max = float(76500)
     assert_that(
         calling(BadImage(numpy_shape_dataloader((10, 10, 3))).validate_image_data).with_args(batch),
-        raises(ValidationError, f'Image data should be in uint8 format\(integers between 0 and 255\). '
-                                f'Found values in range \[{sample_min}, {sample_max}\].')
+        raises(ValidationError, r'Image data should be in uint8 format\(integers between 0 and 255\). '
+                                r'Found values in range \[76500.0, 76500.0\].')
     )
 
 

--- a/tests/vision/utils_tests/formatters_test.py
+++ b/tests/vision/utils_tests/formatters_test.py
@@ -59,6 +59,7 @@ def test_data_formatter_not_numpy():
     class BadImage(VisionData):
         def batch_to_images(self, batch):
             return [[x] for x in batch]
+
     data_loader = numpy_shape_dataloader((10, 10, 3))
     batch = next(iter(data_loader))
     assert_that(
@@ -89,11 +90,14 @@ def test_data_formatter_large_values():
     class BadImage(VisionData):
         def batch_to_images(self, batch):
             return batch * 300
+
     batch = next(iter(numpy_shape_dataloader((10, 10, 3))))
+    sample_min = float(76500)
+    sample_max = float(76500)
     assert_that(
         calling(BadImage(numpy_shape_dataloader((10, 10, 3))).validate_image_data).with_args(batch),
-        raises(ValidationError, r'Image data found to be in range \[76500.0, 76500.0\] instead of expected range '
-                                r'\[0, 255\].')
+        raises(ValidationError, f'Image data should be in uint8 format\(integers between 0 and 255\). '
+                                f'Found values in range \[{sample_min}, {sample_max}\].')
     )
 
 
@@ -101,7 +105,8 @@ def test_data_formatter_normalized_data():
     batch = next(iter(numpy_shape_dataloader((10, 10, 3), value=1)))
     assert_that(
         calling(SimpleImageData(numpy_shape_dataloader((10, 10, 3))).validate_image_data).with_args(batch),
-        raises(ValidationError, r'Image data found to be in range \[1.0, 1.0\] instead of expected range \[0, 255\].')
+        raises(ValidationError, r'Image data should be in uint8 format\(integers between 0 and 255\). Found values in '
+                                r'range \[1.0, 1.0\].')
     )
 
 
@@ -121,13 +126,13 @@ def test_data_formatter_valid_dimensions():
 
 
 def test_brightness_grayscale():
-    value = np.concatenate([np.zeros((3, 10, 1)),  np.ones((7, 10, 1))], axis=0)
+    value = np.concatenate([np.zeros((3, 10, 1)), np.ones((7, 10, 1))], axis=0)
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
     res = image_properties.brightness(batch)
 
-    assert_that(res, equal_to([0.7]*4))
+    assert_that(res, equal_to([0.7] * 4))
 
 
 def test_brightness_rgb():
@@ -143,9 +148,9 @@ def test_brightness_rgb():
 
 
 def test_rms_contrast_grayscale():
-    value = np.concatenate([np.zeros((3, 10, 1)),  np.ones((7, 10, 1))], axis=0)
+    value = np.concatenate([np.zeros((3, 10, 1)), np.ones((7, 10, 1))], axis=0)
 
-    expected_value = np.sqrt((70 * 0.3**2 + 30 * 0.7**2) / 100)
+    expected_value = np.sqrt((70 * 0.3 ** 2 + 30 * 0.7 ** 2) / 100)
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
@@ -156,12 +161,12 @@ def test_rms_contrast_grayscale():
 
 def test_rms_contrast_rgb():
     # Create image that after turning from rgb to grayscale is 30% value 0 and 70% value 3:
-    value = np.concatenate([np.zeros((3, 10, 3)),  np.concatenate([np.ones((7, 10, 1)) * 1/0.2125,
-                                                                   np.ones((7, 10, 1)) * 1/0.7154,
-                                                                   np.ones((7, 10, 1)) * 1/0.0721], axis=2)],
+    value = np.concatenate([np.zeros((3, 10, 3)), np.concatenate([np.ones((7, 10, 1)) * 1 / 0.2125,
+                                                                  np.ones((7, 10, 1)) * 1 / 0.7154,
+                                                                  np.ones((7, 10, 1)) * 1 / 0.0721], axis=2)],
                            axis=0)
 
-    expected_value = np.sqrt((210 * 0.9**2 + 90 * 2.1**2) / 300)
+    expected_value = np.sqrt((210 * 0.9 ** 2 + 90 * 2.1 ** 2) / 300)
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
@@ -175,7 +180,7 @@ def test_aspect_ratio():
 
     res = image_properties.aspect_ratio(batch)
 
-    assert_that(res, equal_to([0.5]*4))
+    assert_that(res, equal_to([0.5] * 4))
 
 
 def test_area():
@@ -183,7 +188,7 @@ def test_area():
 
     res = image_properties.area(batch)
 
-    assert_that(res, equal_to([200]*4))
+    assert_that(res, equal_to([200] * 4))
 
 
 def test_normalized_mean_red():
@@ -191,7 +196,7 @@ def test_normalized_mean_red():
                             np.ones((10, 10, 1)) * 2,
                             np.ones((10, 10, 1)) * 3], axis=2)
 
-    expected_result = 1/6
+    expected_result = 1 / 6
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
@@ -205,7 +210,7 @@ def test_normalized_mean_green():
                             np.ones((10, 10, 1)) * 2,
                             np.ones((10, 10, 1)) * 3], axis=2)
 
-    expected_result = 2/6
+    expected_result = 2 / 6
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
@@ -219,7 +224,7 @@ def test_normalized_mean_blue():
                             np.ones((10, 10, 1)) * 2,
                             np.ones((10, 10, 1)) * 3], axis=2)
 
-    expected_result = 3/6
+    expected_result = 3 / 6
 
     batch = next(iter(numpy_shape_dataloader(value=value)))
 
@@ -228,17 +233,16 @@ def test_normalized_mean_blue():
     assert_that(res[0], close_to(expected_result, 0.0000001))
 
 
-
 def test_allowed_bbox_format_notations():
     notations = (
         '  lxyxy       ',
         'LxywH',
         *[''.join(it) for it in set(permutations(['l', 'xy', 'xy'], 3))],
-        *['n'+''.join(it) for it in set(permutations(['l', 'xy', 'xy'], 3))],
+        *['n' + ''.join(it) for it in set(permutations(['l', 'xy', 'xy'], 3))],
         *[''.join(it) for it in permutations(['l', 'xy', 'wh'], 3)],
         *[''.join(it) for it in permutations(['l', 'xy', 'wh'], 3)],
         *[''.join(it) for it in permutations(['l', 'cxcy', 'wh'], 3)],
-        *[''.join(it)+'n' for it in permutations(['l', 'cxcy', 'wh'], 3)]
+        *[''.join(it) + 'n' for it in permutations(['l', 'cxcy', 'wh'], 3)]
     )
 
     tokens = {
@@ -302,6 +306,7 @@ def test_bbox_format_notations_with_unknown_elements():
             )
         )
 
+
 def test_bbox_format_notation_with_coord_normalization_element_at_wrong_position():
     notations = [
         'lnxyxy',
@@ -342,11 +347,11 @@ def test_batch_of_bboxes_convertion():
 def test_batch_of_bboxes_convertion_with_normalized_coordinates():
     # Arrange
     loader = coco.load_dataset()
-    image, input_bboxes = loader.dataset[9] # it should be always the same sample
+    image, input_bboxes = loader.dataset[9]  # it should be always the same sample
 
     normilized_input_bboxes = torch.stack([
         torch.tensor([
-            bbox[0] / image.width,   # x
+            bbox[0] / image.width,  # x
             bbox[1] / image.height,  # y
             bbox[2],  # w
             bbox[3],  # h
@@ -376,34 +381,34 @@ def test_batch_of_bboxes_convertion_with_normalized_coordinates():
 def test_bbox_convertion_to_the_required_format():
     data = (
         (
-            dict(notation='xylxy', bbox=torch.tensor([20, 15, 2, 41, 23])), # input
-            torch.tensor([2, 20, 15, 21, 8]), # expected result
+            dict(notation='xylxy', bbox=torch.tensor([20, 15, 2, 41, 23])),  # input
+            torch.tensor([2, 20, 15, 21, 8]),  # expected result
         ),
         (
-            dict(notation='cxcywhl', bbox=torch.tensor([50, 55, 100, 100, 0])), # input
-            torch.tensor([0, (50 - 100 / 2), (55 - 100 / 2), 100, 100]), # expected result
+            dict(notation='cxcywhl', bbox=torch.tensor([50, 55, 100, 100, 0])),  # input
+            torch.tensor([0, (50 - 100 / 2), (55 - 100 / 2), 100, 100]),  # expected result
         ),
         (
-            dict(notation='whxyl', bbox=torch.tensor([35, 70, 10, 15, 1])), # input
-            torch.tensor([1, 10, 15, 35, 70,]), # expected result
+            dict(notation='whxyl', bbox=torch.tensor([35, 70, 10, 15, 1])),  # input
+            torch.tensor([1, 10, 15, 35, 70, ]),  # expected result
         ),
         (
-            dict( # input
+            dict(  # input
                 notation='nxywhl',
                 bbox=torch.tensor([0.20, 0.20, 20, 40, 1]),
                 image_width=100,
                 image_height=100,
             ),
-            torch.tensor([1, 20, 20, 20, 40,]), # expected result
+            torch.tensor([1, 20, 20, 20, 40, ]),  # expected result
         ),
         (
-            dict( # input
+            dict(  # input
                 notation='cxcylwhn',
                 bbox=torch.tensor([0.12, 0.17, 0, 50, 100]),
                 image_width=600,
                 image_height=1200,
             ),
-            torch.tensor([0, 47, 154.00000000000003, 50, 100,]), # expected result
+            torch.tensor([0, 47, 154.00000000000003, 50, 100, ]),  # expected result
         )
     )
 


### PR DESCRIPTION
Small change to actual code - casting to 'uint8', if the type of pixels entered is not convertible to uint8 it is already caught in the validation method so no additional changes required.

Medium change to Object Detection doc, see in changes.