### PR TITLE
Hide "nothing found" in suite result display

### DIFF
--- a/deepchecks/core/serialization/check_result/html.py
+++ b/deepchecks/core/serialization/check_result/html.py
@@ -59,6 +59,7 @@ class CheckResultSerializer(HtmlSerializer['check_types.CheckResult']):
         include_requirejs: bool = False,
         include_plotlyjs: bool = True,
         connected: bool = True,
+        display_nothing_found: bool = True,
         **kwargs
     ) -> str:
         """Serialize a CheckResult instance into HTML format.
@@ -78,6 +79,9 @@ class CheckResultSerializer(HtmlSerializer['check_types.CheckResult']):
             whether to include plotlyjs library into output or not
         connected : bool, default True
             whether to use CDN to load js libraries or to inject their code into output
+        display_nothing_found : bool, default True
+            affects the output only when display is empty. If True, will show nothing found message, otherwise will
+            not show the "additional-output" section.
 
         Returns
         -------
@@ -94,7 +98,7 @@ class CheckResultSerializer(HtmlSerializer['check_types.CheckResult']):
         if 'condition-table' in sections_to_include:
             sections.append(''.join(self.prepare_conditions_table(output_id=output_id)))
 
-        if 'additional-output' in sections_to_include:
+        if 'additional-output' in sections_to_include and (display_nothing_found or self.value.display):
             sections.append(''.join(self.prepare_additional_output(output_id)))
 
         plotlyjs = plotlyjs_script(connected) if include_plotlyjs is True else ''

--- a/deepchecks/core/serialization/check_result/ipython.py
+++ b/deepchecks/core/serialization/check_result/ipython.py
@@ -44,6 +44,7 @@ class CheckResultSerializer(IPythonSerializer['check_types.CheckResult']):
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[html.CheckResultSection]] = None,
+        display_nothing_found: bool = True,
         **kwargs
     ) -> t.List[IPythonFormatter]:
         """Serialize a CheckResult instance into a list of IPython formatters.
@@ -55,6 +56,9 @@ class CheckResultSerializer(IPythonSerializer['check_types.CheckResult']):
         check_sections : Optional[Sequence[Literal['condition-table', 'additional-output']]], default None
             sequence of check result sections to include into the output,
             in case of 'None' all sections will be included
+        display_nothing_found : bool, default True
+            affects the output only when display is empty. If True, will show nothing found message, otherwise will
+            not show the "additional-output" section.
 
         Returns
         -------
@@ -69,7 +73,7 @@ class CheckResultSerializer(IPythonSerializer['check_types.CheckResult']):
         if 'condition-table' in sections_to_include:
             sections.append(self.prepare_conditions_table(output_id=output_id))
 
-        if 'additional-output' in sections_to_include:
+        if 'additional-output' in sections_to_include and (display_nothing_found or self.value.display):
             sections.extend(self.prepare_additional_output(output_id))
 
         return list(flatten(sections))

--- a/deepchecks/core/serialization/check_result/widget.py
+++ b/deepchecks/core/serialization/check_result/widget.py
@@ -46,6 +46,7 @@ class CheckResultSerializer(WidgetSerializer['check_types.CheckResult']):
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[html.CheckResultSection]] = None,
+        display_nothing_found: bool = True,
         **kwargs
     ) -> VBox:
         """Serialize a CheckResult instance into ipywidgets.Widget instance.
@@ -57,6 +58,9 @@ class CheckResultSerializer(WidgetSerializer['check_types.CheckResult']):
         check_sections : Optional[Sequence[Literal['condition-table', 'additional-output']]], default None
             sequence of check result sections to include into theoutput,
             in case of 'None' all sections will be included
+        display_nothing_found : bool, default True
+            affects the output only when display is empty. If True, will show nothing found message, otherwise will
+            not show the "additional-output" section.
 
         Returns
         -------
@@ -68,7 +72,7 @@ class CheckResultSerializer(WidgetSerializer['check_types.CheckResult']):
         if 'condition-table' in sections_to_include:
             sections.append(self.prepare_conditions_table(output_id=output_id))
 
-        if 'additional-output' in sections_to_include:
+        if 'additional-output' in sections_to_include and (display_nothing_found or self.value.display):
             sections.append(self.prepare_additional_output(output_id))
 
         return normalize_widget_style(VBox(children=sections))

--- a/deepchecks/core/serialization/suite_result/ipython.py
+++ b/deepchecks/core/serialization/suite_result/ipython.py
@@ -65,12 +65,12 @@ class SuiteResultSerializer(IPythonSerializer['suite.SuiteResult']):
         conditions_table = self.prepare_conditions_table(output_id=output_id, **kwargs)
         failures = self.prepare_failures_list()
 
-        results_with_conditions = self.prepare_results_with_condition_and_display(
+        results_with_conditions = self.prepare_results_with_condition(
             output_id=output_id,
             check_sections=['condition-table', 'additional-output'],
             **kwargs
         )
-        results_without_conditions = self.prepare_results_without_condition(
+        results_without_conditions = self.prepare_results_without_condition_with_display(
             output_id=output_id,
             check_sections=['additional-output'],
             **kwargs
@@ -137,7 +137,7 @@ class SuiteResultSerializer(IPythonSerializer['suite.SuiteResult']):
             **kwargs
         ))
 
-    def prepare_results_with_condition_and_display(
+    def prepare_results_with_condition(
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[CheckResultSection]] = None,
@@ -160,13 +160,14 @@ class SuiteResultSerializer(IPythonSerializer['suite.SuiteResult']):
         results = t.cast(
             t.List[check_types.CheckResult],
             self.value.select_results(
-                self.value.results_with_conditions & self.value.results_with_display
+                self.value.results_with_conditions
             )
         )
         results_with_condition_and_display = [
             CheckResultSerializer(it).serialize(
                 output_id=output_id,
                 check_sections=check_sections,
+                display_nothing_found=False,
                 **kwargs
             )
             for it in results
@@ -180,7 +181,7 @@ class SuiteResultSerializer(IPythonSerializer['suite.SuiteResult']):
             content
         ]))
 
-    def prepare_results_without_condition(
+    def prepare_results_without_condition_with_display(
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[CheckResultSection]] = None,

--- a/deepchecks/core/serialization/suite_result/widget.py
+++ b/deepchecks/core/serialization/suite_result/widget.py
@@ -69,10 +69,10 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
         tab.set_title(2, 'Checks Without Output')
 
         tab.children = [
-            self.prepare_results_with_condition_and_display(
+            self.prepare_results_with_condition(
                 output_id=output_id, **kwargs
             ),
-            self.prepare_results_without_condition(
+            self.prepare_results_without_condition_with_display(
                 output_id=output_id,
                 check_sections=['additional-output'],
                 **kwargs
@@ -117,7 +117,7 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
             value=self._html_serializer.prepare_failures_list()
         ))
 
-    def prepare_results_without_condition(
+    def prepare_results_without_condition_with_display(
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[CheckResultSection]] = None,
@@ -156,7 +156,7 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
             *join(results_without_conditions, HTML(value=CommonHtml.light_hr))
         ]))
 
-    def prepare_results_with_condition_and_display(
+    def prepare_results_with_condition(
         self,
         output_id: t.Optional[str] = None,
         check_sections: t.Optional[t.Sequence[CheckResultSection]] = None,
@@ -184,6 +184,7 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
             CheckResultWidgetSerializer(it).serialize(
                 output_id=output_id,
                 include=check_sections,
+                display_nothing_found=False,
                 **kwargs
             )
             for it in results


### PR DESCRIPTION
Reassured suite display sections:
1. All checks with conditions. If no display then hide the "additional output"
2. Other checks without condition but with display
3. Rest of the checks: failures and checks without condition & without display

![image](https://user-images.githubusercontent.com/9868530/168993503-5c4eaa85-5023-48e5-be65-2cd4b2bcc9fb.png)
