### PR TITLE
Make sure segment performance run only on numeric or categoric features

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/segment_performance.py
+++ b/deepchecks/tabular/checks/model_evaluation/segment_performance.py
@@ -100,6 +100,12 @@ class SegmentPerformance(SingleDatasetCheck):
             if self.feature_1 not in columns or self.feature_2 not in columns:
                 raise DeepchecksValueError('"feature_1" and "feature_2" must be in dataset columns')
 
+        if self.feature_1 not in (dataset.numerical_features + dataset.cat_features):
+            raise DeepchecksValueError('"feature_1" must be numerical or categorical, but it neither.')
+
+        if self.feature_2 not in (dataset.numerical_features + dataset.cat_features):
+            raise DeepchecksValueError('"feature_2" must be numerical or categorical, but it neither.')
+
         feature_1_filters = partition_column(dataset, self.feature_1, max_segments=self.max_segments)
         feature_2_filters = partition_column(dataset, self.feature_2, max_segments=self.max_segments)
 

--- a/deepchecks/tabular/checks/model_evaluation/train_test_prediction_drift.py
+++ b/deepchecks/tabular/checks/model_evaluation/train_test_prediction_drift.py
@@ -13,6 +13,7 @@
 import warnings
 from typing import Dict
 
+import numpy as np
 import pandas as pd
 
 from deepchecks import ConditionCategory
@@ -103,12 +104,12 @@ class TrainTestPredictionDrift(TrainTestCheck):
         test_dataset = context.test
         model = context.model
 
-        train_prediction = model.predict(train_dataset.features_columns)
-        test_prediction = model.predict(test_dataset.features_columns)
+        train_prediction = np.array(model.predict(train_dataset.features_columns))
+        test_prediction = np.array(model.predict(test_dataset.features_columns))
 
         drift_score, method, display = calc_drift_and_plot(
-            train_column=pd.Series(train_prediction),
-            test_column=pd.Series(test_prediction),
+            train_column=pd.Series(train_prediction.flatten()),
+            test_column=pd.Series(test_prediction.flatten()),
             value_name='model predictions',
             column_type='categorical' if train_dataset.label_type == 'classification_label' else 'numerical',
             margin_quantile_filter=self.margin_quantile_filter,

--- a/deepchecks/tabular/suites/default_suites.py
+++ b/deepchecks/tabular/suites/default_suites.py
@@ -42,7 +42,9 @@ from deepchecks.tabular.checks import (BoostingOverfit, CalibrationScore,
                                        TrainTestFeatureDrift,
                                        TrainTestLabelDrift,
                                        TrainTestSamplesMix, UnusedFeatures,
-                                       WholeDatasetDrift)
+                                       WholeDatasetDrift,
+                                       SegmentPerformance,
+                                       TrainTestPredictionDrift)
 
 __all__ = ['single_dataset_integrity', 'train_test_leakage', 'train_test_validation',
            'model_evaluation', 'full_suite']
@@ -125,8 +127,8 @@ def model_evaluation() -> Suite:
         PerformanceReport().add_condition_train_test_relative_degradation_not_greater_than(),
         RocReport().add_condition_auc_not_less_than(),
         ConfusionMatrixReport(),
-        # SegmentPerformance(),
-        # TrainTestPredictionDrift().add_condition_drift_score_not_greater_than(),
+        SegmentPerformance(),
+        TrainTestPredictionDrift().add_condition_drift_score_not_greater_than(),
         SimpleModelComparison().add_condition_gain_not_less_than(),
         ModelErrorAnalysis().add_condition_segments_performance_relative_difference_not_greater_than(),
         CalibrationScore(),

--- a/deepchecks/tabular/suites/default_suites.py
+++ b/deepchecks/tabular/suites/default_suites.py
@@ -33,6 +33,7 @@ from deepchecks.tabular.checks import (BoostingOverfit, CalibrationScore,
                                        PerformanceReport,
                                        RegressionErrorDistribution,
                                        RegressionSystematicError, RocReport,
+                                       SegmentPerformance,
                                        SimpleModelComparison,
                                        SingleFeatureContribution,
                                        SingleFeatureContributionTrainTest,
@@ -41,10 +42,9 @@ from deepchecks.tabular.checks import (BoostingOverfit, CalibrationScore,
                                        StringMismatchComparison,
                                        TrainTestFeatureDrift,
                                        TrainTestLabelDrift,
+                                       TrainTestPredictionDrift,
                                        TrainTestSamplesMix, UnusedFeatures,
-                                       WholeDatasetDrift,
-                                       SegmentPerformance,
-                                       TrainTestPredictionDrift)
+                                       WholeDatasetDrift)
 
 __all__ = ['single_dataset_integrity', 'train_test_leakage', 'train_test_validation',
            'model_evaluation', 'full_suite']

--- a/tests/tabular/checks/model_evaluation/segment_performance_test.py
+++ b/tests/tabular/checks/model_evaluation/segment_performance_test.py
@@ -67,6 +67,17 @@ def test_segment_performance_illegal_features(diabetes_split_dataset_and_model):
     )
 
 
+def test_segment_performance_non_cat_or_num(city_arrogance_split_dataset_and_model):
+    # Arrange
+    _, val, model = city_arrogance_split_dataset_and_model
+
+    # Act & Assert
+    assert_that(
+        calling(SegmentPerformance(feature_1='city', feature_2='sex').run).with_args(val, model),
+        raises(DeepchecksValueError, r'\"feature_1\" must be numerical or categorical, but it neither.')
+    )
+
+
 def test_segment_top_features(diabetes_split_dataset_and_model):
     # Arrange
     _, val, model = diabetes_split_dataset_and_model


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The SegmentPerformance check uses the partition_column util that partitions numeric and categorical features into segmentation bins. In case a feature is neither (such as a string that is converted in a pipeline to some numeric value), the checks should return a value error.