### PR TITLE
Shir was right, I was wrong

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/train_test_prediction_drift.py
+++ b/deepchecks/tabular/checks/model_evaluation/train_test_prediction_drift.py
@@ -173,7 +173,7 @@ class TrainTestPredictionDrift(TrainTestCheck, ReduceMixin):
                 test_column=pd.Series(test_prediction[:, class_idx].flatten()),
                 value_name='model predictions' if not proba_drift else
                            f'predicted probabilities for class {class_name}',
-                column_type='categorical' if (train_dataset.label_type != TaskType.REGRESSION) and (not proba_drift)
+                column_type='categorical' if (context.task_type != TaskType.REGRESSION) and (not proba_drift)
                             else 'numerical',
                 margin_quantile_filter=self.margin_quantile_filter,
                 max_num_categories_for_drift=self.max_num_categories_for_drift,

--- a/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
+++ b/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
@@ -66,11 +66,9 @@ from deepchecks.tabular import Dataset
 # recommend to state them explicitly to avoid misclassification.
 
 # Metadata attributes are optional. Some checks will run only if specific attributes are declared.
-# Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, the task type can be inferred
-# both as multiclass and regression, so it's recommended to declare directly.
 
-train_ds = Dataset(X_train, label=y_train, cat_features=[], label_type='regression_label')
-test_ds = Dataset(X_test, label=y_test, cat_features=[], label_type='regression_label')
+train_ds = Dataset(X_train, label=y_train, cat_features=[])
+test_ds = Dataset(X_test, label=y_test, cat_features=[])
 
 #%%
 # Run the Deepchecks Suite

--- a/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
+++ b/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
@@ -45,7 +45,7 @@ data.head(2)
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import GradientBoostingRegressor
 
-X_train, X_test, y_train, y_test = train_test_split(data.iloc[:, :-1], data['quality'], test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(data.iloc[:, :-1], data['quality'], test_size=0.2, random_state=42)
 gbr = GradientBoostingRegressor()
 gbr.fit(X_train, y_train)
 
@@ -66,9 +66,11 @@ from deepchecks.tabular import Dataset
 # recommend to state them explicitly to avoid misclassification.
 
 # Metadata attributes are optional. Some checks will run only if specific attributes are declared.
+# Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, the problem can be inferred both
+# as multiclass and regression, so it's recommended to declare directly.
 
-train_ds = Dataset(X_train, label=y_train, cat_features=[])
-test_ds = Dataset(X_test, label=y_test, cat_features=[])
+train_ds = Dataset(X_train, label=y_train, cat_features=[], label_type='regression_label')
+test_ds = Dataset(X_test, label=y_test, cat_features=[], label_type='regression_label')
 
 #%%
 # Run the Deepchecks Suite

--- a/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
+++ b/docs/source/user-guide/tabular/tutorials/plot_quick_model_evaluation.py
@@ -66,8 +66,8 @@ from deepchecks.tabular import Dataset
 # recommend to state them explicitly to avoid misclassification.
 
 # Metadata attributes are optional. Some checks will run only if specific attributes are declared.
-# Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, the problem can be inferred both
-# as multiclass and regression, so it's recommended to declare directly.
+# Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, the task type can be inferred
+# both as multiclass and regression, so it's recommended to declare directly.
 
 train_ds = Dataset(X_train, label=y_train, cat_features=[], label_type='regression_label')
 test_ds = Dataset(X_test, label=y_test, cat_features=[], label_type='regression_label')


### PR DESCRIPTION
Refixed bug #1814 - Forgot there's task_type in context that uses the model to infer task_type. This means the prediction_drift used the type wrong - it used the dataset.label_type instead of context.task_type (that takes model into account).