### PR TITLE
Default vision properties improvements 

### DIFF
--- a/deepchecks/vision/utils/image_properties.py
+++ b/deepchecks/vision/utils/image_properties.py
@@ -96,7 +96,7 @@ def _rgb_relative_intensity_mean(batch: List[np.ndarray]) -> List[Tuple[float, f
 
 
 def _rgb_relative_intensity_mean_array(batch: List[np.ndarray]) -> np.ndarray:
-    """Returns the _rgb_relative_intensity_mean result as array"""
+    """Return the _rgb_relative_intensity_mean result as array."""
     return np.array(_rgb_relative_intensity_mean(batch))
 
 

--- a/deepchecks/vision/utils/image_properties.py
+++ b/deepchecks/vision/utils/image_properties.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Module containing the image formatter class for the vision module."""
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 import numpy as np
 from skimage.color import rgb2gray
@@ -149,7 +149,6 @@ def calc_default_image_properties(batch: List[np.ndarray]) -> Dict:
     results_dict['Mean Blue Relative Intensity'] = rgb_intensities[:, 2].tolist()
 
     return results_dict
-
 
 
 default_image_properties = [

--- a/deepchecks/vision/utils/label_prediction_properties.py
+++ b/deepchecks/vision/utils/label_prediction_properties.py
@@ -72,8 +72,10 @@ DEFAULT_SEMANTIC_SEGMENTATION_LABEL_PROPERTIES = [
 
 # Predictions
 
-def _get_samples_per_pred_class_classification(predictions: torch.Tensor) -> List[int]:
+def _get_samples_per_pred_class_classification(predictions: Union[torch.Tensor, List]) -> List[int]:
     """Return a list containing the classes in batch."""
+    if isinstance(predictions, List):
+        predictions = torch.stack(predictions)
     return torch.argmax(predictions, dim=1).tolist()
 
 

--- a/deepchecks/vision/utils/label_prediction_properties.py
+++ b/deepchecks/vision/utils/label_prediction_properties.py
@@ -9,16 +9,16 @@
 # ----------------------------------------------------------------------------
 #
 """Module containing measurements for labels and predictions."""
-from typing import List, Sequence
+from typing import List, Sequence, Union
 
 import torch
 
 # Labels
 
 
-def _get_samples_per_class_classification(labels: torch.Tensor) -> List[int]:
+def _get_samples_per_class_classification(labels: Union[torch.Tensor, List]) -> List[int]:
     """Return a list containing the class per image in batch."""
-    return labels.tolist()
+    return labels if isinstance(labels, List) else labels.tolist()
 
 
 def _get_samples_per_class_object_detection(labels: List[torch.Tensor]) -> List[List[int]]:


### PR DESCRIPTION
default label and prediction properties accept a list in addition to the previous tensor only to comply with calc_vision_properties.
Implemented calc_default_image_properties to be used instead of calc_vision_properties on the default image properties to speed up this use case (x2 speedup).
