### PR TITLE
Remove upper level titles from the image dataset drift guide

### DIFF
--- a/docs/source/checks/vision/train_test_validation/plot_image_dataset_drift.py
+++ b/docs/source/checks/vision/train_test_validation/plot_image_dataset_drift.py
@@ -15,7 +15,7 @@ test datasets.
 * `Run The Check <#run-the-check>`__
 
 What Is Image Dataset Drift?
-============================
+------------------------------------
 
 Drift is simply a change in the distribution of data over time, and it is
 also one of the top reasons why machine learning model's performance degrades
@@ -41,7 +41,7 @@ value when estimating drift. Therefore, we calculate drift on different :doc:`pr
 on which we can directly measure drift.
 
 Which Image Properties Are Used?
-=================================
+------------------------------------
 ==============================  ==========
 Property name                   What is it
 ==============================  ==========


### PR DESCRIPTION
Fixes the irrelevant titles found in docs

![image](https://user-images.githubusercontent.com/17730502/174071231-45735b25-9db2-4bfe-8eb0-41b4fc91be79.png)
