### PR TITLE
Add option to sort columns in drift according to drift + importance

### DIFF
--- a/deepchecks/tabular/checks/train_test_validation/train_test_feature_drift.py
+++ b/deepchecks/tabular/checks/train_test_validation/train_test_feature_drift.py
@@ -230,21 +230,20 @@ class TrainTestFeatureDrift(TrainTestCheck, ReduceMixin):
             displays_dict[column] = display
 
         if context.with_display:
+            sorted_by = self.sort_feature_by
             if self.sort_feature_by == 'feature importance' and feature_importance is not None:
-                features_order = [feat for feat in features_order if feat in train_dataset.features]
+                features_order = [feat for feat in features_order if feat in values_dict]
                 columns_order = features_order[:self.n_top_columns]
             elif self.sort_feature_by == 'drift + importance' and feature_importance is not None:
-                feature_columns = [feat for feat in features_order if feat in train_dataset.features]
+                feature_columns = [feat for feat in features_order if feat in values_dict]
                 feature_columns.sort(key=lambda col: values_dict[col]['Drift score'] + values_dict[col]['Importance'],
                                      reverse=True)
                 columns_order = feature_columns[:self.n_top_columns]
+                sorted_by = 'the sum of the drift score and the feature importance'
             else:
                 columns_order = sorted(values_dict.keys(), key=lambda col: values_dict[col]['Drift score'],
                                        reverse=True)[:self.n_top_columns]
-
-            sorted_by = self.sort_feature_by if feature_importance is not None else 'drift score'
-            if sorted_by == 'drift + importance':
-                sorted_by = 'the sum of the drift score and the feature importance'
+                sorted_by = 'drift score'
 
             headnote = [f"""<span>
                 The Drift score is a measure for the difference between two distributions, in this check - the test

--- a/deepchecks/tabular/checks/train_test_validation/train_test_feature_drift.py
+++ b/deepchecks/tabular/checks/train_test_validation/train_test_feature_drift.py
@@ -57,10 +57,11 @@ class TrainTestFeatureDrift(TrainTestCheck, ReduceMixin):
         columns variable.
     n_top_columns : int , optional
         amount of columns to show ordered by feature importance (date, index, label are first)
-    sort_feature_by : str , default: feature importance
-        Indicates how features will be sorted. Can be either "feature importance", "drift score" or
-        "drift + importance". In the case of "drift + importance", the features will be sorted by the sum of the drift
-         score and the feature importance.
+    sort_feature_by : str , default: "drift + importance"
+        Indicates how features will be sorted. Possible values:
+        - "feature importance":  sort features by feature importance.
+        - "drift score": sort features by drift score.
+        - "drift + importance": sort features by the sum of the drift score and the feature importance.
     margin_quantile_filter: float, default: 0.025
         float in range [0,0.5), representing which margins (high and low quantiles) of the distribution will be filtered
         out of the EMD calculation. This is done in order for extreme values not to affect the calculation
@@ -107,7 +108,7 @@ class TrainTestFeatureDrift(TrainTestCheck, ReduceMixin):
             columns: Union[Hashable, List[Hashable], None] = None,
             ignore_columns: Union[Hashable, List[Hashable], None] = None,
             n_top_columns: int = 5,
-            sort_feature_by: str = 'feature importance',
+            sort_feature_by: str = 'drift + importance',
             margin_quantile_filter: float = 0.025,
             max_num_categories_for_drift: int = 10,
             max_num_categories_for_display: int = 10,

--- a/tests/tabular/checks/train_test_validation/train_test_feature_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/train_test_feature_drift_test.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Test functions of the train test drift."""
-from hamcrest import assert_that, close_to, equal_to, greater_than, has_entries, has_item, has_length
+from hamcrest import assert_that, close_to, equal_to, greater_than, has_entries, has_item, has_length, is_not
 
 from deepchecks.tabular.checks import TrainTestFeatureDrift
 from tests.base.utils import equal_condition_result
@@ -64,6 +64,30 @@ def test_drift_with_model_n_top(drifted_data_and_model):
         ),
     }))
     assert_that(result.display, has_length(4))
+
+
+def test_drift_with_different_sort(drifted_data_and_model):
+    # Arrange
+    train, test, model = drifted_data_and_model
+
+    # Act
+    check = TrainTestFeatureDrift(categorical_drift_method='PSI')
+    result = check.run(train, test, model)
+    fi_display = result.display
+
+    check = TrainTestFeatureDrift(categorical_drift_method='PSI', sort_feature_by='drift + importance')
+    result = check.run(train, test, model)
+    sum_display = result.display
+
+    check = TrainTestFeatureDrift(categorical_drift_method='PSI', sort_feature_by='drift + importance')
+    result = check.run(train, test)
+    no_model_drift_display = result.display
+
+    # Assert
+    assert_that(fi_display[0], is_not(equal_to(sum_display[0])))
+    assert_that(sum_display[0], is_not(equal_to(no_model_drift_display[0])))
+    assert_that(fi_display[0], is_not(equal_to(no_model_drift_display[0])))
+
 
 def test_drift_with_nulls(drifted_data_with_nulls):
     # Arrange

--- a/tests/tabular/checks/train_test_validation/train_test_feature_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/train_test_feature_drift_test.py
@@ -71,7 +71,7 @@ def test_drift_with_different_sort(drifted_data_and_model):
     train, test, model = drifted_data_and_model
 
     # Act
-    check = TrainTestFeatureDrift(categorical_drift_method='PSI')
+    check = TrainTestFeatureDrift(categorical_drift_method='PSI', sort_feature_by='feature importance')
     result = check.run(train, test, model)
     fi_display = result.display
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1322 

#### What does this implement/fix? Explain your changes.
Can sort (not by default) the columns in the TrainTestFeatureDrift by the sum of FI and drift score.

#### Any other comments?
Open for suggestions for the name of the parameter in that case. Current is 'drift + importance'

---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
