### PR TITLE
Improve outlier importance by using numba njit

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 pandas>=1.1.5
 numpy>=1.19
+numba==0.53.0
 scikit-learn>=0.24.2
 jsonpickle>=2
 PyNomaly>=0.3.3


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

- This improves the computation speed of the outlier check by X20 by using numba njit.
- Change default n_samples to 5000 to achieve computation time of 3 secs for avocado (11 features)). @Nadav-Barak We expect time to scale linearly in features and cubically in samples right?

#### Any other comments?
This has several major drawbacks:

1. Direct reliance on numba=0.53.0 so no to clash with numpy. @ItayGabbay 
2. Using np.isnan() instead of the stronger pd.isnull()
3. Harder to maintain

Mainly opening this for discussion, not sure we should merge.


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
