### PR TITLE
Remove warning

### DIFF
--- a/deepchecks/tabular/checks/data_integrity/mixed_nulls.py
+++ b/deepchecks/tabular/checks/data_integrity/mixed_nulls.py
@@ -116,7 +116,7 @@ class MixedNulls(SingleDatasetCheck):
             else:
                 string_null_counts = {
                     repr(value).replace('\'', '"'): count
-                    for value, count in column_data.value_counts(dropna=True).iteritems()
+                    for value, count in column_data.value_counts(dropna=True).items()
                     if string_baseform(value) in null_string_list
                 }
                 nan_data_counts = column_data[column_data.isna()].apply(nan_type).value_counts().to_dict()

--- a/deepchecks/tabular/checks/train_test_validation/train_test_samples_mix.py
+++ b/deepchecks/tabular/checks/train_test_validation/train_test_samples_mix.py
@@ -179,5 +179,5 @@ def _fillna(
     """Fill nan values."""
     return pd.DataFrame({
         name: (_fillna_col(column, value))
-        for name, column in df.iteritems()
+        for name, column in df.items()
     })

--- a/deepchecks/vision/checks/model_evaluation/robustness_report.py
+++ b/deepchecks/vision/checks/model_evaluation/robustness_report.py
@@ -211,7 +211,7 @@ class RobustnessReport(SingleDatasetCheck):
                 .set_index('Class')
             diff = single_metric_scores.apply(lambda x: calc_percent(x.Value, x.Base), axis=1)
 
-            for index_class, diff_value in diff.sort_values().iloc[:n_classes_to_show].iteritems():
+            for index_class, diff_value in diff.sort_values().iloc[:n_classes_to_show].items():
                 aug_top_affected[metric].append({'class': index_class,
                                                  'value': single_metric_scores.at[index_class, 'Value'],
                                                  'diff': diff_value,


### PR DESCRIPTION
The relevant warning was:
iteritems is deprecated and will be removed in a future version. Use .items instead.
