### PR TITLE
[DOCS] Omit double sentence in property label correlation check examples

### DIFF
--- a/docs/source/checks/vision/data_integrity/plot_property_label_correlation.py
+++ b/docs/source/checks/vision/data_integrity/plot_property_label_correlation.py
@@ -62,11 +62,6 @@ The properties' predictive score results in a numeric score between 0 (feature h
 no predictive power) and 1 (feature can fully predict the label alone).
 
 The process of calculating the PPS is the following:
-
-The properties' predictive score results in a numeric score between 0 (feature has no predictive power) and 1 (feature
-can fully predict the label alone).
-
-The process of calculating the PPS is the following:
 """
 #%%
 # 1. Extract from the data only the label and the feature being tested

--- a/docs/source/checks/vision/train_test_validation/plot_property_label_correlation_change.py
+++ b/docs/source/checks/vision/train_test_validation/plot_property_label_correlation_change.py
@@ -72,10 +72,6 @@ The properties' predictive score results in a numeric score between 0 (feature h
 no predictive power) and 1 (feature can fully predict the label alone).
 
 The process of calculating the PPS is the following:
-
-The properties' predictive score results in a numeric score between 0 (feature has no predictive power) and 1 (feature can fully predict the label alone).
-
-The process of calculating the PPS is the following:
 """
 #%%
 # 1. Extract from the data only the label and the feature being tested


### PR DESCRIPTION
#### Reference Issues/PRs

Bug from feedback from MLOps community

#### What does this implement/fix? Explain your changes.

Remove double text
