### PR TITLE
Vision Properties v2

### DIFF
--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -11,12 +11,10 @@
 """Contains code for BatchWrapper."""
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Tuple, TypeVar, cast
-import numpy as np
 
 import torch
 
 from deepchecks.core import DatasetKind
-from deepchecks.core.errors import DeepchecksProcessError
 from deepchecks.vision.task_type import TaskType
 from deepchecks.vision.utils.image_functions import crop_image
 from deepchecks.vision.utils.vision_properties import (PropertiesInputType, calc_vision_properties,
@@ -138,8 +136,8 @@ class Batch:
         # else calculate only those that were not yet calculated.
         if self._vision_properties_cache[input_type.value] is None:
             if (input_type in [PropertiesInputType.BBOXES, PropertiesInputType.IMAGES] or
-                input_type in self._context.static_properties_input_types) \
-                and self._context.static_properties is not None:
+                    input_type in self._context.static_properties_input_types) \
+                    and self._context.static_properties is not None:
                 self._vision_properties_cache = self._do_static_prop()
             else:
                 data = self._get_relevant_data(input_type)

--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -120,7 +120,7 @@ class Batch:
         return imgs
 
     def _get_relevant_data_for_properties(self, input_type: PropertiesInputType):
-        if input_type == PropertiesInputType.PARTIAL_IMAGESES:
+        if input_type == PropertiesInputType.PARTIAL_IMAGES:
             return self._get_cropped_images()
         if input_type == PropertiesInputType.IMAGES:
             return self.images

--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -105,6 +105,7 @@ class Batch:
         props = self._context.static_properties[self._dataset_kind]
         dataset = self._context.get_data_by_kind(self._dataset_kind)
         indexes = list(dataset.data_loader.batch_sampler)[self.batch_index]
+        props = itemgetter(*indexes)(props)
         props_to_cache = static_prop_to_cache_format(dict(zip(indexes, props)))
         return props_to_cache
 
@@ -136,7 +137,9 @@ class Batch:
         # if there are no cached properties at all, calculate all the properties on the list,
         # else calculate only those that were not yet calculated.
         if self._vision_properties_cache[input_type.value] is None:
-            if self._context.static_properties is not None:
+            if (input_type in [PropertiesInputType.BBOXES, PropertiesInputType.IMAGES] or
+                input_type in self._context.static_properties_input_types) \
+                and self._context.static_properties is not None:
                 self._vision_properties_cache = self._do_static_prop()
             else:
                 data = self._get_relevant_data(input_type)

--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -119,8 +119,8 @@ class Batch:
                 imgs.append(crop_image(img, *bbox))
         return imgs
 
-    def _get_relevant_data(self, input_type: PropertiesInputType):
-        if input_type == PropertiesInputType.BBOXES:
+    def _get_relevant_data_for_properties(self, input_type: PropertiesInputType):
+        if input_type == PropertiesInputType.PARTIAL_IMAGESES:
             return self._get_cropped_images()
         if input_type == PropertiesInputType.IMAGES:
             return self.images
@@ -138,13 +138,13 @@ class Batch:
             if input_type.value in self._context.static_properties_input_types(self._dataset_kind):
                 self._vision_properties_cache = self._do_static_prop()
             else:
-                data = self._get_relevant_data(input_type)
+                data = self._get_relevant_data_for_properties(input_type)
                 self._vision_properties_cache[input_type.value] = calc_vision_properties(data, properties_list)
         else:
             properties_to_calc = [p for p in properties_list if p['name'] not in
                                   self._vision_properties_cache[input_type.value].keys()]
             if len(properties_to_calc) > 0:
-                data = self._get_relevant_data(input_type)
+                data = self._get_relevant_data_for_properties(input_type)
                 self._vision_properties_cache[input_type.value].update(calc_vision_properties(data, properties_to_calc))
         return self._vision_properties_cache[input_type.value]
 

--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -135,9 +135,7 @@ class Batch:
         # if there are no cached properties at all, calculate all the properties on the list,
         # else calculate only those that were not yet calculated.
         if self._vision_properties_cache[input_type.value] is None:
-            if (input_type in [PropertiesInputType.BBOXES, PropertiesInputType.IMAGES] or
-                    input_type in self._context.static_properties_input_types) \
-                    and self._context.static_properties is not None:
+            if input_type.value in self._context.static_properties_input_types(self._dataset_kind):
                 self._vision_properties_cache = self._do_static_prop()
             else:
                 data = self._get_relevant_data(input_type)

--- a/deepchecks/vision/batch_wrapper.py
+++ b/deepchecks/vision/batch_wrapper.py
@@ -11,12 +11,14 @@
 """Contains code for BatchWrapper."""
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Tuple, TypeVar, cast
+import numpy as np
 
 import torch
 
 from deepchecks.core import DatasetKind
 from deepchecks.core.errors import DeepchecksProcessError
 from deepchecks.vision.task_type import TaskType
+from deepchecks.vision.utils.image_functions import crop_image
 from deepchecks.vision.utils.vision_properties import (PropertiesInputType, calc_vision_properties,
                                                        static_prop_to_cache_format, validate_properties)
 
@@ -106,7 +108,19 @@ class Batch:
         props_to_cache = static_prop_to_cache_format(dict(zip(indexes, props)))
         return props_to_cache
 
-    def vision_properties(self, raw_data: List, properties_list: List[Dict], input_type: PropertiesInputType):
+    def _get_cropped_images(self):
+        imgs = []
+        for img, labels in zip(self.images, self.labels):
+            for label in labels:
+                label = label.cpu().detach().numpy()
+                bbox = label[1:]
+                # make sure image is not out of bounds
+                if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or round(bbox[3] <= 0) + min(round(bbox[1]), 0):
+                    continue
+                imgs.append(crop_image(img, *bbox))
+        return imgs
+
+    def vision_properties(self, properties_list: List[Dict], input_type: PropertiesInputType):
         """Calculate and cache the properties for the batch according to the property input type."""
         properties_list = validate_properties(properties_list)
         # if there are no cached properties at all, calculate all the properties on the list,
@@ -115,20 +129,15 @@ class Batch:
             if self._context.static_properties is not None:
                 self._vision_properties_cache = self._do_static_prop()
             else:
-                self._vision_properties_cache[input_type.value] = calc_vision_properties(raw_data, properties_list)
-            result_dict = self._vision_properties_cache[input_type.value]
+                data = self._get_cropped_images() if input_type == PropertiesInputType.BBOXES else self.images
+                self._vision_properties_cache[input_type.value] = calc_vision_properties(data, properties_list)
         else:
             properties_to_calc = [p for p in properties_list if p['name'] not in
                                   self._vision_properties_cache[input_type.value].keys()]
-            self._vision_properties_cache[input_type.value].update(
-                                                                calc_vision_properties(raw_data, properties_to_calc))
-            property_names_to_return = [p['name'] for p in properties_list]
-            result_dict = {k: self._vision_properties_cache[input_type.value][k] for k in property_names_to_return}
-        # validate properties length
-        static_prop_lens = [len(pr) for pr in result_dict.values()]
-        if any([(p != len(raw_data) and p != 1) for p in static_prop_lens]):  # pylint: disable=use-a-generator
-            raise DeepchecksProcessError('The properties should have the same length as the raw data')
-        return result_dict
+            if len(properties_to_calc) > 0:
+                data = self._get_cropped_images() if input_type == PropertiesInputType.BBOXES else self.images
+                self._vision_properties_cache[input_type.value].update(calc_vision_properties(data, properties_to_calc))
+        return self._vision_properties_cache[input_type.value]
 
 
 T = TypeVar('T')

--- a/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
@@ -52,7 +52,7 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
         - 'categorical' - for discrete, non-ordinal outputs. These can still be numbers,
           but these numbers do not have inherent value.
         For more on image / label properties, see the :ref:`property guide </user-guide/vision/vision_properties.rst>`
-    property_input_type: PropertiesInputType, default: PropertiesInputType.OTHER
+    property_input_type: PropertiesInputType, default: PropertiesInputType.IMAGES
         The type of input to the properties, required for caching the results after first calculation.
     n_show_top : int , default: 5
         number of outliers to show from each direction (upper limit and bottom limit)
@@ -64,7 +64,7 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
 
     def __init__(self,
                  properties_list: t.List[t.Dict[str, t.Any]] = None,
-                 property_input_type: PropertiesInputType = PropertiesInputType.OTHER,
+                 property_input_type: PropertiesInputType = PropertiesInputType.IMAGES,
                  n_show_top: int = 5,
                  iqr_percentiles: t.Tuple[int, int] = (25, 75),
                  iqr_scale: float = 1.5,

--- a/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/abstract_property_outliers.py
@@ -64,7 +64,7 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
 
     def __init__(self,
                  properties_list: t.List[t.Dict[str, t.Any]] = None,
-                 property_input_type: PropertiesInputType = PropertiesInputType.OTHER,
+                 property_input_type: PropertiesInputType = PropertiesInputType.IMAGES,
                  n_show_top: int = 5,
                  iqr_percentiles: t.Tuple[int, int] = (25, 75),
                  iqr_scale: float = 1.5,
@@ -91,11 +91,10 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
 
     def update(self, context: Context, batch: Batch, dataset_kind: DatasetKind):
         """Aggregate image properties from batch."""
-        raw_data = self.get_relevant_data(batch)
-        batch_properties = batch.vision_properties(raw_data, self.properties_list, self.property_input_type)
+        batch_properties = batch.vision_properties(self.properties_list, self.property_input_type)
 
         for prop_name, property_values in batch_properties.items():
-            _ensure_property_shape(property_values, raw_data, prop_name)
+            self._ensure_property_shape(property_values, len(batch), prop_name)
             self._properties_results[prop_name].extend(property_values)
 
     def compute(self, context: Context, dataset_kind: DatasetKind) -> CheckResult:
@@ -216,10 +215,6 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
 
         return CheckResult(result, display=display)
 
-    @abstractmethod
-    def get_relevant_data(self, batch: Batch):
-        """Get the data on which the check calculates outliers."""
-        pass
 
     @abstractmethod
     def draw_image(self, data: VisionData, sample_index: int, index_of_value_in_sample: int,
@@ -244,26 +239,26 @@ class AbstractPropertyOutliers(SingleDatasetCheck):
         """Return default properties to run in the check."""
         pass
 
+    @staticmethod
+    def _ensure_property_shape(property_values, data_length, prop_name):
+        """Validate the result of the property."""
+        if len(property_values) != data_length:
+            raise DeepchecksProcessError(f'Properties are expected to return value per image but instead got'
+                                        f' {len(property_values)} values for {data_length} images for property '
+                                        f'{prop_name}')
 
-def _ensure_property_shape(property_values, data, prop_name):
-    """Validate the result of the property."""
-    if len(property_values) != len(data):
-        raise DeepchecksProcessError(f'Properties are expected to return value per image but instead got'
-                                     f' {len(property_values)} values for {len(data)} images for property '
-                                     f'{prop_name}')
-
-    # If the first item is list validate all items are list of numbers
-    if isinstance(property_values[0], t.Sequence):
-        if any((not isinstance(x, t.Sequence) for x in property_values)):
-            raise DeepchecksProcessError(f'Property result is expected to be either all lists or all scalars but'
-                                         f' got mix for property {prop_name}')
-        if any((not _is_list_of_numbers(x) for x in property_values)):
+        # If the first item is list validate all items are list of numbers
+        if isinstance(property_values[0], t.Sequence):
+            if any((not isinstance(x, t.Sequence) for x in property_values)):
+                raise DeepchecksProcessError(f'Property result is expected to be either all lists or all scalars but'
+                                            f' got mix for property {prop_name}')
+            if any((not _is_list_of_numbers(x) for x in property_values)):
+                raise DeepchecksProcessError(f'For outliers, properties are expected to be only numeric types but'
+                                            f' found non-numeric value for property {prop_name}')
+        # If first value is not list, validate all items are numeric
+        elif not _is_list_of_numbers(property_values):
             raise DeepchecksProcessError(f'For outliers, properties are expected to be only numeric types but'
-                                         f' found non-numeric value for property {prop_name}')
-    # If first value is not list, validate all items are numeric
-    elif not _is_list_of_numbers(property_values):
-        raise DeepchecksProcessError(f'For outliers, properties are expected to be only numeric types but'
-                                     f' found non-numeric value for property {prop_name}')
+                                        f' found non-numeric value for property {prop_name}')
 
 
 def _is_list_of_numbers(l):

--- a/deepchecks/vision/checks/data_integrity/image_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/image_property_outliers.py
@@ -56,9 +56,13 @@ class ImagePropertyOutliers(AbstractPropertyOutliers):
                          n_show_top=n_show_top, iqr_percentiles=iqr_percentiles,
                          iqr_scale=iqr_scale, **kwargs)
 
-    def get_relevant_data(self, batch: Batch):
-        """Get the data on which the check calculates outliers for."""
-        return batch.images
+    def update(self, context, batch: Batch, dataset_kind):
+        """Aggregate image properties from batch."""
+        batch_properties = batch.vision_properties(self.properties_list, self.property_input_type)
+
+        for prop_name, property_values in batch_properties.items():
+            self._ensure_property_shape(property_values, len(batch), prop_name)
+            self._properties_results[prop_name].extend(property_values)
 
     def draw_image(self, data: VisionData, sample_index: int, index_of_value_in_sample: int,
                    num_properties_in_sample: int) -> np.ndarray:

--- a/deepchecks/vision/checks/data_integrity/image_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/image_property_outliers.py
@@ -13,7 +13,7 @@ import typing as t
 
 import numpy as np
 
-from deepchecks.vision import Batch, VisionData
+from deepchecks.vision import VisionData
 from deepchecks.vision.checks.data_integrity.abstract_property_outliers import AbstractPropertyOutliers
 from deepchecks.vision.utils.image_properties import default_image_properties
 from deepchecks.vision.utils.vision_properties import PropertiesInputType

--- a/deepchecks/vision/checks/data_integrity/image_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/image_property_outliers.py
@@ -56,14 +56,6 @@ class ImagePropertyOutliers(AbstractPropertyOutliers):
                          n_show_top=n_show_top, iqr_percentiles=iqr_percentiles,
                          iqr_scale=iqr_scale, **kwargs)
 
-    def update(self, context, batch: Batch, dataset_kind):
-        """Aggregate image properties from batch."""
-        batch_properties = batch.vision_properties(self.properties_list, self.property_input_type)
-
-        for prop_name, property_values in batch_properties.items():
-            self._ensure_property_shape(property_values, len(batch), prop_name)
-            self._properties_results[prop_name].extend(property_values)
-
     def draw_image(self, data: VisionData, sample_index: int, index_of_value_in_sample: int,
                    num_properties_in_sample: int) -> np.ndarray:
         """Return an image to show as output of the display.

--- a/deepchecks/vision/checks/data_integrity/label_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/label_property_outliers.py
@@ -14,7 +14,6 @@ import typing as t
 import numpy as np
 
 from deepchecks.core.errors import DeepchecksProcessError
-from deepchecks.vision import Batch
 from deepchecks.vision.checks.data_integrity.abstract_property_outliers import AbstractPropertyOutliers
 from deepchecks.vision.utils import label_prediction_properties
 from deepchecks.vision.utils.image_functions import draw_bboxes

--- a/deepchecks/vision/checks/data_integrity/label_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/label_property_outliers.py
@@ -72,9 +72,13 @@ class LabelPropertyOutliers(AbstractPropertyOutliers):
             raise DeepchecksProcessError(f'task type {data.task_type} does not have default label '
                                          f'properties defined.')
 
-    def get_relevant_data(self, batch: Batch):
-        """Get the data on which the check calculates outliers for."""
-        return batch.labels
+    def update(self, context, batch: Batch, dataset_kind):
+        """Aggregate image properties from batch."""
+        for single_property in self.properties_list:
+            prop_name = single_property['name']
+            property_values = single_property['method'](batch.labels)
+            self._ensure_property_shape(property_values, len(batch), prop_name)
+            self._properties_results[prop_name].extend(property_values)
 
     def draw_image(self, data: VisionData, sample_index: int, index_of_value_in_sample: int,
                    num_properties_in_sample: int) -> np.ndarray:

--- a/deepchecks/vision/checks/data_integrity/label_property_outliers.py
+++ b/deepchecks/vision/checks/data_integrity/label_property_outliers.py
@@ -72,14 +72,6 @@ class LabelPropertyOutliers(AbstractPropertyOutliers):
             raise DeepchecksProcessError(f'task type {data.task_type} does not have default label '
                                          f'properties defined.')
 
-    def update(self, context, batch: Batch, dataset_kind):
-        """Aggregate image properties from batch."""
-        for single_property in self.properties_list:
-            prop_name = single_property['name']
-            property_values = single_property['method'](batch.labels)
-            self._ensure_property_shape(property_values, len(batch), prop_name)
-            self._properties_results[prop_name].extend(property_values)
-
     def draw_image(self, data: VisionData, sample_index: int, index_of_value_in_sample: int,
                    num_properties_in_sample: int) -> np.ndarray:
         """Return an image to show as output of the display.

--- a/deepchecks/vision/checks/model_evaluation/image_segment_performance.py
+++ b/deepchecks/vision/checks/model_evaluation/image_segment_performance.py
@@ -84,7 +84,7 @@ class ImageSegmentPerformance(SingleDatasetCheck):
         """Update the bins by the image properties."""
         predictions = [tens.detach() for tens in batch.predictions]
         labels = [tens.detach() for tens in batch.labels]
-        properties_results = batch.vision_properties(batch.images, self.image_properties, PropertiesInputType.IMAGES)
+        properties_results = batch.vision_properties(self.image_properties, PropertiesInputType.IMAGES)
 
         samples_for_bin: t.List = self._state['samples_for_binning']
         bins = self._state['bins']

--- a/deepchecks/vision/checks/model_evaluation/model_error_analysis.py
+++ b/deepchecks/vision/checks/model_evaluation/model_error_analysis.py
@@ -111,7 +111,7 @@ class ModelErrorAnalysis(TrainTestCheck):
 
         predictions = batch.predictions
         labels = batch.labels
-        properties_results = batch.vision_properties(batch.images, self.image_properties, PropertiesInputType.IMAGES)
+        properties_results = batch.vision_properties(self.image_properties, PropertiesInputType.IMAGES)
 
         for prop_name, prop_value in properties_results.items():
             properties[prop_name].extend(prop_value)

--- a/deepchecks/vision/checks/model_evaluation/train_test_prediction_drift.py
+++ b/deepchecks/vision/checks/model_evaluation/train_test_prediction_drift.py
@@ -169,11 +169,11 @@ class TrainTestPredictionDrift(TrainTestCheck, ReduceMixin):
         else:
             raise DeepchecksNotSupportedError(f'Unsupported dataset kind {dataset_kind}')
 
-        for prediction_property in self.prediction_properties:
-            # Flatten the properties since I don't care in this check about the property-per-sample coupling
-            properties_results[prediction_property['name']] += properties_flatten(
-                prediction_property['method'](batch.predictions)
-            )
+        batch_properties = batch.vision_properties(self.prediction_properties, PropertiesInputType.PREDICTIONS)
+
+        for prop_name, prop_value in batch_properties.items():
+            # Flatten the properties since we don't care in this check about the property-per-sample coupling
+            properties_results[prop_name] += properties_flatten(prop_value)
 
     def compute(self, context: Context) -> CheckResult:
         """Calculate drift on prediction properties samples that were collected during update() calls.

--- a/deepchecks/vision/checks/model_evaluation/train_test_prediction_drift.py
+++ b/deepchecks/vision/checks/model_evaluation/train_test_prediction_drift.py
@@ -169,12 +169,11 @@ class TrainTestPredictionDrift(TrainTestCheck, ReduceMixin):
         else:
             raise DeepchecksNotSupportedError(f'Unsupported dataset kind {dataset_kind}')
 
-        batch_properties = batch.vision_properties(
-            batch.predictions, self.prediction_properties, PropertiesInputType.PREDICTIONS)
-
-        for prop_name, prop_value in batch_properties.items():
-            # Flatten the properties since we don't care in this check about the property-per-sample coupling
-            properties_results[prop_name] += properties_flatten(prop_value)
+        for prediction_property in self.prediction_properties:
+            # Flatten the properties since I don't care in this check about the property-per-sample coupling
+            properties_results[prediction_property['name']] += properties_flatten(
+                prediction_property['method'](batch.predictions)
+            )
 
     def compute(self, context: Context) -> CheckResult:
         """Calculate drift on prediction properties samples that were collected during update() calls.

--- a/deepchecks/vision/checks/train_test_validation/image_dataset_drift.py
+++ b/deepchecks/vision/checks/train_test_validation/image_dataset_drift.py
@@ -108,7 +108,7 @@ class ImageDatasetDrift(TrainTestCheck):
         else:
             properties_results = self._test_properties
 
-        data_for_properties = batch.vision_properties(batch.images, self.image_properties, PropertiesInputType.IMAGES)
+        data_for_properties = batch.vision_properties(self.image_properties, PropertiesInputType.IMAGES)
 
         for prop_name, prop_value in data_for_properties.items():
             properties_results[prop_name].extend(prop_value)

--- a/deepchecks/vision/checks/train_test_validation/image_property_drift.py
+++ b/deepchecks/vision/checks/train_test_validation/image_property_drift.py
@@ -129,8 +129,7 @@ class ImagePropertyDrift(TrainTestCheck):
                 f'Internal Error - Should not reach here! unknown dataset_kind: {dataset_kind}'
             )
 
-        all_classes_properties = batch.vision_properties(
-            batch.images, self.image_properties, PropertiesInputType.IMAGES)
+        all_classes_properties = batch.vision_properties(self.image_properties, PropertiesInputType.IMAGES)
 
         if self.classes_to_display:
             # use only images belonging (or containing an annotation belonging) to one of the classes in

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -130,7 +130,7 @@ class PropertyLabelCorrelationChange(TrainTestCheck):
                     label = label.cpu().detach().numpy()
                     bbox = label[1:]
                     # make sure image is not out of bounds
-                    if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or round(bbox[3] <= 0) + min(round(bbox[1]), 0):
+                    if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or round(bbox[3]) <= 0 + min(round(bbox[1]), 0):
                         continue
                     class_id = int(label[0])
                     target.append(dataset.label_id_to_name(class_id))

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -133,7 +133,7 @@ class PropertyLabelCorrelationChange(TrainTestCheck):
                         continue
                     class_id = int(label[0])
                     target.append(dataset.label_id_to_name(class_id))
-            property_type = PropertiesInputType.PARTIAL_IMAGESES
+            property_type = PropertiesInputType.PARTIAL_IMAGES
         else:
             for classes_ids in dataset.get_classes(batch.labels):
                 if len(classes_ids) == 0:

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -136,7 +136,10 @@ class PropertyLabelCorrelationChange(TrainTestCheck):
             property_type = PropertiesInputType.BBOXES
         else:
             for classes_ids in dataset.get_classes(batch.labels):
-                target.append(dataset.label_id_to_name(classes_ids[0]))
+                if len(classes_ids) == 0:
+                    target.append(None)
+                else:
+                    target.append(dataset.label_id_to_name(classes_ids[0]))
             property_type = PropertiesInputType.IMAGES
 
         properties_results['target'] += target

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -133,7 +133,7 @@ class PropertyLabelCorrelationChange(TrainTestCheck):
                         continue
                     class_id = int(label[0])
                     target.append(dataset.label_id_to_name(class_id))
-            property_type = PropertiesInputType.BBOXES
+            property_type = PropertiesInputType.PARTIAL_IMAGESES
         else:
             for classes_ids in dataset.get_classes(batch.labels):
                 if len(classes_ids) == 0:

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -25,7 +25,6 @@ from deepchecks.utils.dict_funcs import get_dict_entry_by_value
 from deepchecks.utils.strings import format_number
 from deepchecks.vision import Context, TrainTestCheck
 from deepchecks.vision.batch_wrapper import Batch
-from deepchecks.vision.utils.image_functions import crop_image
 from deepchecks.vision.utils.image_properties import default_image_properties
 from deepchecks.vision.utils.vision_properties import PropertiesInputType
 from deepchecks.vision.vision_data import TaskType

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -143,7 +143,6 @@ class PropertyLabelCorrelationChange(TrainTestCheck):
         properties_results['target'] += target
 
         data_for_properties = batch.vision_properties(self.image_properties, property_type)
-
         for prop_name, property_values in data_for_properties.items():
             properties_results[prop_name].extend(property_values)
 

--- a/deepchecks/vision/checks/train_test_validation/train_test_label_drift.py
+++ b/deepchecks/vision/checks/train_test_validation/train_test_label_drift.py
@@ -165,11 +165,9 @@ class TrainTestLabelDrift(TrainTestCheck, ReduceMixin):
         else:
             raise DeepchecksNotSupportedError(f'Unsupported dataset kind {dataset_kind}')
 
-        batch_properties = batch.vision_properties(batch.labels, self.label_properties, PropertiesInputType.LABELS)
-
-        for prop_name, prop_value in batch_properties.items():
-            # Flatten the properties since we don't care in this check about the property-per-sample coupling
-            properties_results[prop_name] += properties_flatten(prop_value)
+        for label_property in self.label_properties:
+            # Flatten the properties since I don't care in this check about the property-per-sample coupling
+            properties_results[label_property['name']] += properties_flatten(label_property['method'](batch.labels))
 
     def compute(self, context: Context) -> CheckResult:
         """Calculate drift on label properties samples that were collected during update() calls.

--- a/deepchecks/vision/checks/train_test_validation/train_test_label_drift.py
+++ b/deepchecks/vision/checks/train_test_validation/train_test_label_drift.py
@@ -165,9 +165,11 @@ class TrainTestLabelDrift(TrainTestCheck, ReduceMixin):
         else:
             raise DeepchecksNotSupportedError(f'Unsupported dataset kind {dataset_kind}')
 
-        for label_property in self.label_properties:
-            # Flatten the properties since I don't care in this check about the property-per-sample coupling
-            properties_results[label_property['name']] += properties_flatten(label_property['method'](batch.labels))
+        batch_properties = batch.vision_properties(self.label_properties, PropertiesInputType.LABELS)
+
+        for prop_name, prop_value in batch_properties.items():
+            # Flatten the properties since we don't care in this check about the property-per-sample coupling
+            properties_results[prop_name] += properties_flatten(prop_value)
 
     def compute(self, context: Context) -> CheckResult:
         """Calculate drift on label properties samples that were collected during update() calls.

--- a/deepchecks/vision/context.py
+++ b/deepchecks/vision/context.py
@@ -10,7 +10,7 @@
 #
 """Module for base vision context."""
 from operator import itemgetter
-from typing import Dict, Mapping, Optional, Sequence, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Union
 
 import torch
 from ignite.metrics import Metric
@@ -22,7 +22,7 @@ from deepchecks.core.errors import (DatasetValidationError, DeepchecksNotImpleme
 from deepchecks.utils.logger import get_logger
 from deepchecks.vision._shared_docs import docstrings
 from deepchecks.vision.task_type import TaskType
-from deepchecks.vision.utils.vision_properties import STATIC_PROPERTIES_FORMAT
+from deepchecks.vision.utils.vision_properties import STATIC_PROPERTIES_FORMAT, PropertiesInputType
 from deepchecks.vision.vision_data import VisionData
 
 __all__ = ['Context']
@@ -93,11 +93,11 @@ class Context:
                         msg = None
                     except DeepchecksNotImplementedError:
                         msg = f'infer_on_batch() was not implemented in {dataset_type} ' \
-                           f'dataset, some checks will not run'
+                            f'dataset, some checks will not run'
                     except ValidationError as ex:
                         msg = f'infer_on_batch() was not implemented correctly in the {dataset_type} dataset, the ' \
-                           f'validation has failed with the error: {ex}. To test your prediction formatting use the ' \
-                           'function `vision_data.validate_prediction(batch, model, device)`'
+                            f'validation has failed with the error: {ex}. To test your prediction formatting use the ' \
+                            'function `vision_data.validate_prediction(batch, model, device)`'
 
                     if msg:
                         self._prediction_formatter_error[dataset_type] = msg
@@ -132,9 +132,9 @@ class Context:
                                                          [train_properties, test_properties]):
                 if dataset is not None:
                     try:
-                        props = itemgetter(*list(dataset.data_loader.batch_sampler)[0])(properties)
+                        # TODO: add validation
                         msg = None
-                        self._static_properties[dataset_type] = props
+                        self._static_properties[dataset_type] = properties
                     except ValidationError as ex:
                         msg = f'the properties given were not in a correct format in the {dataset_type} dataset, ' \
                             f'the validation has failed with the error: {ex}.'
@@ -195,6 +195,14 @@ class Context:
     def static_properties(self) -> Dict:
         """Return the static_predictions."""
         return self._static_properties
+
+    @property
+    def static_properties_input_types(self) -> List[PropertiesInputType]:
+        """Return the available static_predictions input types."""
+        if not self._static_properties:
+            return []
+        indices = list(self._static_properties.keys())
+        return list(self._static_properties[indices[0]].keys())
 
     @property
     def model_name(self):

--- a/deepchecks/vision/context.py
+++ b/deepchecks/vision/context.py
@@ -114,7 +114,6 @@ class Context:
                         if dataset.task_type == TaskType.CLASSIFICATION:
                             preds = torch.stack(preds)
                         dataset.validate_inferred_batch_predictions(preds)
-                        msg = None
                         self._static_predictions[dataset_kind] = predictions
                     except ValidationError as ex:
                         msg = f'the predictions given were not in a correct format in the {dataset_kind} dataset, ' \
@@ -132,7 +131,6 @@ class Context:
                                                          [train_properties, test_properties]):
                 if dataset is not None:
                     try:
-                        msg = None
                         self._static_properties[dataset_kind] = properties
                         # make sure input types are within allowed input types
                         for input_type in self.static_properties_input_types(dataset_kind):

--- a/deepchecks/vision/context.py
+++ b/deepchecks/vision/context.py
@@ -192,17 +192,16 @@ class Context:
         return self._static_predictions
 
     @property
-    def static_properties(self) -> Dict:
+    def static_properties(self) -> STATIC_PROPERTIES_FORMAT:
         """Return the static_predictions."""
         return self._static_properties
 
-    @property
-    def static_properties_input_types(self) -> List[PropertiesInputType]:
+    def static_properties_input_types(self, dataset_kind: DatasetKind) -> List[PropertiesInputType]:
         """Return the available static_predictions input types."""
-        if not self._static_properties:
+        if not self.static_properties:
             return []
-        indices = list(self._static_properties.keys())
-        return list(self._static_properties[indices[0]].keys())
+        indices = list(self.static_properties[dataset_kind].keys())
+        return list(self.static_properties[dataset_kind][indices[0]].keys())
 
     @property
     def model_name(self):

--- a/deepchecks/vision/utils/vision_properties.py
+++ b/deepchecks/vision/utils/vision_properties.py
@@ -25,7 +25,7 @@ class PropertiesInputType(Enum):
     """Enum containing supported task types."""
 
     IMAGES = 'images'
-    PARTIAL_IMAGESES = 'partial_images'
+    PARTIAL_IMAGES = 'partial_images'
     LABELS = 'labels'
     PREDICTIONS = 'predictions'
 
@@ -139,7 +139,7 @@ def static_prop_to_cache_format(static_props: STATIC_PROPERTIES_FORMAT) -> PROPE
     for input_type in input_types:
         for prop_name in list(static_props[indices[0]][input_type].keys()):
             prop_vals = [static_props[index][input_type][prop_name] for index in indices]
-            if input_type == PropertiesInputType.PARTIAL_IMAGESES.value:
+            if input_type == PropertiesInputType.PARTIAL_IMAGES.value:
                 prop_vals = list(chain.from_iterable(prop_vals))
             props_cache[input_type][prop_name] = prop_vals
 

--- a/deepchecks/vision/utils/vision_properties.py
+++ b/deepchecks/vision/utils/vision_properties.py
@@ -25,10 +25,9 @@ class PropertiesInputType(Enum):
     """Enum containing supported task types."""
 
     IMAGES = 'images'
-    BBOXES = 'bounding_boxes'
+    PARTIAL_IMAGESES = 'partial_images'
     LABELS = 'labels'
     PREDICTIONS = 'predictions'
-    OTHER = 'other'
 
 
 def calc_vision_properties(raw_data: List, properties_list: List) -> Dict[str, list]:
@@ -140,7 +139,7 @@ def static_prop_to_cache_format(static_props: STATIC_PROPERTIES_FORMAT) -> PROPE
     for input_type in input_types:
         for prop_name in list(static_props[indices[0]][input_type].keys()):
             prop_vals = [static_props[index][input_type][prop_name] for index in indices]
-            if input_type == PropertiesInputType.BBOXES.value:
+            if input_type == PropertiesInputType.PARTIAL_IMAGESES.value:
                 prop_vals = list(chain.from_iterable(prop_vals))
             props_cache[input_type][prop_name] = prop_vals
 

--- a/deepchecks/vision/utils/vision_properties.py
+++ b/deepchecks/vision/utils/vision_properties.py
@@ -10,6 +10,7 @@
 #
 """Module for calculating the properties used in Vision checks."""
 import warnings
+from itertools import chain
 from enum import Enum
 
 __all__ = ['PropertiesInputType', 'validate_properties']
@@ -138,6 +139,9 @@ def static_prop_to_cache_format(static_props: STATIC_PROPERTIES_FORMAT) -> PROPE
 
     for input_type in input_types:
         for prop_name in list(static_props[indices[0]][input_type].keys()):
-            props_cache[input_type][prop_name] = [static_props[index][input_type][prop_name] for index in indices]
+            prop_vals = [static_props[index][input_type][prop_name] for index in indices]
+            if input_type == PropertiesInputType.BBOXES.value:
+                prop_vals = list(chain.from_iterable(prop_vals))
+            props_cache[input_type][prop_name] = prop_vals
 
     return props_cache

--- a/deepchecks/vision/utils/vision_properties.py
+++ b/deepchecks/vision/utils/vision_properties.py
@@ -10,8 +10,8 @@
 #
 """Module for calculating the properties used in Vision checks."""
 import warnings
-from itertools import chain
 from enum import Enum
+from itertools import chain
 
 __all__ = ['PropertiesInputType', 'validate_properties']
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,12 +7,12 @@ PyNomaly>=0.3.3
 # require for python 3.8+
 ipython>=7.15.0,<8; python_version >= '3.8'
 ipykernel>=5.3.0; python_version >= '3.8'
-ipywidgets>=7.6.5; python_version >= '3.8'
+ipywidgets>=7.6.5,<8; python_version >= '3.8'
 
 # google colab requirements (python 3.7)
 ipython>=5.5.0,<8; python_version < '3.8'
 ipykernel>=4.10.1; python_version < '3.8'
-ipywidgets>=7.5.0; python_version < '3.8'
+ipywidgets>=7.5.0,<8; python_version < '3.8'
 
 typing_extensions>=3.7.4.3
 tqdm>=4.62.3

--- a/tests/vision/base/test_static_properties.py
+++ b/tests/vision/base/test_static_properties.py
@@ -65,7 +65,8 @@ def _create_static_properties(train: VisionData, test: VisionData, image_propert
                             label = label.cpu().detach().numpy()
                             bbox = label[1:]
                             # make sure image is not out of bounds
-                            if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or round(bbox[3]) <= 0 + min(round(bbox[1]), 0):
+                            if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or \
+                                    round(bbox[3]) <= 0 + min(round(bbox[1]), 0):
                                 continue
                             class_id = int(label[0])
                             targets.append(vision_data.label_id_to_name(class_id))
@@ -76,11 +77,11 @@ def _create_static_properties(train: VisionData, test: VisionData, image_propert
                             bbox = label[1:]
                             # make sure image is not out of bounds
                             if round(bbox[2]) + min(round(bbox[0]), 0) <= 0 or \
-                                round(bbox[3]) <= 0 + min(round(bbox[1]), 0):
+                                    round(bbox[3]) <= 0 + min(round(bbox[1]), 0):
                                 continue
                             targets += []
                             imgs.append(crop_image(img, *bbox))
-                        count+=len(imgs)
+                        count += len(imgs)
                         bbox_props_list.append(calc_vision_properties(imgs, image_properties))
                     bbox_props = {k: [dic[k] for dic in bbox_props_list] for k in bbox_props_list[0]}
                     static_bbox_prop = vision_props_to_static_format(indexes, bbox_props)
@@ -120,7 +121,6 @@ def test_object_detection_missing_key(coco_train_visiondata, coco_test_visiondat
         raises(KeyError)
 
 
-
 def test_train_test_condition_pps_diff_fail_per_class(coco_train_visiondata, coco_test_visiondata, device):
     # Arrange
     train, test = coco_train_visiondata, coco_test_visiondata
@@ -132,7 +132,7 @@ def test_train_test_condition_pps_diff_fail_per_class(coco_train_visiondata, coc
     condition_value = 0.3
     check = PropertyLabelCorrelationChange(per_class=True, random_state=42
                                            ).add_condition_property_pps_difference_less_than(condition_value)
-
+    train.batch_to_images = None  # make sure it doesn't use images
     # Act
     result = check.run(train_dataset=train,
                        test_dataset=test, device=device, train_properties=train_props, test_properties=test_props)

--- a/tests/vision/base/test_static_properties.py
+++ b/tests/vision/base/test_static_properties.py
@@ -165,7 +165,6 @@ def test_train_test_condition_pps_diff_fail_per_class(coco_train_visiondata, coc
     result = check.run(train_dataset=train,
                        test_dataset=test, device=device, train_properties=train_props, test_properties=test_props)
     condition_result, *_ = check.conditions_decision(result)
-    print(result.value)
     # Assert
     assert_that(condition_result, equal_condition_result(
         is_pass=False,

--- a/tests/vision/base/test_static_properties.py
+++ b/tests/vision/base/test_static_properties.py
@@ -112,6 +112,8 @@ def test_object_detection_missing_key(coco_train_visiondata, coco_test_visiondat
     image_properties = [{'name': 'aspect_ratio', 'method': aspect_ratio, 'output_type': 'numerical'}]
     train_props, test_props = _create_static_properties(coco_train_visiondata, coco_test_visiondata,
                                                         image_properties)
+    coco_train_visiondata = copy(coco_train_visiondata)
+    coco_train_visiondata.batch_to_images = coco_train_visiondata
 
     # assert error is raised if no bbox properties passed in a check that calls bbox properties
     assert_that(calling(PropertyLabelCorrelationChange().run)

--- a/tests/vision/checks/data_integrity/image_property_outliers_test.py
+++ b/tests/vision/checks/data_integrity/image_property_outliers_test.py
@@ -153,7 +153,8 @@ def test_incorrect_properties_count_exception(mnist_dataset_train, device):
     check = ImagePropertyOutliers(image_properties=image_properties)
     # Act - Assert check raise exception
     assert_that(calling(check.run).with_args(mnist_dataset_train, device=device),
-                raises(DeepchecksProcessError, 'The properties should have the same length as the raw data'))
+                raises(DeepchecksProcessError, 'Properties are expected to return value per image but instead got 65 '
+                                               'values for 64 images for property test'))
 
 
 def test_property_with_nones(mnist_dataset_train, device):

--- a/tests/vision/checks/data_integrity/label_property_outliers_test.py
+++ b/tests/vision/checks/data_integrity/label_property_outliers_test.py
@@ -178,4 +178,5 @@ def test_incorrect_properties_count_exception(mnist_dataset_train, device):
     check = LabelPropertyOutliers(label_properties=image_properties)
     # Act - Assert check raise exception
     assert_that(calling(check.run).with_args(mnist_dataset_train, device=device),
-                raises(DeepchecksProcessError, 'The properties should have the same length as the raw data'))
+                raises(DeepchecksProcessError, 'Properties are expected to return value per image but instead got 65 '
+                                               'values for 64 images for property test'))


### PR DESCRIPTION
fixed a bug which causes static properties to always use only the first batch
made property calculation to use index
made label/prediction properties not mandatory if given static properties