### PR TITLE
Adapting tabular SimpleModelComparison API

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
+++ b/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
@@ -27,7 +27,7 @@ from deepchecks.tabular import Context, Dataset, TrainTestCheck
 from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.distribution.preprocessing import ScaledNumerics
 from deepchecks.utils.metrics import get_gain
-from deepchecks.utils.simple_models import RandomModel, ClassificationUniformModel, RegressionUniformModel
+from deepchecks.utils.simple_models import ClassificationUniformModel, RandomModel, RegressionUniformModel
 from deepchecks.utils.strings import format_percent
 
 __all__ = ['SimpleModelComparison']

--- a/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
+++ b/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
@@ -27,7 +27,7 @@ from deepchecks.tabular import Context, Dataset, TrainTestCheck
 from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.distribution.preprocessing import ScaledNumerics
 from deepchecks.utils.metrics import get_gain
-from deepchecks.utils.simple_models import RandomModel, UniformModel
+from deepchecks.utils.simple_models import RandomModel, ClassificationUniformModel, RegressionUniformModel
 from deepchecks.utils.strings import format_percent
 
 __all__ = ['SimpleModelComparison']
@@ -55,7 +55,8 @@ class SimpleModelComparison(TrainTestCheck):
         'most_frequent', 'tree'].
 
         * `stratified`: select one of the labels by random. (Previously 'random')
-        * `uniform`: draws predictions uniformly at random from the list of values in y.
+        * `uniform`: in regression samples predictions uniformly at random from the y ranges. in classification draws
+           predictions uniformly at random from the list of values in y.
         * `most_frequent`: in regression is mean value, in classification the most common value. (Previously 'constant')
         * `tree`: runs a simple decision tree.
     simple_model_type : str , default: most_frequent
@@ -303,7 +304,10 @@ class SimpleModelComparison(TrainTestCheck):
         np.random.seed(self.random_state)
 
         if self.strategy == 'uniform':
-            simple_model = UniformModel()
+            if task_type in [TaskType.BINARY, TaskType.MULTICLASS]:
+                simple_model = ClassificationUniformModel()
+            elif task_type == TaskType.REGRESSION:
+                simple_model = RegressionUniformModel()
         elif self.strategy == 'stratified':
             simple_model = RandomModel()
         elif self.strategy == 'most_frequent':

--- a/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
+++ b/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
@@ -50,7 +50,7 @@ class SimpleModelComparison(TrainTestCheck):
 
     Parameters
     ----------
-    strategy : str, default: 'constant'
+    strategy : str, default: 'most_frequent'
         Strategy to use to generate the predictions of the simple model ['stratified', 'uniform',
         'most_frequent', 'tree'].
 

--- a/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
+++ b/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
@@ -27,19 +27,20 @@ from deepchecks.tabular import Context, Dataset, TrainTestCheck
 from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.distribution.preprocessing import ScaledNumerics
 from deepchecks.utils.metrics import get_gain
-from deepchecks.utils.simple_models import RandomModel
+from deepchecks.utils.simple_models import RandomModel, UniformModel
 from deepchecks.utils.strings import format_percent
 
 __all__ = ['SimpleModelComparison']
 
 _allowed_strategies = (
+    'stratified',
     'most_frequent',
     'uniform',
     'tree'
 )
 
 _depr_strategies = {
-    'random': 'uniform',
+    'random': 'stratified',
     'constant': 'most_frequent',
 }
 
@@ -50,8 +51,11 @@ class SimpleModelComparison(TrainTestCheck):
     Parameters
     ----------
     strategy : str, default: 'constant'
-        Strategy to use to generate the predictions of the simple model ['uniform', 'most_frequent', 'tree'].
-        * `uniform`: select one of the labels by random. (Previously 'random')
+        Strategy to use to generate the predictions of the simple model ['stratified', 'uniform',
+        'most_frequent', 'tree'].
+
+        * `stratified`: select one of the labels by random. (Previously 'random')
+        * `uniform`: draws predictions uniformly at random from the list of values in y.
         * `most_frequent`: in regression is mean value, in classification the most common value. (Previously 'constant')
         * `tree`: runs a simple decision tree.
     simple_model_type : str , default: most_frequent
@@ -299,8 +303,9 @@ class SimpleModelComparison(TrainTestCheck):
         np.random.seed(self.random_state)
 
         if self.strategy == 'uniform':
+            simple_model = UniformModel()
+        elif self.strategy == 'stratified':
             simple_model = RandomModel()
-
         elif self.strategy == 'most_frequent':
             if task_type == TaskType.REGRESSION:
                 simple_model = DummyRegressor(strategy='mean')
@@ -328,7 +333,7 @@ class SimpleModelComparison(TrainTestCheck):
         else:
             raise DeepchecksValueError(
                 f'Unknown model type - {self.strategy}, expected to be one of '
-                f"['uniform', 'most_frequent', 'tree'] "
+                f"['uniform', 'stratified', 'most_frequent', 'tree'] "
                 f"but instead got {self.strategy}"  # pylint: disable=inconsistent-quotes
             )
 

--- a/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
+++ b/deepchecks/tabular/checks/model_evaluation/simple_model_comparison.py
@@ -54,7 +54,7 @@ class SimpleModelComparison(TrainTestCheck):
         Strategy to use to generate the predictions of the simple model ['stratified', 'uniform',
         'most_frequent', 'tree'].
 
-        * `stratified`: select one of the labels by random. (Previously 'random')
+        * `stratified`: randomly draw a label based on the train set label distribution. (Previously 'random')
         * `uniform`: in regression samples predictions uniformly at random from the y ranges. in classification draws
            predictions uniformly at random from the list of values in y.
         * `most_frequent`: in regression is mean value, in classification the most common value. (Previously 'constant')

--- a/deepchecks/tabular/deprecation_warnings.py
+++ b/deepchecks/tabular/deprecation_warnings.py
@@ -114,3 +114,17 @@ warnings.filterwarnings(
     category=DeprecationWarning,
     module=r'deepchecks.*'
 )
+
+warnings.filterwarnings(
+    action='once',
+    message=r'.*simple_model_type is deprecated. please use strategy.*',
+    category=DeprecationWarning,
+    module=r'deepchecks.*'
+)
+
+warnings.filterwarnings(
+    action='once',
+    message=r'.*strategy .* is deprecated. please use.*',
+    category=DeprecationWarning,
+    module=r'deepchecks.*'
+)

--- a/deepchecks/tabular/suites/README.rst
+++ b/deepchecks/tabular/suites/README.rst
@@ -68,7 +68,7 @@ Build the suite with custom checks and desired parameters
        TrainTestDifferenceOverfit(),
        ConfusionMatrixReport(),
        SimpleModelComparision(),
-       SimpleModelComparision(simple_model_type='statistical')
+       SimpleModelComparision(strategy='most_frequent')
    )
 
 Then run with required input parameters (datasets and models)

--- a/deepchecks/utils/simple_models.py
+++ b/deepchecks/utils/simple_models.py
@@ -11,7 +11,7 @@
 """Contains simple models used in checks."""
 import numpy as np
 
-__all__ = ['PerfectModel', 'RandomModel', 'UniformModel']
+__all__ = ['PerfectModel', 'RandomModel', 'ClassificationUniformModel', 'RegressionUniformModel']
 
 
 def create_proba_result(predictions, classes):
@@ -67,8 +67,8 @@ class RandomModel:
         return create_proba_result(predictions, classes)
 
 
-class UniformModel:
-    """Model that draws predictions uniformly at random from the list of values in y."""
+class ClassificationUniformModel:
+    """Model that draws predictions uniformly at random from the list of classes in y."""
 
     def __init__(self):
         self.unique_labels = None
@@ -87,3 +87,21 @@ class UniformModel:
         classes = sorted(self.unique_labels.tolist())
         predictions = self.predict(X)
         return create_proba_result(predictions, classes)
+
+
+class RegressionUniformModel:
+    """Model that draws predictions uniformly at random from the range of values in y."""
+
+    def __init__(self):
+        self.min_value = None
+        self.max_value = None
+
+    def fit(self, X, y):  # pylint: disable=unused-argument,invalid-name
+        """Fit model."""
+        # The X is not used, but it is needed to be matching to sklearn `fit` signature
+        self.min_value = y.min()
+        self.max_value = y.max()
+
+    def predict(self, X):  # pylint: disable=invalid-name
+        """Predict on given X."""
+        return np.random.uniform(self.min_value, self.max_value, X.shape[0])

--- a/deepchecks/utils/simple_models.py
+++ b/deepchecks/utils/simple_models.py
@@ -11,7 +11,7 @@
 """Contains simple models used in checks."""
 import numpy as np
 
-__all__ = ['PerfectModel', 'RandomModel']
+__all__ = ['PerfectModel', 'RandomModel', 'UniformModel']
 
 
 def create_proba_result(predictions, classes):
@@ -63,5 +63,27 @@ class RandomModel:
     def predict_proba(self, X):  # pylint: disable=invalid-name
         """Predict proba for given X."""
         classes = sorted(self.labels.unique().tolist())
+        predictions = self.predict(X)
+        return create_proba_result(predictions, classes)
+
+
+class UniformModel:
+    """Model that draws predictions uniformly at random from the list of values in y"""
+
+    def __init__(self):
+        self.unique_labels = None
+
+    def fit(self, X, y):  # pylint: disable=unused-argument,invalid-name
+        """Fit model."""
+        # The X is not used, but it is needed to be matching to sklearn `fit` signature
+        self.unique_labels = np.unique(y)
+
+    def predict(self, X):  # pylint: disable=invalid-name
+        """Predict on given X."""
+        return np.random.choice(self.unique_labels, X.shape[0])
+
+    def predict_proba(self, X):  # pylint: disable=invalid-name
+        """Predict proba for given X."""
+        classes = sorted(self.unique_labels.tolist())
         predictions = self.predict(X)
         return create_proba_result(predictions, classes)

--- a/deepchecks/utils/simple_models.py
+++ b/deepchecks/utils/simple_models.py
@@ -68,7 +68,7 @@ class RandomModel:
 
 
 class UniformModel:
-    """Model that draws predictions uniformly at random from the list of values in y"""
+    """Model that draws predictions uniformly at random from the list of values in y."""
 
     def __init__(self):
         self.unique_labels = None

--- a/docs/source/checks/tabular/model_evaluation/plot_simple_model_comparison.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_simple_model_comparison.py
@@ -22,16 +22,17 @@ model achieves less or a similar score to the simple model, this is an indicator
 for a possible problem with the model (e.g. it wasn't trained properly).
 
 The check has three possible "simple model" heuristics, from which one is chosen and
-compared to. By default the check uses the **constant** heuristic, which can be
-overridden in the checks' parameters using simple_model_type. There is no simple
+compared to. By default the check uses the **most_frequent** heuristic, which can be
+overridden in the checks' parameters using strategy. There is no simple
 model which is more "correct" to use, each gives a different baseline to compare to,
 and you may experiment with the different types and see how it performs on your data.
 
 The simple models are:
 
-* A **constant** model - The default. In regression the prediction is equal to the
+* A **most_frequent** model - The default. In regression the prediction is equal to the
   mean value, in classification the prediction is equal to the most common value.
-* A **random** model - Draws the prediction from the distribution of the labels in the train.
+* A **uniform** model - In regression, selects a random value from the y range.
+  In classification, selects one of the labels by random.
 * A **tree** model - Trains a simple decision tree with a given depth. The depth
   can be customized using the ``max_depth`` parameter.
 """
@@ -60,7 +61,7 @@ model = load_fitted_model()
 from deepchecks.tabular.checks import SimpleModelComparison
 
 # Using tree model as a simple model, and changing the tree depth from the default 3 to 5
-check = SimpleModelComparison(simple_model_type='tree', max_depth=5)
+check = SimpleModelComparison(strategy='tree', max_depth=5)
 check.run(train_dataset, test_dataset, model)
 
 #%%
@@ -104,7 +105,7 @@ result.value
 #
 # Let's add a condition to the check and see what happens when it fails:
 
-check = SimpleModelComparison(simple_model_type='tree')
+check = SimpleModelComparison(strategy='tree')
 check.add_condition_gain_greater_than(0.9)
 result = check.run(train_dataset, test_dataset, model)
 result.show(show_additional_outputs=False)

--- a/docs/source/checks/tabular/model_evaluation/plot_simple_model_comparison.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_simple_model_comparison.py
@@ -33,6 +33,7 @@ The simple models are:
   mean value, in classification the prediction is equal to the most common value.
 * A **uniform** model - In regression, selects a random value from the y range.
   In classification, selects one of the labels by random.
+* A **stratified** model - Draws the prediction from the distribution of the labels in the train.
 * A **tree** model - Trains a simple decision tree with a given depth. The depth
   can be customized using the ``max_depth`` parameter.
 """

--- a/docs/source/user-guide/general/customizations/plot_create_a_custom_suite.py
+++ b/docs/source/user-guide/general/customizations/plot_create_a_custom_suite.py
@@ -45,7 +45,7 @@ new_custom_suite = Suite('Simple Suite For Model Performance',
                          TrainTestPerformance().add_condition_train_test_relative_degradation_less_than(threshold=0.15 \
                                                                                                         ).add_condition_test_performance_greater_than(0.8),
                          ConfusionMatrixReport(),
-                         SimpleModelComparison(simple_model_type='constant', \
+                         SimpleModelComparison(strategy='most_frequent', \
                           alternative_scorers={'Recall (Multiclass)': make_scorer(recall_score, average=None), \
                                                'Precision (Multiclass)': make_scorer(precision_score, average=None)} \
                          ).add_condition_gain_greater_than(0.3)

--- a/tests/base/test_tabular_deprecation_warnings.py
+++ b/tests/base/test_tabular_deprecation_warnings.py
@@ -16,7 +16,7 @@ import pytest
 
 from deepchecks.tabular.checks import (DominantFrequencyChange, ModelErrorAnalysis, PerformanceReport,
                                        SegmentPerformance, TrainTestFeatureDrift, TrainTestLabelDrift,
-                                       TrainTestPredictionDrift, WholeDatasetDrift)
+                                       TrainTestPredictionDrift, WholeDatasetDrift, SimpleModelComparison)
 
 
 def test_deprecation_warning_label_drift():
@@ -84,3 +84,13 @@ def test_deprecation_performance_report_warning():
     with pytest.warns(DeprecationWarning, match='the performance report check is deprecated. use the train test '
                                                 'performance check instead'):
         _ = PerformanceReport()
+
+
+def test_simple_model_args_warning():
+    with pytest.warns(DeprecationWarning, match='simple_model_type is deprecated. please use strategy instead'):
+        _ = SimpleModelComparison(simple_model_type='uniform')
+
+
+def test_simple_model_strategy_warning():
+    with pytest.warns(DeprecationWarning, match='strategy random is deprecated. please use uniform instead.'):
+        _ = SimpleModelComparison(strategy='random')

--- a/tests/base/test_tabular_deprecation_warnings.py
+++ b/tests/base/test_tabular_deprecation_warnings.py
@@ -92,5 +92,5 @@ def test_simple_model_args_warning():
 
 
 def test_simple_model_strategy_warning():
-    with pytest.warns(DeprecationWarning, match='strategy random is deprecated. please use uniform instead.'):
+    with pytest.warns(DeprecationWarning, match='strategy random is deprecated. please use stratified instead.'):
         _ = SimpleModelComparison(strategy='random')

--- a/tests/tabular/checks/model_evaluation/simple_model_comparison_test.py
+++ b/tests/tabular/checks/model_evaluation/simple_model_comparison_test.py
@@ -31,6 +31,16 @@ def test_dataset_wrong_input():
 def test_classification_random(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
+    check = SimpleModelComparison(strategy='stratified')
+    # Act X
+    result = check.run(train_ds, test_ds, clf).value
+    # Assert
+    assert_classification(result, [0, 1, 2])
+
+
+def test_classification_uniform(iris_split_dataset_and_model):
+    train_ds, test_ds, clf = iris_split_dataset_and_model
+    # Arrange
     check = SimpleModelComparison(strategy='uniform')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
@@ -61,7 +71,7 @@ def test_classification_binary_string_labels(iris_binary_string_split_dataset_an
 def test_classification_random_custom_metric(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(strategy='uniform',
+    check = SimpleModelComparison(strategy='stratified',
                                   alternative_scorers={'recall': make_scorer(recall_score, average=None)})
     # Act X
     result = check.run(train_ds, test_ds, clf)
@@ -73,7 +83,7 @@ def test_classification_random_custom_metric(iris_split_dataset_and_model):
 def test_classification_random_custom_metric_without_display(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(strategy='uniform',
+    check = SimpleModelComparison(strategy='stratified',
                                   alternative_scorers={'recall': make_scorer(recall_score, average=None)})
     # Act X
     result = check.run(train_ds, test_ds, clf, with_display=False)
@@ -85,7 +95,7 @@ def test_classification_random_custom_metric_without_display(iris_split_dataset_
 def test_regression_random(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(strategy='uniform')
+    check = SimpleModelComparison(strategy='stratified')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -95,7 +105,7 @@ def test_regression_random(diabetes_split_dataset_and_model):
 def test_regression_random_state(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(strategy='uniform', random_state=0)
+    check = SimpleModelComparison(strategy='stratified', random_state=0)
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -106,6 +116,16 @@ def test_regression_constant(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
     check = SimpleModelComparison(strategy='most_frequent')
+    # Act X
+    result = check.run(train_ds, test_ds, clf).value
+    # Assert
+    assert_regression(result)
+
+
+def test_regression_uniform(diabetes_split_dataset_and_model):
+    train_ds, test_ds, clf = diabetes_split_dataset_and_model
+    # Arrange
+    check = SimpleModelComparison(strategy='uniform')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -201,7 +221,7 @@ def test_condition_pass_for_new_test_classes(kiss_dataset_and_model):
 def test_condition_ratio_not_less_than_passed(diabetes_split_dataset_and_model):
     # Arrange
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
-    check = SimpleModelComparison(strategy='uniform').add_condition_gain_greater_than()
+    check = SimpleModelComparison(strategy='stratified').add_condition_gain_greater_than()
 
     # Act
     check_result = check.run(train_ds, test_ds, clf)

--- a/tests/tabular/checks/model_evaluation/simple_model_comparison_test.py
+++ b/tests/tabular/checks/model_evaluation/simple_model_comparison_test.py
@@ -31,7 +31,7 @@ def test_dataset_wrong_input():
 def test_classification_random(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='random')
+    check = SimpleModelComparison(strategy='uniform')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -41,7 +41,7 @@ def test_classification_random(iris_split_dataset_and_model):
 def test_classification_constant(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant')
+    check = SimpleModelComparison(strategy='most_frequent')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -61,7 +61,7 @@ def test_classification_binary_string_labels(iris_binary_string_split_dataset_an
 def test_classification_random_custom_metric(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='random',
+    check = SimpleModelComparison(strategy='uniform',
                                   alternative_scorers={'recall': make_scorer(recall_score, average=None)})
     # Act X
     result = check.run(train_ds, test_ds, clf)
@@ -73,7 +73,7 @@ def test_classification_random_custom_metric(iris_split_dataset_and_model):
 def test_classification_random_custom_metric_without_display(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='random',
+    check = SimpleModelComparison(strategy='uniform',
                                   alternative_scorers={'recall': make_scorer(recall_score, average=None)})
     # Act X
     result = check.run(train_ds, test_ds, clf, with_display=False)
@@ -85,7 +85,7 @@ def test_classification_random_custom_metric_without_display(iris_split_dataset_
 def test_regression_random(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='random')
+    check = SimpleModelComparison(strategy='uniform')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -95,7 +95,7 @@ def test_regression_random(diabetes_split_dataset_and_model):
 def test_regression_random_state(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='random', random_state=0)
+    check = SimpleModelComparison(strategy='uniform', random_state=0)
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -105,7 +105,7 @@ def test_regression_random_state(diabetes_split_dataset_and_model):
 def test_regression_constant(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant')
+    check = SimpleModelComparison(strategy='most_frequent')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -133,7 +133,7 @@ def test_condition_ratio_not_less_than_not_passed(diabetes_split_dataset_and_mod
 def test_condition_failed_for_multiclass(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant').add_condition_gain_greater_than(0.8)
+    check = SimpleModelComparison(strategy='most_frequent').add_condition_gain_greater_than(0.8)
     # Act X
     result = check.run(train_ds, test_ds, clf)
     # Assert
@@ -148,7 +148,7 @@ def test_condition_failed_for_multiclass(iris_split_dataset_and_model):
 def test_condition_pass_for_multiclass_avg(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant').add_condition_gain_greater_than(0.43, average=True)
+    check = SimpleModelComparison(strategy='most_frequent').add_condition_gain_greater_than(0.43, average=True)
     # Act X
     result = check.run(train_ds, test_ds, clf)
     # Assert
@@ -163,7 +163,7 @@ def test_condition_pass_for_multiclass_avg(iris_split_dataset_and_model):
 def test_condition_pass_for_multiclass_avg_with_classes(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant').add_condition_gain_greater_than(1, average=False)\
+    check = SimpleModelComparison(strategy='most_frequent').add_condition_gain_greater_than(1, average=False)\
         .add_condition_gain_greater_than(1, average=True, classes=[0])
     # Act X
     result = check.run(train_ds, test_ds, clf)
@@ -185,7 +185,7 @@ def test_condition_pass_for_multiclass_avg_with_classes(iris_split_dataset_and_m
 def test_condition_pass_for_new_test_classes(kiss_dataset_and_model):
     train_ds, test_ds, clf = kiss_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant').add_condition_gain_greater_than(1)
+    check = SimpleModelComparison(strategy='most_frequent').add_condition_gain_greater_than(1)
     # Act X
     result = check.run(train_ds, test_ds, clf)
     # Assert
@@ -201,7 +201,7 @@ def test_condition_pass_for_new_test_classes(kiss_dataset_and_model):
 def test_condition_ratio_not_less_than_passed(diabetes_split_dataset_and_model):
     # Arrange
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
-    check = SimpleModelComparison(simple_model_type='random').add_condition_gain_greater_than()
+    check = SimpleModelComparison(strategy='uniform').add_condition_gain_greater_than()
 
     # Act
     check_result = check.run(train_ds, test_ds, clf)
@@ -220,7 +220,7 @@ def test_condition_ratio_not_less_than_passed(diabetes_split_dataset_and_model):
 def test_classification_tree(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='tree')
+    check = SimpleModelComparison(strategy='tree')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -230,7 +230,7 @@ def test_classification_tree(iris_split_dataset_and_model):
 def test_classification_tree_custom_metric(iris_split_dataset_and_model):
     train_ds, test_ds, clf = iris_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='tree',
+    check = SimpleModelComparison(strategy='tree',
                                   alternative_scorers={'recall': make_scorer(recall_score, average=None),
                                                        'f1': make_scorer(f1_score, average=None)})
     # Act X
@@ -242,7 +242,7 @@ def test_classification_tree_custom_metric(iris_split_dataset_and_model):
 def test_regression_constant(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='constant')
+    check = SimpleModelComparison(strategy='most_frequent')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -252,7 +252,7 @@ def test_regression_constant(diabetes_split_dataset_and_model):
 def test_regression_tree(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='tree')
+    check = SimpleModelComparison(strategy='tree')
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -262,7 +262,7 @@ def test_regression_tree(diabetes_split_dataset_and_model):
 def test_regression_tree_random_state(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='tree', random_state=55)
+    check = SimpleModelComparison(strategy='tree', random_state=55)
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert
@@ -272,7 +272,7 @@ def test_regression_tree_random_state(diabetes_split_dataset_and_model):
 def test_regression_tree_max_depth(diabetes_split_dataset_and_model):
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     # Arrange
-    check = SimpleModelComparison(simple_model_type='tree', max_depth=5)
+    check = SimpleModelComparison(strategy='tree', max_depth=5)
     # Act X
     result = check.run(train_ds, test_ds, clf).value
     # Assert

--- a/tests/tabular/test_dummy_model.py
+++ b/tests/tabular/test_dummy_model.py
@@ -121,7 +121,7 @@ def test_simple_model_comparison_regression_random_state(diabetes_split_dataset_
     # Arrange
     train_ds, test_ds, clf = diabetes_split_dataset_and_model
     y_pred_train, y_pred_test, y_proba_train, y_proba_test = _dummify_model(train_ds, test_ds, clf)
-    check = SimpleModelComparison(simple_model_type='random', random_state=0)
+    check = SimpleModelComparison(strategy='uniform', random_state=0)
     # Act X
     result = check.run(train_ds, test_ds,
                        y_pred_train=y_pred_train, y_pred_test=y_pred_test,


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #1640 

A few points to consider:
- What I've done in the PR is simply renaming the values and adding deprecation warnings. I wanted to include the prior and stratified dummy models but it would make this check really complex since they are not for regression.
- For regression - I think a lot is missing. Take a look [here](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html#sklearn.dummy.DummyRegressor).
- Currently, the tabular simple model comparison is too general in my opinion, and I think we should separate it into classification and regression types. This will allow us much more features and different valuable simple dummy models.
- When reading the difference between prior and stratified in the vision check, it was pretty clear to me. Couldn't find better wording to make it clearer. I'm open to suggestions :)



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
