### PR TITLE
Serialization subpackage fix - added __init__.py module

### DIFF
--- a/deepchecks/core/check_result.py
+++ b/deepchecks/core/check_result.py
@@ -307,7 +307,7 @@ class CheckResult:
     def _ipython_display_(
         self,
         unique_id: Optional[str] = None,
-        as_widget: bool = False,
+        as_widget: bool = True,
         show_additional_outputs: bool = True
     ):
         as_widget = is_widgets_use_possible() and as_widget

--- a/deepchecks/core/serialization/__init__.py
+++ b/deepchecks/core/serialization/__init__.py
@@ -1,0 +1,12 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2022 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Module for serialization logic."""
+__all__ = []

--- a/deepchecks/core/serialization/abc.py
+++ b/deepchecks/core/serialization/abc.py
@@ -8,6 +8,7 @@
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
 #
+# pylint: disable=unnecessary-ellipsis
 """Main serialization abstractions."""
 import abc
 import io
@@ -15,16 +16,17 @@ import typing as t
 
 import pandas as pd
 from ipywidgets.widgets import Widget
-# import matplotlib.pyplot as plt
 from pandas.io.formats.style import Styler
 from plotly.basedatatypes import BaseFigure
 from typing_extensions import Protocol, runtime_checkable
 
-from deepchecks.core import check_result as check_types
+from deepchecks.core import \
+    check_result as check_types  # pylint: disable=unused-import
 from deepchecks.core.serialization import common
 
 try:
-    from wandb.sdk.data_types.base_types.wb_value import WBValue
+    from wandb.sdk.data_types.base_types.wb_value import \
+        WBValue  # pylint: disable=unused-import
 except ImportError:
     pass
 
@@ -39,7 +41,7 @@ __all__ = [
 ]
 
 
-T = t.TypeVar("T")
+T = t.TypeVar('T')
 
 
 @runtime_checkable
@@ -96,6 +98,7 @@ class ABCDisplayItemsHandler(Protocol):
     ])
 
     @classmethod
+    @abc.abstractmethod
     def handle_display(
         cls,
         display: t.List['check_types.TDisplayItem'],
@@ -115,6 +118,7 @@ class ABCDisplayItemsHandler(Protocol):
         return [cls.handle_item(it, index) for index, it in enumerate(display)]
 
     @classmethod
+    @abc.abstractmethod
     def handle_item(cls, item: 'check_types.TDisplayItem', index: int, **kwargs) -> t.Any:
         """Serialize display item."""
         if isinstance(item, str):
@@ -128,17 +132,20 @@ class ABCDisplayItemsHandler(Protocol):
         else:
             raise TypeError(f'Unable to handle display item of type: {type(item)}')
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def handle_string(cls, item: str, index: int, **kwargs) -> t.Any:
         """Handle textual item."""
         raise NotImplementedError()
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def handle_dataframe(cls, item: t.Union[pd.DataFrame, Styler], index: int, **kwargs) -> t.Any:
         """Handle dataframe item."""
         raise NotImplementedError()
 
     @classmethod
+    @abc.abstractmethod
     def handle_callable(cls, item: t.Callable, index: int, **kwargs) -> t.List[io.BytesIO]:
         """Handle callable."""
         # TODO: callable is a special case, add comments
@@ -146,7 +153,8 @@ class ABCDisplayItemsHandler(Protocol):
             item()
             return common.read_matplot_figures()
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def handle_figure(cls, item: BaseFigure, index: int, **kwargs) -> t.Any:
         """Handle plotly figure item."""
         raise NotImplementedError()

--- a/deepchecks/core/serialization/check_failure/wandb.py
+++ b/deepchecks/core/serialization/check_failure/wandb.py
@@ -18,11 +18,11 @@ from deepchecks.core.serialization.common import prettify
 try:
     import wandb
     from wandb.sdk.data_types.base_types.wb_value import WBValue
-except ImportError:
+except ImportError as e:
     raise ImportError(
         'Wandb serializer requires the wandb python package. '
         'To get it, run "pip install wandb".'
-    )
+    ) from e
 
 
 __all__ = ['CheckFailureSerializer']

--- a/deepchecks/core/serialization/check_result/html.py
+++ b/deepchecks/core/serialization/check_result/html.py
@@ -12,6 +12,7 @@
 import textwrap
 import typing as t
 
+from plotly.io import to_html
 from typing_extensions import Literal
 
 from deepchecks.core import check_result as check_types
@@ -263,7 +264,6 @@ class DisplayItemsHandler(ABCDisplayItemsHandler):
     @classmethod
     def handle_figure(cls, item, index, **kwargs) -> str:
         """Handle plotly figure item."""
-        from plotly.io import to_html
         post_script = textwrap.dedent("""
             var gd = document.getElementById('{plot_id}');
             var x = new MutationObserver(function (mutations, observer) {{
@@ -293,7 +293,7 @@ class DisplayItemsHandler(ABCDisplayItemsHandler):
             include_plotlyjs='require',
             post_script=post_script,
             full_html=False,
-            default_width="100%",
+            default_width='100%',
             default_height=525,
             validate=True,
         )

--- a/deepchecks/core/serialization/check_result/json.py
+++ b/deepchecks/core/serialization/check_result/json.py
@@ -23,7 +23,7 @@ from plotly.basedatatypes import BaseFigure
 from typing_extensions import TypedDict
 
 from deepchecks.core import check_result as check_types
-from deepchecks.core import checks
+from deepchecks.core import checks  # pylint: disable=unused-import
 from deepchecks.core.serialization.abc import (ABCDisplayItemsHandler,
                                                JsonSerializer)
 from deepchecks.core.serialization.common import (aggregate_conditions,

--- a/deepchecks/core/serialization/check_result/wandb.py
+++ b/deepchecks/core/serialization/check_result/wandb.py
@@ -8,6 +8,7 @@
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
 #
+# pylint: disable=import-outside-toplevel
 """Module containing Wandb serializer for the CheckResult type."""
 import typing as t
 from collections import OrderedDict
@@ -26,11 +27,11 @@ from deepchecks.core.serialization.common import (aggregate_conditions,
 try:
     import wandb
     from wandb.sdk.data_types.base_types.wb_value import WBValue
-except ImportError:
+except ImportError as e:
     raise ImportError(
         'Wandb serializer requires the wandb python package. '
         'To get it, run "pip install wandb".'
-    )
+    ) from e
 
 __all__ = ['CheckResultSerializer']
 
@@ -129,11 +130,11 @@ class DisplayItemsHandler(ABCDisplayItemsHandler):
         """Handle callable."""
         try:
             import PIL.Image as pilimage
-        except ImportError:
+        except ImportError as error:
             raise ImportError(
                 'Wandb CheckResultSerializer requires the PIL package '
                 'to process matplot figures. To get it, run "pip install pillow".'
-            )
+            ) from error
         else:
             images = super().handle_callable(item, index, **kwargs)
             image = concatv_images([pilimage.open(buffer) for buffer in images])

--- a/deepchecks/core/serialization/common.py
+++ b/deepchecks/core/serialization/common.py
@@ -8,6 +8,7 @@
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
 #
+# pylint: disable=unused-import,import-outside-toplevel, protected-access
 """Module with common utilities routines for serialization subpackage."""
 import io
 import json
@@ -84,8 +85,7 @@ def normalize_widget_style(w: TDOMWidget) -> TDOMWidget:
 
 def prettify(data: t.Any, indent: int = 3) -> str:
     """Prettify data."""
-    default = lambda it: repr(it)
-    return json.dumps(data, indent=indent, default=default)
+    return json.dumps(data, indent=indent, default=repr)
 
 
 def normalize_value(value: object) -> t.Any:
@@ -201,7 +201,7 @@ def requirejs_script(connected: bool = True):
             </script>
         """)
     else:
-        path = os.path.join('core', 'resources', "requirejs.min.js")
+        path = os.path.join('core', 'resources', 'requirejs.min.js')
         js = pkgutil.get_data('deepchecks', path).decode('utf-8')
         return f'<script>{js}</script>'
 
@@ -248,7 +248,7 @@ def plotlyjs_script(connected: bool = True) -> str:
         return script.format(
             win_config=plotlyhtml._window_plotly_config,
             mathjax_config=plotlyhtml._mathjax_config,
-            plotly_cdn=plotly_cdn_url().rstrip(".js"),
+            plotly_cdn=plotly_cdn_url().rstrip('.js'),
         )
     else:
         # If not connected then we embed a copy of the plotly.js library
@@ -324,11 +324,11 @@ def concatv_images(images, gap=10):
     """
     try:
         import PIL.Image as pilimage
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             'concatv_images function requires the PIL package. '
             'To get it, run "pip install pillow".'
-        )
+        ) from e
     else:
         assert isinstance(images, list) and len(images) != 0
         assert isinstance(gap, int) and gap >= 0

--- a/deepchecks/core/serialization/common.py
+++ b/deepchecks/core/serialization/common.py
@@ -224,22 +224,19 @@ def plotlyjs_script(connected: bool = True) -> str:
             {mathjax_config}
             <script type="text/javascript">
                 if (typeof require !== 'undefined') {{
-                    require(['plotly'], function () {{}}, function (error) {{
-                        console.log('Plotly is not defined - loading it.');
-                        require.undef("plotly");
-                        requirejs.config({{
-                            paths: {{'plotly': ['{plotly_cdn}']}}
-                        }});
-                        require(
-                            ['plotly'],
-                            function(Plotly) {{
-                                window._Plotly = Plotly;
-                                window.Plotly = Plotly;
-                                console.log('Loaded plotly successfully');
-                            }},
-                            function() {{console.log('Failed to load plotly')}}
-                        );
+                    require.undef("plotly");
+                    requirejs.config({{
+                        paths: {{'plotly': ['{plotly_cdn}']}}
                     }});
+                    require(
+                        ['plotly'],
+                        function(Plotly) {{
+                            window._Plotly = Plotly;
+                            window.Plotly = Plotly;
+                            console.log('Loaded plotly successfully');
+                        }},
+                        function() {{console.log('Failed to load plotly')}}
+                    );
                 }} else {{
                     console.log('requirejs is not present');
                 }}
@@ -257,22 +254,19 @@ def plotlyjs_script(connected: bool = True) -> str:
             {mathjax_config}
             <script type="text/javascript">
                 if (typeof require !== 'undefined') {{
-                    require(['plotly'], function () {{}}, function (error) {{
-                        console.log('Plotly is not defined - loading it.');
-                        require.undef("plotly");
-                        define('plotly', function(require, exports, module) {{
-                            {script}
-                        }});
-                        require(
-                            ['plotly'],
-                            function(Plotly) {{
-                                window._Plotly = Plotly;
-                                window.Plotly = Plotly;
-                                console.log('Loaded plotly successfully');
-                            }},
-                            function() {{console.log('Failed to load plotly')}}
-                        );
-                    }})
+                    require.undef("plotly");
+                    define('plotly', function(require, exports, module) {{
+                        {script}
+                    }});
+                    require(
+                        ['plotly'],
+                        function(Plotly) {{
+                            window._Plotly = Plotly;
+                            window.Plotly = Plotly;
+                            console.log('Loaded plotly successfully');
+                        }},
+                        function() {{console.log('Failed to load plotly')}}
+                    );
                 }} else {{
                     console.log('requirejs is not present');
                 }}

--- a/deepchecks/core/serialization/suite_result/html.py
+++ b/deepchecks/core/serialization/suite_result/html.py
@@ -142,8 +142,8 @@ class SuiteResultSerializer(HtmlSerializer['suite.SuiteResult']):
 
     def prepare_prologue(self) -> str:
         """Prepare prologue section."""
-        long_prologue_version = "The suite is composed of various checks such as: {names}, etc..."
-        short_prologue_version = "The suite is composed of the following checks: {names}."
+        long_prologue_version = 'The suite is composed of various checks such as: {names}, etc...'
+        short_prologue_version = 'The suite is composed of the following checks: {names}.'
         check_names = list(set(
             it.check.name()
             for it in self.value.results

--- a/deepchecks/core/serialization/suite_result/wandb.py
+++ b/deepchecks/core/serialization/suite_result/wandb.py
@@ -22,11 +22,11 @@ from deepchecks.core.serialization.check_result.wandb import \
 
 try:
     from wandb.sdk.data_types.base_types.wb_value import WBValue
-except ImportError:
+except ImportError as error:
     raise ImportError(
         'Wandb serializer requires the wandb python package. '
         'To get it, run "pip install wandb".'
-    )
+    ) from error
 
 
 class SuiteResultSerializer(WandbSerializer['suite.SuiteResult']):


### PR DESCRIPTION
I forgot to add `__init__` module to the serialization subpackage and as result it is not included in distribution during the package build plus it appears that pylint omits subpackages without `__init__` module