### PR TITLE
Image property outliers display when there are no outliers

### DIFF
--- a/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
@@ -211,7 +211,10 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
             grouped = no_outliers.groupby(level=0).unique().str.join(', ')
             grouped_df = pd.DataFrame(grouped, columns=['Properties'])
             grouped_df['Reason'] = grouped_df.index
-            display.append(grouped_df.to_html(columns=['Reason', 'Properties'], index=False))
+            grouped_df = grouped_df[['Reason', 'Properties']]
+            display.append('<h5><b>Properties Without Outliers</h5></b>')
+            # display.append(grouped_df.to_html(columns=['Reason', 'Properties'], justify='start', index=False))
+            display.append(grouped_df.style.hide_index())
             # display = ''.join(display)
         else:
             display = None
@@ -318,7 +321,7 @@ HTML_TEMPLATE = """
         width: fill-available;
     }}
 </style>
-<h3><b>Property "{prop_name}"</b></h3>
+<h5><b>Property "{prop_name}"</b></h5>
 <div>
 Total number of outliers: {count}
 </div>

--- a/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
@@ -208,10 +208,10 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
                     )
 
                     display.append(html)
-            grouped = no_outliers.groupby(level=0).unique().apply(lambda x: ',\n'.join(x))
-            grouped_df = pd.DataFrame(grouped, columns=['properties'])
-            grouped_df.index.name = 'info'
-            display.append(grouped_df)
+            grouped = no_outliers.groupby(level=0).unique().str.join(', ')
+            grouped_df = pd.DataFrame(grouped, columns=['Properties'])
+            grouped_df['Reason'] = grouped_df.index
+            display.append(grouped_df.to_html(columns=['Reason', 'Properties'], index=False))
             # display = ''.join(display)
         else:
             display = None

--- a/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
@@ -184,10 +184,8 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
                 # If info is string it means there was error
                 if isinstance(info, str):
                     no_outliers = pd.concat([no_outliers, pd.Series(property_name, index=[info])])
-                    # html = NO_IMAGES_TEMPLATE.format(prop_name=property_name, message=info)
                 elif len(info['indices']) == 0:
                     no_outliers = pd.concat([no_outliers, pd.Series(property_name, index=['No outliers found.'])])
-                    # html = NO_IMAGES_TEMPLATE.format(prop_name=property_name, message='No outliers found.')
                 else:
                     # Create id of alphabetic characters
                     sid = ''.join([choice(string.ascii_uppercase) for _ in range(6)])
@@ -213,9 +211,7 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
             grouped_df['Reason'] = grouped_df.index
             grouped_df = grouped_df[['Reason', 'Properties']]
             display.append('<h5><b>Properties Without Outliers</h5></b>')
-            # display.append(grouped_df.to_html(columns=['Reason', 'Properties'], justify='start', index=False))
             display.append(grouped_df.style.hide_index())
-            # display = ''.join(display)
         else:
             display = None
 


### PR DESCRIPTION
The properties without outliers grouped by the reason for not having outliers.
Headline size for the properties is now smaller than the "additional outputs" title.

