### PR TITLE
use deepchecks metrics for precision recall f1

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/single_dataset_performance.py
+++ b/deepchecks/tabular/checks/model_evaluation/single_dataset_performance.py
@@ -56,7 +56,10 @@ class SingleDatasetPerformance(SingleDatasetCheck, ReduceMetricClassMixin):
         results = []
         classes = dataset.classes
         label = cast(pd.Series, dataset.label_col)
-        n_samples = label.groupby(label).count()
+        if context.with_display:
+            n_samples = label.groupby(label).count()
+        else:
+            n_samples = dict(zip(classes, [None] * len(classes)))
         for scorer in scorers:
             scorer_value = scorer(model, dataset)
             if isinstance(scorer_value, Number):

--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -16,11 +16,11 @@ from numbers import Number
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.metrics import (get_scorer, make_scorer, mean_absolute_error, mean_squared_error)
+from sklearn.metrics import get_scorer, make_scorer, mean_absolute_error, mean_squared_error
 from sklearn.metrics._scorer import _BaseScorer, _ProbaScorer
 
 try:
-    from deepchecks_metrics import f1_score, recall_score, precision_score  # noqa: F401
+    from deepchecks_metrics import f1_score, precision_score, recall_score  # noqa: F401
 except ImportError:
     from sklearn.metrics import f1_score, recall_score, precision_score  # noqa: F401  pylint: disable=ungrouped-imports
 

--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -20,9 +20,9 @@ from sklearn.metrics import (get_scorer, make_scorer, mean_absolute_error, mean_
 from sklearn.metrics._scorer import _BaseScorer, _ProbaScorer
 
 try:
-    from deepchecks_metrics import f1_score, recall_score, precision_scpre
+    from deepchecks_metrics import f1_score, recall_score, precision_score  # noqa: F401
 except ImportError:
-    from sklearn.metrics import f1_score, recall_score, precision_score
+    from sklearn.metrics import f1_score, recall_score, precision_score  # noqa: F401  pylint: disable=ungrouped-imports
 
 from deepchecks import tabular  # pylint: disable=unused-import; it is used for type annotations
 from deepchecks.core import errors

--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -16,9 +16,13 @@ from numbers import Number
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.metrics import (f1_score, get_scorer, make_scorer, mean_absolute_error, mean_squared_error,
-                             precision_score, recall_score)
+from sklearn.metrics import (get_scorer, make_scorer, mean_absolute_error, mean_squared_error)
 from sklearn.metrics._scorer import _BaseScorer, _ProbaScorer
+
+try:
+    from deepchecks_metrics import f1_score, recall_score, precision_scpre
+except ImportError:
+    from sklearn.metrics import f1_score, recall_score, precision_score
 
 from deepchecks import tabular  # pylint: disable=unused-import; it is used for type annotations
 from deepchecks.core import errors
@@ -105,9 +109,16 @@ binary_scorers_dict = {
 multiclass_scorers_dict = {
     'accuracy': get_scorer('accuracy'),
     'precision_macro': make_scorer(precision_score, average='macro', zero_division=0),
-    'recall_macro': make_scorer(recall_score, average='macro', zero_division=0),
+    'precision_micro': make_scorer(precision_score, average='micro', zero_division=0),
+    'precision_weighted': make_scorer(precision_score, average='weighted', zero_division=0),
     'precision_per_class': make_scorer(precision_score, average=None, zero_division=0),
+    'recall_macro': make_scorer(recall_score, average='macro', zero_division=0),
+    'recall_micro': make_scorer(recall_score, average='micro', zero_division=0),
+    'recall_weighted': make_scorer(recall_score, average='weighted', zero_division=0),
     'recall_per_class': make_scorer(recall_score, average=None, zero_division=0),
+    'f1_macro': make_scorer(f1_score, average='macro', zero_division=0),
+    'f1_micro': make_scorer(f1_score, average='micro', zero_division=0),
+    'f1_weighted': make_scorer(f1_score, average='weighted', zero_division=0),
     'f1_per_class': make_scorer(f1_score, average=None, zero_division=0),
     'roc_auc_per_class': make_scorer(roc_auc_per_class, needs_proba=True),
     'fpr_per_class': make_scorer(false_positive_rate_metric, averaging_method='per_class'),


### PR DESCRIPTION
#### Reference Issues/PRs

Closes https://github.com/deepchecks/private-issues/issues/73 (For now, we'll probably want to keep improving and extend improvements to other metrics)

#### What does this implement/fix? Explain your changes.
Uses the metrics implemented in https://github.com/deepchecks/deepchecks-metrics to reduce the runtime of precision/recall/f1 by around %60

Does not cover regression metrics and roc_auc for example.

