### PR TITLE
1863 resolve two ways of passing n samples to vision suites checks

### DIFF
--- a/deepchecks/vision/_shared_docs.py
+++ b/deepchecks/vision/_shared_docs.py
@@ -28,8 +28,6 @@ device : Union[str, torch.device], default: 'cpu'
     processing unit for use
 random_state : int
     A seed to set for pseudo-random functions
-n_samples : Optional[int], default: None
-    number of samples
 with_display : bool , default: True
     flag that determines if checks will calculate display (redundant in some checks).
 train_predictions: Optional[Dict[int, Union[Sequence[torch.Tensor], torch.Tensor]]] , default None

--- a/deepchecks/vision/checks/train_test_validation/image_dataset_drift.py
+++ b/deepchecks/vision/checks/train_test_validation/image_dataset_drift.py
@@ -63,8 +63,6 @@ class ImageDatasetDrift(TrainTestCheck):
         - 'train_largest': Show the largest train categories.
         - 'test_largest': Show the largest test categories.
         - 'largest_difference': Show the largest difference between categories.
-    sample_size : int , default: 10_000
-        Max number of rows to use from each dataset for the training and evaluation of the domain classifier.
     test_size : float , default: 0.3
         Fraction of the combined datasets to use for the evaluation of the domain classifier.
     min_meaningful_drift_score : float , default 0.05
@@ -76,7 +74,6 @@ class ImageDatasetDrift(TrainTestCheck):
             image_properties: List[Dict[str, Any]] = None,
             n_top_properties: int = 3,
             min_feature_importance: float = 0.05,
-            sample_size: int = 10_000,
             test_size: float = 0.3,
             min_meaningful_drift_score: float = 0.05,
             max_num_categories_for_display: int = 10,
@@ -88,7 +85,6 @@ class ImageDatasetDrift(TrainTestCheck):
 
         self.n_top_properties = n_top_properties
         self.min_feature_importance = min_feature_importance
-        self.sample_size = sample_size
         self.test_size = test_size
         self.min_meaningful_drift_score = min_meaningful_drift_score
         self._train_properties = None
@@ -127,7 +123,7 @@ class ImageDatasetDrift(TrainTestCheck):
         df_train = pd.DataFrame(self._train_properties)
         df_test = pd.DataFrame(self._test_properties)
 
-        sample_size = min(self.sample_size, df_train.shape[0], df_test.shape[0])
+        sample_size = min(df_train.shape[0], df_test.shape[0])
 
         headnote = """
         <span>

--- a/deepchecks/vision/suites/default_suites.py
+++ b/deepchecks/vision/suites/default_suites.py
@@ -33,7 +33,6 @@ __all__ = ['train_test_validation', 'model_evaluation', 'full_suite', 'integrity
 def train_test_validation(n_top_show: int = 5,
                           label_properties: List[Dict[str, Any]] = None,
                           image_properties: List[Dict[str, Any]] = None,
-                          sample_size: int = None,
                           random_state: int = None,
                           **kwargs) -> Suite:
     """Suite for validating correctness of train-test split, including distribution, \
@@ -83,8 +82,6 @@ def train_test_validation(n_top_show: int = 5,
         - 'categorical' - for discrete, non-ordinal outputs. These can still be numbers,
           but these numbers do not have inherent value.
         For more on image / label properties, see the :ref:`vision_properties_guide`.
-    sample_size : int , default: None
-        Number of samples to use for checks that sample data. If none, using the default sample_size per check.
     random_state: int, default: None
         Random seed for all checks.
     **kwargs : dict
@@ -99,7 +96,7 @@ def train_test_validation(n_top_show: int = 5,
     Examples
     --------
     >>> from deepchecks.vision.suites import train_test_validation
-    >>> suite = train_test_validation(n_top_show=3, sample_size=100)
+    >>> suite = train_test_validation(n_top_show=3)
     >>> result = suite.run()
     >>> result.show()
 

--- a/tests/vision/checks/train_test_validation/image_dataset_drift_test.py
+++ b/tests/vision/checks/train_test_validation/image_dataset_drift_test.py
@@ -34,10 +34,10 @@ def test_no_drift_grayscale(mnist_dataset_train, device):
     check = ImageDatasetDrift(categorical_drift_method='PSI')
 
     # Act
-    result = check.run(train, test, random_state=42, device=device, n_samples=None)
+    result = check.run(train, test, random_state=42, device=device, n_samples=10000)
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.479, 0.001),
+        'domain_classifier_auc': close_to(0.467, 0.001),
         'domain_classifier_drift_score': equal_to(0),
         'domain_classifier_feature_importance': has_entries({
             'Brightness': equal_to(0),
@@ -56,10 +56,10 @@ def test_no_drift_grayscale_cramer(mnist_dataset_train, device):
     check = ImageDatasetDrift(categorical_drift_method='cramer_v')
 
     # Act
-    result = check.run(train, test, random_state=42, device=device, n_samples=None)
+    result = check.run(train, test, random_state=42, device=device, n_samples=10000)
     # Assert
     assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.479, 0.001),
+        'domain_classifier_auc': close_to(0.467, 0.001),
         'domain_classifier_drift_score': equal_to(0),
         'domain_classifier_feature_importance': has_entries({
             'Brightness': equal_to(0),


### PR DESCRIPTION
The issue is resolved- matched to the format of the rest of the checks- n_samples from run. 