### PR TITLE
`AveragePrecisionRecall._evaluate_image`: Don't recompute on each `min_iou`.

### DIFF
--- a/deepchecks/vision/metrics_utils/detection_precision_recall.py
+++ b/deepchecks/vision/metrics_utils/detection_precision_recall.py
@@ -165,21 +165,20 @@ class AveragePrecisionRecall(Metric, MetricMixin):
         scores = {}
         matched = {}
         n_gts = {}
-        for min_iou in self.iou_thresholds:
-            for top_n_detections in self.max_detections_per_class:
-                for area_size in self.area_ranges_names:
-                    # sort list of dts and chop by max dets
-                    top_detections_idx = sorted_confidence_ids[:top_n_detections]
-                    ious = orig_ious[top_detections_idx]
-                    ground_truth_to_ignore = [self._is_ignore_area(gt_area, area_size) for gt_area in ground_truth_area]
+        for top_n_detections in self.max_detections_per_class:
+            for area_size in self.area_ranges_names:
+                # sort list of dts and chop by max dets
+                top_detections_idx = sorted_confidence_ids[:top_n_detections]
+                ious = orig_ious[top_detections_idx]
+                ground_truth_to_ignore = [self._is_ignore_area(gt_area, area_size) for gt_area in ground_truth_area]
 
-                    # sort gts by ignore last
-                    gt_sort = np.argsort(ground_truth_to_ignore, kind="stable")
-                    ground_truths = [orig_gt[idx] for idx in gt_sort]
-                    ground_truth_to_ignore = [ground_truth_to_ignore[idx] for idx in gt_sort]
+                # sort gts by ignore last
+                gt_sort = np.argsort(ground_truth_to_ignore, kind="stable")
+                ground_truths = [orig_gt[idx] for idx in gt_sort]
+                ground_truth_to_ignore = [ground_truth_to_ignore[idx] for idx in gt_sort]
 
-                    ious = ious[:, gt_sort]
-
+                ious = ious[:, gt_sort]
+                for min_iou in self.iou_thresholds:
                     detection_matches = \
                         self._get_best_matches(top_detections_idx, min_iou, ground_truths, ground_truth_to_ignore, ious)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Small refactor of `AveragePrecisionRecall._evaluate_image` to remove unnecessary recomputations.

#### Any other comments?

I was just going through the AP implementation and noticed it.

Didn't run any exhaustive benchmarks as it felt obvious. For the following snippet:

```python
from deepchecks.vision.datasets.detection.coco import load_dataset as load_coco_dataset
from deepchecks.vision.metrics_utils.detection_precision_recall import ObjectDetectionAveragePrecision
coco_test_visiondata = load_coco_dataset(train=False, object_type='VisionData', shuffle=False)
metric = ObjectDetectionAveragePrecision(return_option=None)

%%timeit
for batch in coco_test_visiondata:
    label = coco_test_visiondata.batch_to_labels(batch)
    prediction = coco_test_visiondata.infer_on_batch(batch, mock_trained_yolov5_object_detection, device)
    metric.update((prediction, label))
```

This branch:

```console
464 ms ± 26.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

main:

```console
671 ms ± 31.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```