### PR TITLE
run time improvements

### DIFF
--- a/deepchecks/tabular/context.py
+++ b/deepchecks/tabular/context.py
@@ -112,18 +112,16 @@ class _DummyModel:
             self.predict_proba = self._predict_proba
 
     def _validate_data(self, data: pd.DataFrame):
-        # Validate only up to 100 samples
         data = data.sample(min(100, len(data)))
         for feature_df in self.feature_df_list:
-            # If all indices are found than test for equality
+            # If all indices are found than test for equality in actual data (statistically significant portion)
             if set(data.index).issubset(set(feature_df.index)):
-                # If data indices are part of feature_df, compare the actual data of a statistically significant portion
                 sample_data = np.unique(np.random.choice(data.index, 30))
                 if feature_df.loc[sample_data].equals(data.loc[sample_data]):
                     return
                 else:
                     break
-        raise DeepchecksValueError('Data with indices that has not been seen before passed for inference with static '
+        raise DeepchecksValueError('Data that has not been seen before passed for inference with static '
                                    'predictions. Pass a real model to resolve this')
 
     def _predict(self, data: pd.DataFrame):

--- a/deepchecks/tabular/context.py
+++ b/deepchecks/tabular/context.py
@@ -117,12 +117,12 @@ class _DummyModel:
         for feature_df in self.feature_df_list:
             # If all indices are found than test for equality
             if set(data.index).issubset(set(feature_df.index)):
-                # If equal than data is valid, can return
-                if feature_df.loc[data.index].fillna('').equals(data.fillna('')):
+                # If data indices are part of feature_df, compare the actual data of a statistically significant portion
+                sample_data = np.unique(np.random.choice(data.index, 30))
+                if feature_df.loc[sample_data].equals(data.loc[sample_data]):
                     return
                 else:
-                    raise DeepchecksValueError('Data that has not been seen before passed for inference with static '
-                                               'predictions. Pass a real model to resolve this')
+                    break
         raise DeepchecksValueError('Data with indices that has not been seen before passed for inference with static '
                                    'predictions. Pass a real model to resolve this')
 

--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -178,9 +178,8 @@ class DeepcheckScorer:
     def validate_fitting(self, model, dataset: 'tabular.Dataset'):
         """Validate given scorer for the model and dataset."""
         dataset.assert_features()
-        dataset = self.filter_nulls(dataset)
         # In order for scorer to return result in right dimensions need to pass it samples from all labels
-        single_label_data = dataset.data.groupby(dataset.label_name).head(1)
+        single_label_data = dataset.data[dataset.data[dataset.label_name].notna()].groupby(dataset.label_name).head(1)
         result = self._run_score(model, dataset.copy(single_label_data))
 
         if isinstance(result, np.ndarray):


### PR DESCRIPTION
resolves https://github.com/deepchecks/deepchecks/issues/1918

Reduce run time by ~33%.
In addition run time will be further improved since we will reduce the default from 3 scorers to 1.