### PR TITLE
Nlp docs base & supported tasks

### DIFF
--- a/deepchecks/nlp/__init__.py
+++ b/deepchecks/nlp/__init__.py
@@ -10,10 +10,14 @@
 #
 """Package for nlp functionality."""
 from .base_checks import SingleDatasetCheck, TrainTestCheck
+from .context import Context
 from .suite import Suite
+from .text_data import TextData
 
 __all__ = [
-    "SingleDatasetCheck",
-    "TrainTestCheck",
-    "Suite",
+    'TextData',
+    'SingleDatasetCheck',
+    'TrainTestCheck',
+    'Suite',
+    'Context'
 ]

--- a/deepchecks/nlp/_shared_docs.py
+++ b/deepchecks/nlp/_shared_docs.py
@@ -62,7 +62,7 @@ _shared_docstrings = {'prediction_formats': """
 
         **Token Classification**
 
-        >>> predictions = [('class_1', 0, 2, 0.5), ('class_2', 7, 10, 0.8)]
+        >>> predictions = [[('class_1', 0, 2, 0.8), ('class_2', 7, 10, 0.9)], [('class_2', 42, 54, 0.4)], []]
 
 """.strip('\n')}
 

--- a/deepchecks/nlp/metric_utils/__init__.py
+++ b/deepchecks/nlp/metric_utils/__init__.py
@@ -10,4 +10,9 @@
 #
 """Module containing metrics utils for nlp tasks."""
 
-__all__ = []
+from deepchecks.nlp.metric_utils.scorers import infer_on_text_data, init_validate_scorers
+from deepchecks.nlp.metric_utils.token_classification import (get_default_token_scorers, get_scorer_dict,
+                                                              validate_scorers)
+
+__all__ = ['get_default_token_scorers', 'validate_scorers', 'get_scorer_dict', 'init_validate_scorers',
+           'infer_on_text_data']

--- a/docs/source/api/deepchecks.nlp.checks.rst
+++ b/docs/source/api/deepchecks.nlp.checks.rst
@@ -1,0 +1,15 @@
+checks
+======
+
+.. automodule:: deepchecks.nlp.checks
+
+.. currentmodule:: deepchecks.nlp.checks
+
+.. rubric:: Modules
+
+.. autosummary::
+    :toctree: generated
+    :template: autosummary/check-module.rst
+    
+    train_test_validation
+    model_evaluation

--- a/docs/source/api/deepchecks.nlp.rst
+++ b/docs/source/api/deepchecks.nlp.rst
@@ -1,4 +1,4 @@
-deepchecks.vision
+deepchecks.nlp
 ==================
 
 .. automodule:: deepchecks.nlp

--- a/docs/source/api/deepchecks.nlp.rst
+++ b/docs/source/api/deepchecks.nlp.rst
@@ -1,0 +1,38 @@
+deepchecks.vision
+==================
+
+.. automodule:: deepchecks.nlp
+
+.. currentmodule:: deepchecks.nlp
+
+.. rubric:: Modules
+
+.. autosummary::
+    :toctree: generated
+    :caption: Modules
+    
+    checks
+    suites
+    metric_utils
+
+.. rubric:: Classes
+    
+.. autoclass:: TextData
+    :members:
+    :inherited-members:
+
+.. autoclass:: Context
+    :members:
+    :inherited-members:
+
+.. autoclass:: SingleDatasetCheck
+    :members:
+    :inherited-members:
+
+.. autoclass:: TrainTestCheck
+    :members:
+    :inherited-members:
+
+.. autoclass:: Suite
+    :members:
+    :inherited-members:

--- a/docs/source/api/deepchecks.nlp.suites.rst
+++ b/docs/source/api/deepchecks.nlp.suites.rst
@@ -1,0 +1,16 @@
+suites
+======
+
+.. automodule:: deepchecks.nlp.suites
+
+.. currentmodule:: deepchecks.nlp.suites
+
+.. rubric:: Members
+
+.. autosummary::
+    :toctree: generated
+    :template: autosummary/suite.rst
+
+    train_test_validation
+    model_evaluation
+    full_suite

--- a/docs/source/user-guide/index.rst
+++ b/docs/source/user-guide/index.rst
@@ -48,6 +48,15 @@ Vision
     vision/custom_check_templates
     vision/using_precomputed_predictions_vision
 
+NLP
+-------
+
+.. toctree::
+    :maxdepth: 2
+    :caption: NLP
+
+    nlp/coming_soon
+
 
 .. _user_guide__integrations:
 

--- a/docs/source/user-guide/nlp/coming_soon.rst
+++ b/docs/source/user-guide/nlp/coming_soon.rst
@@ -1,4 +1,4 @@
-.. _coming_soon:
+'.. _coming_soon:
 
 =================================
 Deepchecks for NLP - Coming Soon!

--- a/docs/source/user-guide/nlp/coming_soon.rst
+++ b/docs/source/user-guide/nlp/coming_soon.rst
@@ -5,3 +5,7 @@ Deepchecks for NLP - Coming Soon!
 =================================
 
 We are working on new and exciting checks for the new ``deepchecks.nlp``. Stay tuned!
+
+In the meanwhile, you can read about the supported task types in this
+:doc:`guide </user-guide/nlp/supported_tasks>`, and see some of the currently implemented checks at our
+:doc:`API ref <../../../api/deepchecks.nlp>`.

--- a/docs/source/user-guide/nlp/coming_soon.rst
+++ b/docs/source/user-guide/nlp/coming_soon.rst
@@ -1,0 +1,7 @@
+.. _coming_soon:
+
+=================================
+Deepchecks for NLP - Coming Soon!
+=================================
+
+We are working on new and exciting checks for the new ``deepchecks.nlp``. Stay tuned!

--- a/docs/source/user-guide/nlp/coming_soon.rst
+++ b/docs/source/user-guide/nlp/coming_soon.rst
@@ -7,5 +7,5 @@ Deepchecks for NLP - Coming Soon!
 We are working on new and exciting checks for the new ``deepchecks.nlp``. Stay tuned!
 
 In the meanwhile, you can read about the supported task types in this
-:doc:`guide </user-guide/nlp/supported_tasks>`, and see some of the currently implemented checks at our
-:doc:`API ref <../../../api/deepchecks.nlp>`.
+:doc:`guide </user-guide/nlp/supported_tasks>`, and see some of the currently implemented checks in our
+:doc:`API reference <../../../api/deepchecks.nlp>`.

--- a/docs/source/user-guide/nlp/supported_tasks.rst
+++ b/docs/source/user-guide/nlp/supported_tasks.rst
@@ -1,4 +1,4 @@
-.. _supported_tasks:
+.. _nlp_supported_tasks:
 
 ===================================
 Working with Labels and Predictions
@@ -33,60 +33,70 @@ While labels are passed when constructing the :class:`TextData <text_data.TextDa
 separately to the ``run`` method of the check / suite. Labels and predictions must be in the format detailed in this
 section, according to the task type.
 
-Label Formats
---------------
+Text Classification
+-------------------
 
-* **Text Classification** Label - For text classification the accepted label format differs between multilabel and
+Label Format
+~~~~~~~~~~~~
+
+* For text classification the accepted label format differs between multilabel and
   single label cases. For single label data, the label should be passed as a sequence of labels, with one entry
   per sample that can be either a string or an integer. For multilabel data, the label should be passed as a
   sequence of sequences, with the sequence for each sample being a binary vector, representing the presence of
   the i-th label in that sample.
-* **Token Classification** Label - For token classification the accepted label format is a sequence of sequences,
-  with the inner sequence containing tuples in the following format: (class_name, span_start, span_end).
-  span_start and span_end are the start and end character indices of the token within the text, as it was
-  passed to the raw_text argument. Each outer sequence contains the sequence of tokens for each sample.
 
 >>> text_classification_label_multiclass = [0, 0, 1, 2]
 >>> text_classification_label_multilabel = [[0, 0, 1], [0, 1, 1], [1, 0, 1], [0, 0, 0]]
->>> token_classification_label = [[('class_1', 0, 2), ('class_2', 7, 10)], [('class_2', 42, 54)], []]
 
-Prediction Formats
--------------------
+Prediction Format
+~~~~~~~~~~~~~~~~~
 
-The accepted formats for providing model predictions and probabilities are detailed below
+Single Class Predictions
+""""""""""""""""""""""""
 
-**Text Classification**
-
-*Single Class Predictions*
-
-* predictions - A sequence of class names or indices with one entry per sample, matching the set of classes
+* **predictions** - A sequence of class names or indices with one entry per sample, matching the set of classes
   present in the labels.
-* probabilities - A sequence of sequences with each element containing the vector of class probabilities for
+* **probabilities** - A sequence of sequences with each element containing the vector of class probabilities for
   each sample. Each such vector should have one probability per class according to the class (sorted) order, and
   the probabilities should sum to 1 for each sample.
 
 >>> predictions = ['class_1', 'class_1', 'class_2']
 >>> probabilities = [[0.2, 0.8], [0.5, 0.5], [0.3, 0.7]]
 
-*Multilabel Predictions*
+Multilabel Predictions
+""""""""""""""""""""""
 
-* predictions - A sequence of sequences with each element containing a binary vector denoting the presence of
+* **predictions** - A sequence of sequences with each element containing a binary vector denoting the presence of
   the i-th class for the given sample. Each such vector should have one binary indicator per class according to
   the class (sorted) order. More than one class can be present for each sample.
-* probabilities - A sequence of sequences with each element containing the vector of class probabilities for
+* **probabilities** - A sequence of sequences with each element containing the vector of class probabilities for
   each sample. Each such vector should have one probability per class according to the class (sorted) order, and
   the probabilities should range from 0 to 1 for each sample, but are not required to sum to 1.
 
 >>> predictions = [[0, 0, 1], [0, 1, 1]]
 >>> probabilities = [[0.2, 0.3, 0.8], [0.4, 0.9, 0.6]]
 
-**Token Classification**
+Token Classification
+--------------------
 
-* predictions - A sequence of sequences, with the inner sequence containing tuples in the following
+Label Format
+~~~~~~~~~~~~
+
+* For token classification the accepted label format is a sequence of sequences,
+  with the inner sequence containing tuples in the following format: (class_name, span_start, span_end).
+  span_start and span_end are the start and end character indices of the token within the text, as it was
+  passed to the raw_text argument. Each outer sequence contains the sequence of tokens for each sample.
+
+>>> token_classification_label = [[('class_1', 0, 2), ('class_2', 7, 10)], [('class_2', 42, 54)], []]
+
+Prediction Format
+~~~~~~~~~~~~~~~~~
+
+* **predictions** - A sequence of sequences, with the inner sequence containing tuples in the following
   format: (class_name, span_start, span_end, class_probability). span_start and span_end are the start and end
   character indices  of the token within the text, as it was passed to the raw_text argument. Each upper level
   sequence contains a sequence of tokens for each sample.
-* probabilities - No probabilities should be passed for Token Classification tasks. Passing probabilities will
+* **probabilities** - No probabilities should be passed for Token Classification tasks. Passing probabilities will
   result in an error.
 
 >>> predictions = [[('class_1', 0, 2, 0.8), ('class_2', 7, 10, 0.9)], [('class_2', 42, 54, 0.4)], []]

--- a/docs/source/user-guide/nlp/supported_tasks.rst
+++ b/docs/source/user-guide/nlp/supported_tasks.rst
@@ -1,0 +1,100 @@
+.. _supported_tasks:
+
+===================================
+Working with Labels and Predictions
+===================================
+
+Some checks, mainly the ones related to model evaluation, require labels and model predictions in order to run.
+In the deepchecks nlp package, predictions are passed into the suite / check ``run`` method as pre-computed
+predictions only (passing a fitted model is currently not supported).
+
+
+.. _supported_task__types:
+
+Supported Task Types
+====================
+
+Deepchecks currently supports two NLP task types:
+
+* **Text Classification**: Text classification is any NLP task in which a whole body of text (ranging from a sentence
+  to a document) is assigned a class (in the binary/multiclass case) or a certain set of classes (in the multilateral
+  case). In both the binary, the multiclass and the multilabel case the class "belongs" / "classifies" the whole text
+  sample. Examples for such tasks are Sentiment Analysis, Topic Extraction, detecting harmful content and more.
+* **Token Classification**: Token Classification is any NLP task in which each word (or to be more accurate, token) in
+  the text sample is assigned a class of it's own. In many cases most tokens will belong to a "background" class,
+  allowing the model to focus on the interesting tokens. Examples for such tasks are Named Entity Recognition, Part
+  of Speach annotation (in which all tokens have a non-background class).
+
+.. _supported_labels__predictions_format:
+
+Supported Labels and Predictions Format
+=======================================
+
+While labels are passed while constructing the :class:`TextData <text_data.TextData>` object, predictions are passed
+separately to the ``run`` method of the check / suite. Labels and predictions must be in the format detailed in this
+section, according the task type.
+
+Label Formats:
+--------------
+
+* **Text Classification** Label - For text classification the accepted label format differs between multilabel and
+  single label cases. For single label data, the label should be passed as a sequence of labels, with one entry
+  per sample that can be either a string or an integer. For multilabel data, the label should be passed as a
+  sequence of sequences, with the sequence for each sample being a binary vector, representing the presence of
+  the i-th label in that sample.
+* **Token Classification** Label - For token classification the accepted label format is a sequence of sequences,
+  with the inner sequence containing tuples in the following format: (class_name, span_start, span_end).
+  span_start and span_end are the start and end character indices of the token within the text, as it was
+  passed to the raw_text argument. Each upper level sequence contains a sequence of tokens for each sample.
+
+>>> text_classification_label_multiclass = [0, 0, 1, 2]
+>>> text_classification_label_multilabel = [[0, 0, 1], [0, 1, 1], [1, 0, 1], [0, 0, 0]]
+>>> token_classification_label = [[('class_1', 0, 2), ('class_2', 7, 10)], [('class_2', 42, 54)], []]
+
+Prediction Formats:
+-------------------
+
+The accepted formats for providing model predictions and probabilities are detailed below
+
+**Text Classification**
+
+*Single Class Predictions*
+
+* predictions - A sequence of class names or indices with one entry per sample, matching the set of classes
+  present in the labels.
+* probabilities - A sequence of sequences with each element containing the vector of class probabilities for
+  each sample. Each such vector should have one probability per class according to the class (sorted) order, and
+  the probabilities should sum to 1 for each sample.
+
+>>> predictions = ['class_1', 'class_1', 'class_2']
+>>> probabilities = [[0.2, 0.8], [0.5, 0.5], [0.3, 0.7]]
+
+*Multilabel Predictions*
+
+* predictions - A sequence of sequences with each element containing a binary vector denoting the presence of
+  the i-th class for the given sample. Each such vector should have one binary indicator per class according to
+  the class (sorted) order. More than one class can be present for each sample.
+* probabilities - A sequence of sequences with each element containing the vector of class probabilities for
+  each sample. Each such vector should have one probability per class according to the class (sorted) order, and
+  the probabilities should range from 0 to 1 for each sample, but are not required to sum to 1.
+
+>>> predictions = [[0, 0, 1], [0, 1, 1]]
+>>> probabilities = [[0.2, 0.3, 0.8], [0.4, 0.9, 0.6]]
+
+**Token Classification**
+
+* predictions - A sequence of sequences, with the inner sequence containing tuples in the following
+  format: (class_name, span_start, span_end, class_probability). span_start and span_end are the start and end
+  character indices  of the token within the text, as it was passed to the raw_text argument. Each upper level
+  sequence contains a sequence of tokens for each sample.
+* probabilities - No probabilities should be passed for Token Classification tasks. Passing probabilities will
+  result in an error.
+
+>>> predictions = [[('class_1', 0, 2, 0.8), ('class_2', 7, 10, 0.9)], [('class_2', 42, 54, 0.4)], []]
+
+..
+    external links to open in new window
+
+.. |sequence| raw:: html
+
+    <a href="https://www.pythontutorial.net/advanced-python/python-sequences/#:~:text=A%20sequence%20is%20a%20positionally,s%5Bn%2D1%5D%20." target="_blank">sequence</a>

--- a/docs/source/user-guide/nlp/supported_tasks.rst
+++ b/docs/source/user-guide/nlp/supported_tasks.rst
@@ -65,7 +65,7 @@ Prediction Format
     labels and the predictions, this matrix must follow the convention that the i-th element represents the class
     probabilities for the class in the i-th position in the sorted array of class names. The sorted array of class names
     is the result of sorting the set of all class names present in the label and prediction, namely
-    ``sorted(set(y_true).union(set(y_pred)))``.
+    ``sorted(list(set(y_true).union(set(y_pred))))``.
 
 Single Class Predictions
 """"""""""""""""""""""""

--- a/docs/source/user-guide/nlp/supported_tasks.rst
+++ b/docs/source/user-guide/nlp/supported_tasks.rst
@@ -9,7 +9,7 @@ In the deepchecks nlp package, predictions are passed into the suite / check ``r
 predictions only (passing a fitted model is currently not supported).
 
 
-.. _supported_task__types:
+.. _nlp_supported_task__types:
 
 Supported Task Types
 ====================
@@ -17,24 +17,23 @@ Supported Task Types
 Deepchecks currently supports two NLP task types:
 
 * **Text Classification**: Text classification is any NLP task in which a whole body of text (ranging from a sentence
-  to a document) is assigned a class (in the binary/multiclass case) or a certain set of classes (in the multilateral
+  to a document) is assigned a class (in the binary/multiclass case) or a certain set of classes (in the multilabel
   case). In both the binary, the multiclass and the multilabel case the class "belongs" / "classifies" the whole text
-  sample. Examples for such tasks are Sentiment Analysis, Topic Extraction, detecting harmful content and more.
+  sample. Examples for such tasks are: Sentiment Analysis, Topic Extraction, harmful content detection and more.
 * **Token Classification**: Token Classification is any NLP task in which each word (or to be more accurate, token) in
-  the text sample is assigned a class of it's own. In many cases most tokens will belong to a "background" class,
-  allowing the model to focus on the interesting tokens. Examples for such tasks are Named Entity Recognition, Part
-  of Speach annotation (in which all tokens have a non-background class).
+  the text sample is assigned a class of its own. In many cases most tokens will belong to a "background" class,
+  allowing the model to focus on the interesting tokens. Examples for such tasks are: Named Entity Recognition, Part-of-speech annotation (in which all tokens have a non-background class).
 
-.. _supported_labels__predictions_format:
+.. _nlp_supported_labels__predictions_format:
 
 Supported Labels and Predictions Format
 =======================================
 
-While labels are passed while constructing the :class:`TextData <text_data.TextData>` object, predictions are passed
+While labels are passed when constructing the :class:`TextData <text_data.TextData>` object, predictions are passed
 separately to the ``run`` method of the check / suite. Labels and predictions must be in the format detailed in this
-section, according the task type.
+section, according to the task type.
 
-Label Formats:
+Label Formats
 --------------
 
 * **Text Classification** Label - For text classification the accepted label format differs between multilabel and
@@ -45,13 +44,13 @@ Label Formats:
 * **Token Classification** Label - For token classification the accepted label format is a sequence of sequences,
   with the inner sequence containing tuples in the following format: (class_name, span_start, span_end).
   span_start and span_end are the start and end character indices of the token within the text, as it was
-  passed to the raw_text argument. Each upper level sequence contains a sequence of tokens for each sample.
+  passed to the raw_text argument. Each outer sequence contains the sequence of tokens for each sample.
 
 >>> text_classification_label_multiclass = [0, 0, 1, 2]
 >>> text_classification_label_multilabel = [[0, 0, 1], [0, 1, 1], [1, 0, 1], [0, 0, 0]]
 >>> token_classification_label = [[('class_1', 0, 2), ('class_2', 7, 10)], [('class_2', 42, 54)], []]
 
-Prediction Formats:
+Prediction Formats
 -------------------
 
 The accepted formats for providing model predictions and probabilities are detailed below

--- a/docs/source/user-guide/nlp/supported_tasks.rst
+++ b/docs/source/user-guide/nlp/supported_tasks.rst
@@ -45,11 +45,27 @@ Label Format
   sequence of sequences, with the sequence for each sample being a binary vector, representing the presence of
   the i-th label in that sample.
 
->>> text_classification_label_multiclass = [0, 0, 1, 2]
+>>> text_classification_label_multiclass = ['class_0', 'class_0', 'class_1', 'class_2']
 >>> text_classification_label_multilabel = [[0, 0, 1], [0, 1, 1], [1, 0, 1], [0, 0, 0]]
+
+.. note::
+
+    For multilabel tasks, in order for deepchecks to use string names for the different classes (rather than just noting
+    the classes id in the label matrix) you may pass a list of the class names to the ``classes`` argument
+    of the :class:`TextData <text_data.TextData>` constructor method. This list of names, having the same length as the
+    number of rows in the label matrix, will be used to name the multilabel classes throughout deepchecks.
 
 Prediction Format
 ~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Class probabilities (and for multilabel tasks, also predictions) are always provided as a matrix of
+    (n_samples, n_classes). In order to understand which column corresponds to each of the class names present in the
+    labels and the predictions, this matrix must follow the convention that the i-th element represents the class
+    probabilities for the class in the i-th position in the sorted array of class names. The sorted array of class names
+    is the result of sorting the set of all class names present in the label and prediction, namely
+    ``sorted(set(y_true).union(set(y_pred)))``.
 
 Single Class Predictions
 """"""""""""""""""""""""
@@ -61,6 +77,7 @@ Single Class Predictions
   the probabilities should sum to 1 for each sample.
 
 >>> predictions = ['class_1', 'class_1', 'class_2']
+>>> # Note that even in the binary case the probability must be specified for each class, as is the case in this example
 >>> probabilities = [[0.2, 0.8], [0.5, 0.5], [0.3, 0.7]]
 
 Multilabel Predictions


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #1971

#### What does this implement/fix? Explain your changes.
Added:

1. API reference for NLP
2. Supported tasks and formats guide
3. Link to both from a new NLP user guide section

#### Any other comments?
Need help with two things that are not working properly:

1. link to TextData at line 33 of supported_tasks.rst isn't working
2. in api reference -> TextData, the docstring for the label argument isn't rendering correctly

The built docs: (remove the .zip extension from z01 and z02 after downloading before unzipping)
[build.z02.zip](https://github.com/deepchecks/deepchecks/files/9524874/build.z02.zip)
[build.z01.zip](https://github.com/deepchecks/deepchecks/files/9524878/build.z01.zip)
[build.zip](https://github.com/deepchecks/deepchecks/files/9524881/build.zip)


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
