### PR TITLE
[FEAT] Help user avoid misclassification of task type #1820

### DIFF
--- a/deepchecks/tabular/dataset.py
+++ b/deepchecks/tabular/dataset.py
@@ -542,9 +542,9 @@ class Dataset:
                         and label_col.nunique() > warning_for_infer_TaskType_from_label_nunique:
                     get_logger().warning(
                         'Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, '
-                        'the task type can be inferred '
-                        ' both as multiclass and regression, so it\'s recommended to declare directly.'
-                        ' Auto inferring label type as multiclass. '
+                        'the task type can be inferred both as multiclass and regression, '
+                        'so it\'s recommended to declare directly. '
+                        'Auto inferring label type as multiclass.'
                     )
                 return TaskType.MULTICLASS
             else:

--- a/deepchecks/tabular/dataset.py
+++ b/deepchecks/tabular/dataset.py
@@ -535,11 +535,11 @@ class Dataset:
         return self.copy(train_df), self.copy(test_df)
 
     @staticmethod
-    def _infer_label_type(label_col: pd.Series, warning_for_infer_TaskType_from_label_nunique: int=10):
+    def _infer_label_type(label_col: pd.Series, infer_TaskType_from_label_nunique: int=10):
         if is_categorical(label_col, max_categorical_ratio=0.05):
             if label_col.nunique(dropna=True) > 2:
                 if infer_dtype(label_col) == 'integer' \
-                        and label_col.nunique() > warning_for_infer_TaskType_from_label_nunique:
+                        and label_col.nunique() > infer_TaskType_from_label_nunique:
                     get_logger().warning(
                         'Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, '
                         'the task type can be inferred both as multiclass and regression, '

--- a/deepchecks/tabular/dataset.py
+++ b/deepchecks/tabular/dataset.py
@@ -535,9 +535,17 @@ class Dataset:
         return self.copy(train_df), self.copy(test_df)
 
     @staticmethod
-    def _infer_label_type(label_col: pd.Series):
+    def _infer_label_type(label_col: pd.Series, warning_for_infer_TaskType_from_label_nunique: int=10):
         if is_categorical(label_col, max_categorical_ratio=0.05):
             if label_col.nunique(dropna=True) > 2:
+                if infer_dtype(label_col) == 'integer' \
+                        and label_col.nunique() > warning_for_infer_TaskType_from_label_nunique:
+                    get_logger().warning(
+                        'Attributes such as "label_type" are not mandatory, but in a case of ordinal integers, '
+                        'the task type can be inferred '
+                        ' both as multiclass and regression, so it\'s recommended to declare directly.'
+                        ' Auto inferring label type as multiclass. '
+                    )
                 return TaskType.MULTICLASS
             else:
                 return TaskType.BINARY


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1820


#### What does this implement/fix? Explain your changes.
This address the first section in the issue.
I've added a warning when inferring task type as multiclass if we found more than 10 unique values in the label and
the label contains only integers.


#### Any other comments?
i would appreciate your review.
if i'm in the right direction, will move to the second section.


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
