### PR TITLE
[Issue-1846] fixed CheckResult.priority property

### DIFF
--- a/deepchecks/core/check_result.py
+++ b/deepchecks/core/check_result.py
@@ -187,15 +187,15 @@ class CheckResult(BaseCheckResult, DisplayableResult):
         int
             priority of the check result.
         """
-        if not self.have_conditions:
+        if not self.have_conditions():
             return 5
 
         for c in self.conditions_results:
-            if c.is_pass is False and c.category == ConditionCategory.FAIL:
+            if c.is_pass() is False and c.category == ConditionCategory.FAIL:
                 return 1
-            if c.is_pass is False and c.category == ConditionCategory.WARN:
+            if c.is_pass() is False and c.category == ConditionCategory.WARN:
                 return 2
-            if c.is_pass is False and c.category == ConditionCategory.ERROR:
+            if c.is_pass() is False and c.category == ConditionCategory.ERROR:
                 return 3
 
         return 4

--- a/deepchecks/core/serialization/check_result/json.py
+++ b/deepchecks/core/serialization/check_result/json.py
@@ -79,7 +79,7 @@ class CheckResultSerializer(JsonSerializer['check_types.CheckResult']):
 
     def prepare_condition_results(self) -> t.List[t.Dict[t.Any, t.Any]]:
         """Serialize condition results into json."""
-        if self.value.have_conditions:
+        if self.value.have_conditions():
             df = aggregate_conditions(self.value, include_icon=False)
             return df.data.to_dict(orient='records')
         else:

--- a/deepchecks/core/serialization/suite_result/widget.py
+++ b/deepchecks/core/serialization/suite_result/widget.py
@@ -204,13 +204,13 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
         else:
             section_id = f'{output_id}-section-{get_random_string()}'
             section_anchor = HTML(value=f'<span id="{form_output_anchor(section_id)}"></span>')
-            
+
             serialized_results = [
                 select_serializer(it).serialize(output_id=section_id, **kwargs)
                 for it in results
                 if it.display  # we do not form full-output for the check results without display
             ]
-            
+
             if callable(summary_creation_method):
                 children = (
                     summary_creation_method(results=results, output_id=section_id, **kwargs),
@@ -222,7 +222,7 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
                     *join(serialized_results, HTML(value=CommonHtml.light_hr)),
                 )
 
-            
+
             accordion = normalize_widget_style(Accordion(
                 children=(VBox(children=children),),
                 _titles={'0': title},

--- a/deepchecks/core/serialization/suite_result/widget.py
+++ b/deepchecks/core/serialization/suite_result/widget.py
@@ -204,11 +204,13 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
         else:
             section_id = f'{output_id}-section-{get_random_string()}'
             section_anchor = HTML(value=f'<span id="{form_output_anchor(section_id)}"></span>')
+            
             serialized_results = [
                 select_serializer(it).serialize(output_id=section_id, **kwargs)
                 for it in results
                 if it.display  # we do not form full-output for the check results without display
             ]
+            
             if callable(summary_creation_method):
                 children = (
                     summary_creation_method(results=results, output_id=section_id, **kwargs),
@@ -220,6 +222,7 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
                     *join(serialized_results, HTML(value=CommonHtml.light_hr)),
                 )
 
+            
             accordion = normalize_widget_style(Accordion(
                 children=(VBox(children=children),),
                 _titles={'0': title},

--- a/deepchecks/core/serialization/suite_result/widget.py
+++ b/deepchecks/core/serialization/suite_result/widget.py
@@ -222,7 +222,6 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
                     *join(serialized_results, HTML(value=CommonHtml.light_hr)),
                 )
 
-
             accordion = normalize_widget_style(Accordion(
                 children=(VBox(children=children),),
                 _titles={'0': title},


### PR DESCRIPTION
resolves #1846 


results (as we can see now `Regression Error` is shown before `Weak Segment Performance`):

![image](https://user-images.githubusercontent.com/71635444/185046951-5094f366-2759-4b67-98ba-5eccf7500b81.png)
