### PR TITLE
[Fix: 2110] Pass feature_importance_timeout through to feature importance

### DIFF
--- a/deepchecks/core/check_utils/multivariate_drift_utils.py
+++ b/deepchecks/core/check_utils/multivariate_drift_utils.py
@@ -42,7 +42,8 @@ def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.Da
                             max_num_categories_for_display: int, show_categories_by: str,
                             min_meaningful_drift_score: float,
                             with_display: bool,
-                            dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES
+                            dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES,
+                            feature_importance_timeout: int = 120,
                             ):
     """Calculate multivariable drift."""
     train_sample_df = train_dataframe.sample(sample_size, random_state=random_state)[numerical_features + cat_features]
@@ -80,7 +81,7 @@ def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.Da
         force_permutation=True,
         permutation_kwargs={'n_repeats': 10,
                             'random_state': random_state,
-                            'timeout': 120,
+                            'timeout': feature_importance_timeout,
                             'skip_messages': True}
     )
 

--- a/deepchecks/core/check_utils/multivariate_drift_utils.py
+++ b/deepchecks/core/check_utils/multivariate_drift_utils.py
@@ -16,10 +16,8 @@ import pandas as pd
 import plotly.graph_objects as go
 
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from sklearn.experimental import (
-        enable_hist_gradient_boosting,
-    )  # noqa # pylint: disable=unused-import
+    warnings.simplefilter('ignore')
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa # pylint: disable=unused-import
 
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.metrics import roc_auc_score
@@ -27,85 +25,49 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import OrdinalEncoder
 
 from deepchecks.tabular import Dataset
-from deepchecks.tabular.utils.feature_importance import (
-    N_TOP_MESSAGE,
-    calculate_feature_importance_or_none,
-)
+from deepchecks.tabular.utils.feature_importance import N_TOP_MESSAGE, calculate_feature_importance_or_none
 from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.dataframes import floatify_dataframe
 from deepchecks.utils.distribution.drift import get_drift_plot_sidenote
-from deepchecks.utils.distribution.plot import (
-    drift_score_bar_traces,
-    feature_distribution_traces,
-)
+from deepchecks.utils.distribution.plot import drift_score_bar_traces, feature_distribution_traces
 from deepchecks.utils.distribution.rare_category_encoder import RareCategoryEncoder
 from deepchecks.utils.plot import DEFAULT_DATASET_NAMES
 from deepchecks.utils.strings import format_percent
 from deepchecks.utils.typing import Hashable
 
 
-def run_multivariable_drift(
-    train_dataframe: pd.DataFrame,
-    test_dataframe: pd.DataFrame,
-    numerical_features: List[Hashable],
-    cat_features: List[Hashable],
-    sample_size: int,
-    random_state: int,
-    test_size: float,
-    n_top_columns: int,
-    min_feature_importance: float,
-    max_num_categories_for_display: int,
-    show_categories_by: str,
-    min_meaningful_drift_score: float,
-    with_display: bool,
-    dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES,
-    feature_importance_timeout: int = 120,
-):
+def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.DataFrame,
+                            numerical_features: List[Hashable], cat_features: List[Hashable], sample_size: int,
+                            random_state: int, test_size: float, n_top_columns: int, min_feature_importance: float,
+                            max_num_categories_for_display: int, show_categories_by: str,
+                            min_meaningful_drift_score: float,
+                            with_display: bool,
+                            dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES
+                            ):
     """Calculate multivariable drift."""
-    train_sample_df = train_dataframe.sample(sample_size, random_state=random_state)[
-        numerical_features + cat_features
-    ]
-    test_sample_df = test_dataframe.sample(sample_size, random_state=random_state)[
-        numerical_features + cat_features
-    ]
+    train_sample_df = train_dataframe.sample(sample_size, random_state=random_state)[numerical_features + cat_features]
+    test_sample_df = test_dataframe.sample(sample_size, random_state=random_state)[numerical_features + cat_features]
 
     # create new dataset, with label denoting whether sample belongs to test dataset
     domain_class_df = pd.concat([train_sample_df, test_sample_df])
-    domain_class_df[cat_features] = RareCategoryEncoder(254).fit_transform(
-        domain_class_df[cat_features].astype(str)
-    )
-    domain_class_df[cat_features] = OrdinalEncoder().fit_transform(
-        domain_class_df[cat_features].astype(str)
-    )
-    domain_class_labels = pd.Series(
-        [0] * len(train_sample_df) + [1] * len(test_sample_df)
-    )
+    domain_class_df[cat_features] = RareCategoryEncoder(254).fit_transform(domain_class_df[cat_features].astype(str))
+    domain_class_df[cat_features] = OrdinalEncoder().fit_transform(domain_class_df[cat_features].astype(str))
+    domain_class_labels = pd.Series([0] * len(train_sample_df) + [1] * len(test_sample_df))
 
-    x_train, x_test, y_train, y_test = train_test_split(
-        floatify_dataframe(domain_class_df),
-        domain_class_labels,
-        stratify=domain_class_labels,
-        random_state=random_state,
-        test_size=test_size,
-    )
+    x_train, x_test, y_train, y_test = train_test_split(floatify_dataframe(domain_class_df), domain_class_labels,
+                                                        stratify=domain_class_labels,
+                                                        random_state=random_state,
+                                                        test_size=test_size)
 
     # train a model to disguise between train and test samples
-    domain_classifier = HistGradientBoostingClassifier(
-        max_depth=2,
-        max_iter=10,
-        random_state=random_state,
-        categorical_features=[x in cat_features for x in domain_class_df.columns],
-    )
+    domain_classifier = HistGradientBoostingClassifier(max_depth=2, max_iter=10, random_state=random_state,
+                                                       categorical_features=[x in cat_features for x in
+                                                                             domain_class_df.columns])
     domain_classifier.fit(x_train, y_train)
 
-    y_test.name = "belongs_to_test"
-    domain_test_dataset = Dataset(
-        pd.concat(
-            [x_test.reset_index(drop=True), y_test.reset_index(drop=True)], axis=1
-        ),
-        cat_features=cat_features,
-        label="belongs_to_test",
-    )
+    y_test.name = 'belongs_to_test'
+    domain_test_dataset = Dataset(pd.concat([x_test.reset_index(drop=True), y_test.reset_index(drop=True)], axis=1),
+                                  cat_features=cat_features, label='belongs_to_test')
 
     # calculate feature importance of domain_classifier, containing the information which features separate
     # the dataset best.
@@ -116,25 +78,21 @@ def run_multivariable_drift(
         observed_classes=[0, 1],
         task_type=TaskType.BINARY,
         force_permutation=True,
-        permutation_kwargs={
-            "n_repeats": 10,
-            "random_state": random_state,
-            "timeout": feature_importance_timeout,
-            "skip_messages": True,
-        },
+        permutation_kwargs={'n_repeats': 10,
+                            'random_state': random_state,
+                            'timeout': 120,
+                            'skip_messages': True}
     )
 
     fi = fi.sort_values(ascending=False) if fi is not None else None
 
-    domain_classifier_auc = roc_auc_score(
-        y_test, domain_classifier.predict_proba(x_test)[:, 1]
-    )
+    domain_classifier_auc = roc_auc_score(y_test, domain_classifier.predict_proba(x_test)[:, 1])
     drift_score = auc_to_drift_score(domain_classifier_auc)
 
     values_dict = {
-        "domain_classifier_auc": domain_classifier_auc,
-        "domain_classifier_drift_score": drift_score,
-        "domain_classifier_feature_importance": fi.to_dict() if fi is not None else {},
+        'domain_classifier_auc': domain_classifier_auc,
+        'domain_classifier_drift_score': drift_score,
+        'domain_classifier_feature_importance': fi.to_dict() if fi is not None else {},
     }
 
     feature_importance_note = f"""
@@ -151,12 +109,12 @@ def run_multivariable_drift(
         top_fi = None
 
     if top_fi is not None and len(top_fi):
-        score = values_dict["domain_classifier_drift_score"]
+        score = values_dict['domain_classifier_drift_score']
 
         displays = [
             feature_importance_note,
             build_drift_plot(score),
-            "<h3>Main features contributing to drift</h3>",
+            '<h3>Main features contributing to drift</h3>',
             N_TOP_MESSAGE % n_top_columns,
             get_drift_plot_sidenote(max_num_categories_for_display, show_categories_by),
             *(
@@ -167,10 +125,9 @@ def run_multivariable_drift(
                     cat_features,
                     max_num_categories_for_display,
                     show_categories_by,
-                    dataset_names,
-                )
+                    dataset_names)
                 for feature in top_fi.index
-            ),
+            )
         ]
     else:
         displays = None
@@ -192,33 +149,31 @@ def auc_to_drift_score(auc: float) -> float:
 def build_drift_plot(score):
     """Build traffic light drift plot."""
     bar_traces, x_axis, y_axis = drift_score_bar_traces(score)
-    x_axis["title"] = "Drift score"
-    drift_plot = go.Figure(
-        layout=dict(
-            title="Drift Score - Multivariable Total",
-            xaxis=x_axis,
-            yaxis=y_axis,
-            height=200,
-        )
-    )
+    x_axis['title'] = 'Drift score'
+    drift_plot = go.Figure(layout=dict(
+        title='Drift Score - Multivariable Total',
+        xaxis=x_axis,
+        yaxis=y_axis,
+        height=200
+    ))
 
     drift_plot.add_traces(bar_traces)
     return drift_plot
 
 
 def display_dist(
-    train_column: pd.Series,
-    test_column: pd.Series,
-    fi: pd.Series,
-    cat_features: Container[str],
-    max_num_categories: int,
-    show_categories_by: str,
-    dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES,
+        train_column: pd.Series,
+        test_column: pd.Series,
+        fi: pd.Series,
+        cat_features: Container[str],
+        max_num_categories: int,
+        show_categories_by: str,
+        dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES
 ):
     """Create a distribution comparison plot for the given columns."""
-    column_name = train_column.name or ""
+    column_name = train_column.name or ''
     column_fi = fi.loc[column_name]
-    title = f"Feature: {column_name} - Explains {format_percent(column_fi)} of dataset difference"
+    title = f'Feature: {column_name} - Explains {format_percent(column_fi)} of dataset difference'
 
     dist_traces, xaxis_layout, yaxis_layout = feature_distribution_traces(
         train_column.dropna(),
@@ -227,18 +182,20 @@ def display_dist(
         is_categorical=column_name in cat_features,
         max_num_categories=max_num_categories,
         show_categories_by=show_categories_by,
-        dataset_names=dataset_names,
+        dataset_names=dataset_names
     )
 
     fig = go.Figure()
     fig.add_traces(dist_traces)
 
-    return fig.update_layout(
-        go.Layout(
-            title=title,
-            xaxis=xaxis_layout,
-            yaxis=yaxis_layout,
-            legend=dict(title="Dataset", yanchor="top", y=0.9, xanchor="left"),
-            height=300,
-        )
-    )
+    return fig.update_layout(go.Layout(
+        title=title,
+        xaxis=xaxis_layout,
+        yaxis=yaxis_layout,
+        legend=dict(
+            title='Dataset',
+            yanchor='top',
+            y=0.9,
+            xanchor='left'),
+        height=300
+    ))

--- a/deepchecks/core/check_utils/multivariate_drift_utils.py
+++ b/deepchecks/core/check_utils/multivariate_drift_utils.py
@@ -16,8 +16,10 @@ import pandas as pd
 import plotly.graph_objects as go
 
 with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    from sklearn.experimental import enable_hist_gradient_boosting  # noqa # pylint: disable=unused-import
+    warnings.simplefilter("ignore")
+    from sklearn.experimental import (
+        enable_hist_gradient_boosting,
+    )  # noqa # pylint: disable=unused-import
 
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.metrics import roc_auc_score
@@ -25,49 +27,85 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import OrdinalEncoder
 
 from deepchecks.tabular import Dataset
-from deepchecks.tabular.utils.feature_importance import N_TOP_MESSAGE, calculate_feature_importance_or_none
+from deepchecks.tabular.utils.feature_importance import (
+    N_TOP_MESSAGE,
+    calculate_feature_importance_or_none,
+)
 from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.dataframes import floatify_dataframe
 from deepchecks.utils.distribution.drift import get_drift_plot_sidenote
-from deepchecks.utils.distribution.plot import drift_score_bar_traces, feature_distribution_traces
+from deepchecks.utils.distribution.plot import (
+    drift_score_bar_traces,
+    feature_distribution_traces,
+)
 from deepchecks.utils.distribution.rare_category_encoder import RareCategoryEncoder
 from deepchecks.utils.plot import DEFAULT_DATASET_NAMES
 from deepchecks.utils.strings import format_percent
 from deepchecks.utils.typing import Hashable
 
 
-def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.DataFrame,
-                            numerical_features: List[Hashable], cat_features: List[Hashable], sample_size: int,
-                            random_state: int, test_size: float, n_top_columns: int, min_feature_importance: float,
-                            max_num_categories_for_display: int, show_categories_by: str,
-                            min_meaningful_drift_score: float,
-                            with_display: bool,
-                            dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES
-                            ):
+def run_multivariable_drift(
+    train_dataframe: pd.DataFrame,
+    test_dataframe: pd.DataFrame,
+    numerical_features: List[Hashable],
+    cat_features: List[Hashable],
+    sample_size: int,
+    random_state: int,
+    test_size: float,
+    n_top_columns: int,
+    min_feature_importance: float,
+    max_num_categories_for_display: int,
+    show_categories_by: str,
+    min_meaningful_drift_score: float,
+    with_display: bool,
+    dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES,
+    feature_importance_timeout: int = 120,
+):
     """Calculate multivariable drift."""
-    train_sample_df = train_dataframe.sample(sample_size, random_state=random_state)[numerical_features + cat_features]
-    test_sample_df = test_dataframe.sample(sample_size, random_state=random_state)[numerical_features + cat_features]
+    train_sample_df = train_dataframe.sample(sample_size, random_state=random_state)[
+        numerical_features + cat_features
+    ]
+    test_sample_df = test_dataframe.sample(sample_size, random_state=random_state)[
+        numerical_features + cat_features
+    ]
 
     # create new dataset, with label denoting whether sample belongs to test dataset
     domain_class_df = pd.concat([train_sample_df, test_sample_df])
-    domain_class_df[cat_features] = RareCategoryEncoder(254).fit_transform(domain_class_df[cat_features].astype(str))
-    domain_class_df[cat_features] = OrdinalEncoder().fit_transform(domain_class_df[cat_features].astype(str))
-    domain_class_labels = pd.Series([0] * len(train_sample_df) + [1] * len(test_sample_df))
+    domain_class_df[cat_features] = RareCategoryEncoder(254).fit_transform(
+        domain_class_df[cat_features].astype(str)
+    )
+    domain_class_df[cat_features] = OrdinalEncoder().fit_transform(
+        domain_class_df[cat_features].astype(str)
+    )
+    domain_class_labels = pd.Series(
+        [0] * len(train_sample_df) + [1] * len(test_sample_df)
+    )
 
-    x_train, x_test, y_train, y_test = train_test_split(floatify_dataframe(domain_class_df), domain_class_labels,
-                                                        stratify=domain_class_labels,
-                                                        random_state=random_state,
-                                                        test_size=test_size)
+    x_train, x_test, y_train, y_test = train_test_split(
+        floatify_dataframe(domain_class_df),
+        domain_class_labels,
+        stratify=domain_class_labels,
+        random_state=random_state,
+        test_size=test_size,
+    )
 
     # train a model to disguise between train and test samples
-    domain_classifier = HistGradientBoostingClassifier(max_depth=2, max_iter=10, random_state=random_state,
-                                                       categorical_features=[x in cat_features for x in
-                                                                             domain_class_df.columns])
+    domain_classifier = HistGradientBoostingClassifier(
+        max_depth=2,
+        max_iter=10,
+        random_state=random_state,
+        categorical_features=[x in cat_features for x in domain_class_df.columns],
+    )
     domain_classifier.fit(x_train, y_train)
 
-    y_test.name = 'belongs_to_test'
-    domain_test_dataset = Dataset(pd.concat([x_test.reset_index(drop=True), y_test.reset_index(drop=True)], axis=1),
-                                  cat_features=cat_features, label='belongs_to_test')
+    y_test.name = "belongs_to_test"
+    domain_test_dataset = Dataset(
+        pd.concat(
+            [x_test.reset_index(drop=True), y_test.reset_index(drop=True)], axis=1
+        ),
+        cat_features=cat_features,
+        label="belongs_to_test",
+    )
 
     # calculate feature importance of domain_classifier, containing the information which features separate
     # the dataset best.
@@ -78,21 +116,25 @@ def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.Da
         observed_classes=[0, 1],
         task_type=TaskType.BINARY,
         force_permutation=True,
-        permutation_kwargs={'n_repeats': 10,
-                            'random_state': random_state,
-                            'timeout': 120,
-                            'skip_messages': True}
+        permutation_kwargs={
+            "n_repeats": 10,
+            "random_state": random_state,
+            "timeout": feature_importance_timeout,
+            "skip_messages": True,
+        },
     )
 
     fi = fi.sort_values(ascending=False) if fi is not None else None
 
-    domain_classifier_auc = roc_auc_score(y_test, domain_classifier.predict_proba(x_test)[:, 1])
+    domain_classifier_auc = roc_auc_score(
+        y_test, domain_classifier.predict_proba(x_test)[:, 1]
+    )
     drift_score = auc_to_drift_score(domain_classifier_auc)
 
     values_dict = {
-        'domain_classifier_auc': domain_classifier_auc,
-        'domain_classifier_drift_score': drift_score,
-        'domain_classifier_feature_importance': fi.to_dict() if fi is not None else {},
+        "domain_classifier_auc": domain_classifier_auc,
+        "domain_classifier_drift_score": drift_score,
+        "domain_classifier_feature_importance": fi.to_dict() if fi is not None else {},
     }
 
     feature_importance_note = f"""
@@ -109,12 +151,12 @@ def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.Da
         top_fi = None
 
     if top_fi is not None and len(top_fi):
-        score = values_dict['domain_classifier_drift_score']
+        score = values_dict["domain_classifier_drift_score"]
 
         displays = [
             feature_importance_note,
             build_drift_plot(score),
-            '<h3>Main features contributing to drift</h3>',
+            "<h3>Main features contributing to drift</h3>",
             N_TOP_MESSAGE % n_top_columns,
             get_drift_plot_sidenote(max_num_categories_for_display, show_categories_by),
             *(
@@ -125,9 +167,10 @@ def run_multivariable_drift(train_dataframe: pd.DataFrame, test_dataframe: pd.Da
                     cat_features,
                     max_num_categories_for_display,
                     show_categories_by,
-                    dataset_names)
+                    dataset_names,
+                )
                 for feature in top_fi.index
-            )
+            ),
         ]
     else:
         displays = None
@@ -149,31 +192,33 @@ def auc_to_drift_score(auc: float) -> float:
 def build_drift_plot(score):
     """Build traffic light drift plot."""
     bar_traces, x_axis, y_axis = drift_score_bar_traces(score)
-    x_axis['title'] = 'Drift score'
-    drift_plot = go.Figure(layout=dict(
-        title='Drift Score - Multivariable Total',
-        xaxis=x_axis,
-        yaxis=y_axis,
-        height=200
-    ))
+    x_axis["title"] = "Drift score"
+    drift_plot = go.Figure(
+        layout=dict(
+            title="Drift Score - Multivariable Total",
+            xaxis=x_axis,
+            yaxis=y_axis,
+            height=200,
+        )
+    )
 
     drift_plot.add_traces(bar_traces)
     return drift_plot
 
 
 def display_dist(
-        train_column: pd.Series,
-        test_column: pd.Series,
-        fi: pd.Series,
-        cat_features: Container[str],
-        max_num_categories: int,
-        show_categories_by: str,
-        dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES
+    train_column: pd.Series,
+    test_column: pd.Series,
+    fi: pd.Series,
+    cat_features: Container[str],
+    max_num_categories: int,
+    show_categories_by: str,
+    dataset_names: Tuple[str] = DEFAULT_DATASET_NAMES,
 ):
     """Create a distribution comparison plot for the given columns."""
-    column_name = train_column.name or ''
+    column_name = train_column.name or ""
     column_fi = fi.loc[column_name]
-    title = f'Feature: {column_name} - Explains {format_percent(column_fi)} of dataset difference'
+    title = f"Feature: {column_name} - Explains {format_percent(column_fi)} of dataset difference"
 
     dist_traces, xaxis_layout, yaxis_layout = feature_distribution_traces(
         train_column.dropna(),
@@ -182,20 +227,18 @@ def display_dist(
         is_categorical=column_name in cat_features,
         max_num_categories=max_num_categories,
         show_categories_by=show_categories_by,
-        dataset_names=dataset_names
+        dataset_names=dataset_names,
     )
 
     fig = go.Figure()
     fig.add_traces(dist_traces)
 
-    return fig.update_layout(go.Layout(
-        title=title,
-        xaxis=xaxis_layout,
-        yaxis=yaxis_layout,
-        legend=dict(
-            title='Dataset',
-            yanchor='top',
-            y=0.9,
-            xanchor='left'),
-        height=300
-    ))
+    return fig.update_layout(
+        go.Layout(
+            title=title,
+            xaxis=xaxis_layout,
+            yaxis=yaxis_layout,
+            legend=dict(title="Dataset", yanchor="top", y=0.9, xanchor="left"),
+            height=300,
+        )
+    )

--- a/deepchecks/core/errors.py
+++ b/deepchecks/core/errors.py
@@ -60,6 +60,11 @@ class DeepchecksTimeoutError(DeepchecksBaseError):
 
     pass
 
+class DeepchecksSkippedFeatureImportance(DeepchecksBaseError):
+    """Represents a situation when feature importance is skipped."""
+
+    pass
+
 
 class ValidationError(DeepchecksBaseError):
     """Represents more specific case of the ValueError (DeepchecksValueError)."""

--- a/deepchecks/core/errors.py
+++ b/deepchecks/core/errors.py
@@ -60,6 +60,7 @@ class DeepchecksTimeoutError(DeepchecksBaseError):
 
     pass
 
+
 class DeepchecksSkippedFeatureImportance(DeepchecksBaseError):
     """Represents a situation when feature importance is skipped."""
 

--- a/deepchecks/tabular/checks/train_test_validation/multivariate_drift.py
+++ b/deepchecks/tabular/checks/train_test_validation/multivariate_drift.py
@@ -122,7 +122,8 @@ class MultivariateDrift(TrainTestCheck):
             show_categories_by=self.show_categories_by,
             min_meaningful_drift_score=self.min_meaningful_drift_score,
             with_display=context.with_display,
-            dataset_names=(train_dataset.name, test_dataset.name)
+            dataset_names=(train_dataset.name, test_dataset.name),
+            feature_importance_timeout=context.feature_importance_timeout,
         )
 
         if displays:

--- a/deepchecks/tabular/checks/train_test_validation/multivariate_drift.py
+++ b/deepchecks/tabular/checks/train_test_validation/multivariate_drift.py
@@ -122,8 +122,7 @@ class MultivariateDrift(TrainTestCheck):
             show_categories_by=self.show_categories_by,
             min_meaningful_drift_score=self.min_meaningful_drift_score,
             with_display=context.with_display,
-            dataset_names=(train_dataset.name, test_dataset.name),
-            feature_importance_timeout=context.feature_importance_timeout,
+            dataset_names=(train_dataset.name, test_dataset.name)
         )
 
         if displays:

--- a/deepchecks/tabular/context.py
+++ b/deepchecks/tabular/context.py
@@ -311,6 +311,11 @@ class Context:
         return self._feature_importance
 
     @property
+    def feature_importance_timeout(self) -> t.Optional[int]:
+        """Return feature importance timeout."""
+        return self._feature_importance_timeout
+
+    @property
     def feature_importance_type(self) -> t.Optional[str]:
         """Return feature importance type if feature importance is available, else None."""
         # Calling first feature_importance, because _importance_type is assigned only after feature importance is

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -21,36 +21,30 @@ from sklearn.pipeline import Pipeline
 
 from deepchecks import tabular
 from deepchecks.core import errors
-from deepchecks.tabular.metric_utils.scorers import (
-    DeepcheckScorer,
-    get_default_scorers,
-    init_validate_scorers,
-)
+from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer, get_default_scorers, init_validate_scorers
 from deepchecks.tabular.utils.validation import validate_model
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import Hashable
 
 __all__ = [
-    "_calculate_feature_importance",
-    "calculate_feature_importance_or_none",
-    "column_importance_sorter_dict",
-    "column_importance_sorter_df",
-    "N_TOP_MESSAGE",
+    '_calculate_feature_importance',
+    'calculate_feature_importance_or_none',
+    'column_importance_sorter_dict',
+    'column_importance_sorter_df',
+    'N_TOP_MESSAGE'
 ]
 
-N_TOP_MESSAGE = (
-    "Showing only the top %s columns, you can change it using n_top_columns param"
-)
+N_TOP_MESSAGE = 'Showing only the top %s columns, you can change it using n_top_columns param'
 
 
 def calculate_feature_importance_or_none(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
-    model_classes,
-    observed_classes,
-    task_type,
-    force_permutation: bool = False,
-    permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+        model_classes,
+        observed_classes,
+        task_type,
+        force_permutation: bool = False,
+        permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Calculate features effect on the label or None if the input is incorrect.
 
@@ -94,12 +88,12 @@ def calculate_feature_importance_or_none(
 
         return fi, calculation_type
     except (
-        errors.DeepchecksValueError,
-        errors.NumberOfFeaturesLimitError,
-        errors.DeepchecksTimeoutError,
-        errors.ModelValidationError,
-        errors.DatasetValidationError,
-        errors.DeepchecksSkippedFeatureImportance,
+            errors.DeepchecksValueError,
+            errors.NumberOfFeaturesLimitError,
+            errors.DeepchecksTimeoutError,
+            errors.ModelValidationError,
+            errors.DatasetValidationError,
+            errors.DeepchecksSkippedFeatureImportance
     ) as error:
         # DeepchecksValueError:
         #     if model validation failed;
@@ -111,18 +105,18 @@ def calculate_feature_importance_or_none(
         # ModelValidationError:
         #     if wrong type of model was provided;
         #     if function failed to predict on model;
-        get_logger().warning("Features importance was not calculated:\n%s", error)
+        get_logger().warning('Features importance was not calculated:\n%s', error)
         return None, None
 
 
 def _calculate_feature_importance(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
-    model_classes,
-    observed_classes,
-    task_type,
-    force_permutation: bool = False,
-    permutation_kwargs: t.Dict[str, t.Any] = None,
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+        model_classes,
+        observed_classes,
+        task_type,
+        force_permutation: bool = False,
+        permutation_kwargs: t.Dict[str, t.Any] = None,
 ) -> t.Tuple[pd.Series, str]:
     """Calculate features effect on the label.
 
@@ -161,7 +155,7 @@ def _calculate_feature_importance(
         if the number of features limit were exceeded.
     """
     permutation_kwargs = permutation_kwargs or {}
-    permutation_kwargs["random_state"] = permutation_kwargs.get("random_state", 42)
+    permutation_kwargs['random_state'] = permutation_kwargs.get('random_state', 42)
     validate_model(dataset, model)
     permutation_failure = None
     calc_type = None
@@ -169,21 +163,13 @@ def _calculate_feature_importance(
 
     if force_permutation:
         if isinstance(dataset, pd.DataFrame):
-            raise errors.DeepchecksValueError(
-                "Cannot calculate permutation feature importance on a pandas Dataframe. "
-                "In order to force permutation feature importance, please use the Dataset"
-                " object."
-            )
+            raise errors.DeepchecksValueError('Cannot calculate permutation feature importance on a pandas Dataframe. '
+                                              'In order to force permutation feature importance, please use the Dataset'
+                                              ' object.')
         else:
-            importance = _calc_permutation_importance(
-                model,
-                dataset,
-                model_classes,
-                observed_classes,
-                task_type,
-                **permutation_kwargs,
-            )
-            calc_type = "permutation_importance"
+            importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
+                                                      task_type, **permutation_kwargs)
+            calc_type = 'permutation_importance'
 
     # If there was no force permutation, or if it failed while trying to calculate importance,
     # we don't take built-in importance in pipelines because the pipeline is changing the features
@@ -197,82 +183,61 @@ def _calculate_feature_importance(
             get_logger().warning(permutation_failure)
 
     # If there was no permutation failure and no importance on the model, using permutation anyway
-    if (
-        importance is None
-        and permutation_failure is None
-        and isinstance(dataset, tabular.Dataset)
-    ):
-        if not permutation_kwargs.get("skip_messages", False):
+    if importance is None and permutation_failure is None and isinstance(dataset, tabular.Dataset):
+        if not permutation_kwargs.get('skip_messages', False):
             if isinstance(model, Pipeline):
-                pre_text = "Cannot use model's built-in feature importance on a Scikit-learn Pipeline,"
+                pre_text = 'Cannot use model\'s built-in feature importance on a Scikit-learn Pipeline,'
             else:
-                pre_text = "Could not find built-in feature importance on the model,"
-            get_logger().warning(
-                "%s using permutation feature importance calculation instead", pre_text
-            )
+                pre_text = 'Could not find built-in feature importance on the model,'
+            get_logger().warning('%s using permutation feature importance calculation instead', pre_text)
 
-        importance = _calc_permutation_importance(
-            model,
-            dataset,
-            model_classes,
-            observed_classes,
-            task_type,
-            **permutation_kwargs,
-        )
-        calc_type = "permutation_importance"
+        importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
+                                                  task_type, **permutation_kwargs)
+        calc_type = 'permutation_importance'
 
     # If after all importance is still none raise error
     if importance is None:
         # FIXME: better message
-        raise errors.DeepchecksValueError(
-            "Was not able to calculate features importance"
-        )
+        raise errors.DeepchecksValueError('Was not able to calculate features importance')
     return importance.fillna(0), calc_type
 
 
 def _built_in_importance(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Get feature importance member if present in model."""
-    features = (
-        dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
-    )
+    features = dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
 
-    if hasattr(model, "feature_importances_"):  # Ensembles
+    if hasattr(model, 'feature_importances_'):  # Ensembles
         if model.feature_importances_ is None:
             return None, None
-        normalized_feature_importance_values = (
-            model.feature_importances_ / model.feature_importances_.sum()
-        )
-        return (
-            pd.Series(normalized_feature_importance_values, index=features),
-            "feature_importances_",
-        )
+        normalized_feature_importance_values = model.feature_importances_ / model.feature_importances_.sum()
+        return pd.Series(normalized_feature_importance_values, index=features), 'feature_importances_'
 
-    if hasattr(model, "coef_"):  # Linear models
+    if hasattr(model, 'coef_'):  # Linear models
         if model.coef_ is None:
             return None, None
         coef = np.abs(model.coef_.flatten())
         coef = coef / coef.sum()
-        return pd.Series(coef, index=features), "coef_"
+        return pd.Series(coef, index=features), 'coef_'
 
     return None, None
 
 
 def _calc_permutation_importance(
-    model: t.Any,
-    dataset: "tabular.Dataset",
-    model_classes,
-    observed_classes,
-    task_type,
-    n_repeats: int = 30,
-    mask_high_variance_features: bool = False,
-    random_state: int = 42,
-    n_samples: int = 10_000,
-    alternative_scorer: t.Optional[DeepcheckScorer] = None,
-    skip_messages: bool = False,
-    timeout: int = None,
+        model: t.Any,
+        dataset: 'tabular.Dataset',
+        model_classes,
+        observed_classes,
+        task_type,
+        n_repeats: int = 30,
+        mask_high_variance_features: bool = False,
+        random_state: int = 42,
+        n_samples: int = 10_000,
+        alternative_scorer: t.Optional[DeepcheckScorer] = None,
+        skip_messages: bool = False,
+        timeout: int = None,
 ) -> pd.Series:
     """Calculate permutation feature importance. Return nonzero value only when std doesn't mask signal.
 
@@ -315,14 +280,12 @@ def _calc_permutation_importance(
         feature importance normalized to 0-1 indexed by feature names
     """
     if not dataset.has_label():
-        raise errors.DatasetValidationError("Expected dataset with label.")
+        raise errors.DatasetValidationError('Expected dataset with label.')
 
     if len(dataset.features) == 1:
         return pd.Series([1], index=dataset.features)
 
-    dataset_sample = dataset.sample(
-        n_samples, drop_na_label=True, random_state=random_state
-    )
+    dataset_sample = dataset.sample(n_samples, drop_na_label=True, random_state=random_state)
 
     # Test score time on the dataset sample
     if alternative_scorer:
@@ -331,39 +294,28 @@ def _calc_permutation_importance(
         default_scorers = get_default_scorers(task_type)
         scorer_name = next(iter(default_scorers))
         single_scorer_dict = {scorer_name: default_scorers[scorer_name]}
-        scorer = init_validate_scorers(
-            single_scorer_dict, model, dataset, model_classes, observed_classes
-        )[0]
+        scorer = init_validate_scorers(single_scorer_dict, model, dataset, model_classes, observed_classes)[0]
 
     start_time = time.time()
     scorer(model, dataset_sample)
     calc_time = time.time() - start_time
 
-    predicted_time_to_run = (
-        int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
-    )
+    predicted_time_to_run = int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
 
     if timeout is not None:
         if predicted_time_to_run > timeout:
             raise errors.DeepchecksTimeoutError(
-                f"Skipping permutation importance calculation: calculation was projected to finish in "
-                f"{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds"
-            )
+                f'Skipping permutation importance calculation: calculation was projected to finish in '
+                f'{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds')
         elif not skip_messages:
-            get_logger().info(
-                "Calculating permutation feature importance. Expected to finish in %s seconds",
-                predicted_time_to_run,
-            )
+            get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
+                              predicted_time_to_run)
     elif timeout == 0 and not skip_messages:
-        raise errors.DeepchecksSkippedFeatureImportance(
-            "feature_importance_timeout set to 0. Skipping any feature importance calculation."
-        )
+            raise errors.DeepchecksSkippedFeatureImportance(
+                "feature_importance_timeout set to 0. Skipping any feature importance calculation.")
     elif not skip_messages:
-        get_logger().warning(
-            "Calculating permutation feature importance without time limit. Expected to finish in "
-            "%s seconds",
-            predicted_time_to_run,
-        )
+        get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
+                             '%s seconds', predicted_time_to_run)
 
     r = permutation_importance(
         model,
@@ -372,7 +324,7 @@ def _calc_permutation_importance(
         n_repeats=n_repeats,
         random_state=random_state,
         n_jobs=-1,
-        scoring=scorer.scorer,
+        scoring=scorer.scorer
     )
 
     significance_mask = (
@@ -390,9 +342,7 @@ def _calc_permutation_importance(
     return pd.Series(feature_importance, index=dataset.features)
 
 
-def get_importance(
-    name: str, feature_importances: pd.Series, ds: "tabular.Dataset"
-) -> int:
+def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Dataset') -> int:
     """Return importance based on feature importance or label/date/index first."""
     if name in feature_importances.keys():
         return feature_importances[name]
@@ -404,10 +354,10 @@ def get_importance(
 
 
 def column_importance_sorter_dict(
-    cols_dict: t.Dict[Hashable, t.Any],
-    dataset: "tabular.Dataset",
-    feature_importances: t.Optional[pd.Series] = None,
-    n_top: int = 10,
+        cols_dict: t.Dict[Hashable, t.Any],
+        dataset: 'tabular.Dataset',
+        feature_importances: t.Optional[pd.Series] = None,
+        n_top: int = 10
 ) -> t.Dict:
     """Return the dict of columns sorted and limited by feature importance.
 
@@ -439,11 +389,11 @@ def column_importance_sorter_dict(
 
 
 def column_importance_sorter_df(
-    df: pd.DataFrame,
-    ds: "tabular.Dataset",
-    feature_importances: pd.Series,
-    n_top: int = 10,
-    col: t.Optional[Hashable] = None,
+        df: pd.DataFrame,
+        ds: 'tabular.Dataset',
+        feature_importances: pd.Series,
+        n_top: int = 10,
+        col: t.Optional[Hashable] = None
 ) -> pd.DataFrame:
     """Return the dataframe of columns sorted and limited by feature importance.
 

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -355,8 +355,7 @@ def _calc_permutation_importance(
             )
     elif timeout == 0 and not skip_messages:
         raise errors.DeepchecksNotImplementedError(
-            "Timeout of 0 is not supported as feature importance is needed. "
-            "Try setting timeout to None for unlimited time."
+            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time."
         )
     elif not skip_messages:
         get_logger().warning(

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -21,30 +21,36 @@ from sklearn.pipeline import Pipeline
 
 from deepchecks import tabular
 from deepchecks.core import errors
-from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer, get_default_scorers, init_validate_scorers
+from deepchecks.tabular.metric_utils.scorers import (
+    DeepcheckScorer,
+    get_default_scorers,
+    init_validate_scorers,
+)
 from deepchecks.tabular.utils.validation import validate_model
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import Hashable
 
 __all__ = [
-    '_calculate_feature_importance',
-    'calculate_feature_importance_or_none',
-    'column_importance_sorter_dict',
-    'column_importance_sorter_df',
-    'N_TOP_MESSAGE'
+    "_calculate_feature_importance",
+    "calculate_feature_importance_or_none",
+    "column_importance_sorter_dict",
+    "column_importance_sorter_df",
+    "N_TOP_MESSAGE",
 ]
 
-N_TOP_MESSAGE = 'Showing only the top %s columns, you can change it using n_top_columns param'
+N_TOP_MESSAGE = (
+    "Showing only the top %s columns, you can change it using n_top_columns param"
+)
 
 
 def calculate_feature_importance_or_none(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
-        model_classes,
-        observed_classes,
-        task_type,
-        force_permutation: bool = False,
-        permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+    model_classes,
+    observed_classes,
+    task_type,
+    force_permutation: bool = False,
+    permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Calculate features effect on the label or None if the input is incorrect.
 
@@ -88,12 +94,12 @@ def calculate_feature_importance_or_none(
 
         return fi, calculation_type
     except (
-            errors.DeepchecksValueError,
-            errors.NumberOfFeaturesLimitError,
-            errors.DeepchecksTimeoutError,
-            errors.ModelValidationError,
-            errors.DatasetValidationError,
-            errors.DeepchecksSkippedFeatureImportance
+        errors.DeepchecksValueError,
+        errors.NumberOfFeaturesLimitError,
+        errors.DeepchecksTimeoutError,
+        errors.ModelValidationError,
+        errors.DatasetValidationError,
+        errors.DeepchecksSkippedFeatureImportance,
     ) as error:
         # DeepchecksValueError:
         #     if model validation failed;
@@ -105,18 +111,18 @@ def calculate_feature_importance_or_none(
         # ModelValidationError:
         #     if wrong type of model was provided;
         #     if function failed to predict on model;
-        get_logger().warning('Features importance was not calculated:\n%s', error)
+        get_logger().warning("Features importance was not calculated:\n%s", error)
         return None, None
 
 
 def _calculate_feature_importance(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
-        model_classes,
-        observed_classes,
-        task_type,
-        force_permutation: bool = False,
-        permutation_kwargs: t.Dict[str, t.Any] = None,
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+    model_classes,
+    observed_classes,
+    task_type,
+    force_permutation: bool = False,
+    permutation_kwargs: t.Dict[str, t.Any] = None,
 ) -> t.Tuple[pd.Series, str]:
     """Calculate features effect on the label.
 
@@ -155,7 +161,7 @@ def _calculate_feature_importance(
         if the number of features limit were exceeded.
     """
     permutation_kwargs = permutation_kwargs or {}
-    permutation_kwargs['random_state'] = permutation_kwargs.get('random_state', 42)
+    permutation_kwargs["random_state"] = permutation_kwargs.get("random_state", 42)
     validate_model(dataset, model)
     permutation_failure = None
     calc_type = None
@@ -163,13 +169,21 @@ def _calculate_feature_importance(
 
     if force_permutation:
         if isinstance(dataset, pd.DataFrame):
-            raise errors.DeepchecksValueError('Cannot calculate permutation feature importance on a pandas Dataframe. '
-                                              'In order to force permutation feature importance, please use the Dataset'
-                                              ' object.')
+            raise errors.DeepchecksValueError(
+                "Cannot calculate permutation feature importance on a pandas Dataframe. "
+                "In order to force permutation feature importance, please use the Dataset"
+                " object."
+            )
         else:
-            importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
-                                                      task_type, **permutation_kwargs)
-            calc_type = 'permutation_importance'
+            importance = _calc_permutation_importance(
+                model,
+                dataset,
+                model_classes,
+                observed_classes,
+                task_type,
+                **permutation_kwargs,
+            )
+            calc_type = "permutation_importance"
 
     # If there was no force permutation, or if it failed while trying to calculate importance,
     # we don't take built-in importance in pipelines because the pipeline is changing the features
@@ -183,61 +197,82 @@ def _calculate_feature_importance(
             get_logger().warning(permutation_failure)
 
     # If there was no permutation failure and no importance on the model, using permutation anyway
-    if importance is None and permutation_failure is None and isinstance(dataset, tabular.Dataset):
-        if not permutation_kwargs.get('skip_messages', False):
+    if (
+        importance is None
+        and permutation_failure is None
+        and isinstance(dataset, tabular.Dataset)
+    ):
+        if not permutation_kwargs.get("skip_messages", False):
             if isinstance(model, Pipeline):
-                pre_text = 'Cannot use model\'s built-in feature importance on a Scikit-learn Pipeline,'
+                pre_text = "Cannot use model's built-in feature importance on a Scikit-learn Pipeline,"
             else:
-                pre_text = 'Could not find built-in feature importance on the model,'
-            get_logger().warning('%s using permutation feature importance calculation instead', pre_text)
+                pre_text = "Could not find built-in feature importance on the model,"
+            get_logger().warning(
+                "%s using permutation feature importance calculation instead", pre_text
+            )
 
-        importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
-                                                  task_type, **permutation_kwargs)
-        calc_type = 'permutation_importance'
+        importance = _calc_permutation_importance(
+            model,
+            dataset,
+            model_classes,
+            observed_classes,
+            task_type,
+            **permutation_kwargs,
+        )
+        calc_type = "permutation_importance"
 
     # If after all importance is still none raise error
     if importance is None:
         # FIXME: better message
-        raise errors.DeepchecksValueError('Was not able to calculate features importance')
+        raise errors.DeepchecksValueError(
+            "Was not able to calculate features importance"
+        )
     return importance.fillna(0), calc_type
 
 
 def _built_in_importance(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Get feature importance member if present in model."""
-    features = dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
+    features = (
+        dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
+    )
 
-    if hasattr(model, 'feature_importances_'):  # Ensembles
+    if hasattr(model, "feature_importances_"):  # Ensembles
         if model.feature_importances_ is None:
             return None, None
-        normalized_feature_importance_values = model.feature_importances_ / model.feature_importances_.sum()
-        return pd.Series(normalized_feature_importance_values, index=features), 'feature_importances_'
+        normalized_feature_importance_values = (
+            model.feature_importances_ / model.feature_importances_.sum()
+        )
+        return (
+            pd.Series(normalized_feature_importance_values, index=features),
+            "feature_importances_",
+        )
 
-    if hasattr(model, 'coef_'):  # Linear models
+    if hasattr(model, "coef_"):  # Linear models
         if model.coef_ is None:
             return None, None
         coef = np.abs(model.coef_.flatten())
         coef = coef / coef.sum()
-        return pd.Series(coef, index=features), 'coef_'
+        return pd.Series(coef, index=features), "coef_"
 
     return None, None
 
 
 def _calc_permutation_importance(
-        model: t.Any,
-        dataset: 'tabular.Dataset',
-        model_classes,
-        observed_classes,
-        task_type,
-        n_repeats: int = 30,
-        mask_high_variance_features: bool = False,
-        random_state: int = 42,
-        n_samples: int = 10_000,
-        alternative_scorer: t.Optional[DeepcheckScorer] = None,
-        skip_messages: bool = False,
-        timeout: int = None,
+    model: t.Any,
+    dataset: "tabular.Dataset",
+    model_classes,
+    observed_classes,
+    task_type,
+    n_repeats: int = 30,
+    mask_high_variance_features: bool = False,
+    random_state: int = 42,
+    n_samples: int = 10_000,
+    alternative_scorer: t.Optional[DeepcheckScorer] = None,
+    skip_messages: bool = False,
+    timeout: int = None,
 ) -> pd.Series:
     """Calculate permutation feature importance. Return nonzero value only when std doesn't mask signal.
 
@@ -280,12 +315,14 @@ def _calc_permutation_importance(
         feature importance normalized to 0-1 indexed by feature names
     """
     if not dataset.has_label():
-        raise errors.DatasetValidationError('Expected dataset with label.')
+        raise errors.DatasetValidationError("Expected dataset with label.")
 
     if len(dataset.features) == 1:
         return pd.Series([1], index=dataset.features)
 
-    dataset_sample = dataset.sample(n_samples, drop_na_label=True, random_state=random_state)
+    dataset_sample = dataset.sample(
+        n_samples, drop_na_label=True, random_state=random_state
+    )
 
     # Test score time on the dataset sample
     if alternative_scorer:
@@ -294,28 +331,39 @@ def _calc_permutation_importance(
         default_scorers = get_default_scorers(task_type)
         scorer_name = next(iter(default_scorers))
         single_scorer_dict = {scorer_name: default_scorers[scorer_name]}
-        scorer = init_validate_scorers(single_scorer_dict, model, dataset, model_classes, observed_classes)[0]
+        scorer = init_validate_scorers(
+            single_scorer_dict, model, dataset, model_classes, observed_classes
+        )[0]
 
     start_time = time.time()
     scorer(model, dataset_sample)
     calc_time = time.time() - start_time
 
-    predicted_time_to_run = int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
+    predicted_time_to_run = (
+        int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
+    )
 
     if timeout is not None:
         if predicted_time_to_run > timeout:
             raise errors.DeepchecksTimeoutError(
-                f'Skipping permutation importance calculation: calculation was projected to finish in '
-                f'{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds')
+                f"Skipping permutation importance calculation: calculation was projected to finish in "
+                f"{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds"
+            )
         elif not skip_messages:
-            get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
-                              predicted_time_to_run)
+            get_logger().info(
+                "Calculating permutation feature importance. Expected to finish in %s seconds",
+                predicted_time_to_run,
+            )
     elif timeout == 0 and not skip_messages:
-            raise errors.DeepchecksSkippedFeatureImportance(
-                "feature_importance_timeout set to 0. Skipping any feature importance calculation.")
+        raise errors.DeepchecksSkippedFeatureImportance(
+            "feature_importance_timeout set to 0. Skipping any feature importance calculation."
+        )
     elif not skip_messages:
-        get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
-                             '%s seconds', predicted_time_to_run)
+        get_logger().warning(
+            "Calculating permutation feature importance without time limit. Expected to finish in "
+            "%s seconds",
+            predicted_time_to_run,
+        )
 
     r = permutation_importance(
         model,
@@ -324,7 +372,7 @@ def _calc_permutation_importance(
         n_repeats=n_repeats,
         random_state=random_state,
         n_jobs=-1,
-        scoring=scorer.scorer
+        scoring=scorer.scorer,
     )
 
     significance_mask = (
@@ -342,7 +390,9 @@ def _calc_permutation_importance(
     return pd.Series(feature_importance, index=dataset.features)
 
 
-def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Dataset') -> int:
+def get_importance(
+    name: str, feature_importances: pd.Series, ds: "tabular.Dataset"
+) -> int:
     """Return importance based on feature importance or label/date/index first."""
     if name in feature_importances.keys():
         return feature_importances[name]
@@ -354,10 +404,10 @@ def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Datas
 
 
 def column_importance_sorter_dict(
-        cols_dict: t.Dict[Hashable, t.Any],
-        dataset: 'tabular.Dataset',
-        feature_importances: t.Optional[pd.Series] = None,
-        n_top: int = 10
+    cols_dict: t.Dict[Hashable, t.Any],
+    dataset: "tabular.Dataset",
+    feature_importances: t.Optional[pd.Series] = None,
+    n_top: int = 10,
 ) -> t.Dict:
     """Return the dict of columns sorted and limited by feature importance.
 
@@ -389,11 +439,11 @@ def column_importance_sorter_dict(
 
 
 def column_importance_sorter_df(
-        df: pd.DataFrame,
-        ds: 'tabular.Dataset',
-        feature_importances: pd.Series,
-        n_top: int = 10,
-        col: t.Optional[Hashable] = None
+    df: pd.DataFrame,
+    ds: "tabular.Dataset",
+    feature_importances: pd.Series,
+    n_top: int = 10,
+    col: t.Optional[Hashable] = None,
 ) -> pd.DataFrame:
     """Return the dataframe of columns sorted and limited by feature importance.
 

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -311,8 +311,8 @@ def _calc_permutation_importance(
             get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
                               predicted_time_to_run)
     elif timeout == 0 and not skip_messages:
-            raise errors.DeepchecksSkippedFeatureImportance(
-                "feature_importance_timeout set to 0. Skipping any feature importance calculation.")
+        raise errors.DeepchecksSkippedFeatureImportance(
+            'feature_importance_timeout set to 0. Skipping any feature importance calculation.')
     elif not skip_messages:
         get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
                              '%s seconds', predicted_time_to_run)

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -92,7 +92,8 @@ def calculate_feature_importance_or_none(
             errors.NumberOfFeaturesLimitError,
             errors.DeepchecksTimeoutError,
             errors.ModelValidationError,
-            errors.DatasetValidationError
+            errors.DatasetValidationError,
+            errors.DeepchecksSkippedFeatureImportance
     ) as error:
         # DeepchecksValueError:
         #     if model validation failed;
@@ -310,10 +311,8 @@ def _calc_permutation_importance(
             get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
                               predicted_time_to_run)
     elif timeout == 0 and not skip_messages:
-            raise errors.DeepchecksNotImplementedError(
-                "Timeout of 0 is not supported as feature importance is needed. "
-                "Try setting timeout to None for unlimited time."
-            )
+            raise errors.DeepchecksSkippedFeatureImportance(
+                "feature_importance_timeout set to 0. Skipping any feature importance calculation.")
     elif not skip_messages:
         get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
                              '%s seconds', predicted_time_to_run)

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -355,7 +355,8 @@ def _calc_permutation_importance(
             )
     elif timeout == 0 and not skip_messages:
         raise errors.DeepchecksNotImplementedError(
-            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time."
+            "Timeout of 0 is not supported as feature importance is needed. "
+            "Try setting timeout to None for unlimited time."
         )
     elif not skip_messages:
         get_logger().warning(

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -21,36 +21,30 @@ from sklearn.pipeline import Pipeline
 
 from deepchecks import tabular
 from deepchecks.core import errors
-from deepchecks.tabular.metric_utils.scorers import (
-    DeepcheckScorer,
-    get_default_scorers,
-    init_validate_scorers,
-)
+from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer, get_default_scorers, init_validate_scorers
 from deepchecks.tabular.utils.validation import validate_model
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import Hashable
 
 __all__ = [
-    "_calculate_feature_importance",
-    "calculate_feature_importance_or_none",
-    "column_importance_sorter_dict",
-    "column_importance_sorter_df",
-    "N_TOP_MESSAGE",
+    '_calculate_feature_importance',
+    'calculate_feature_importance_or_none',
+    'column_importance_sorter_dict',
+    'column_importance_sorter_df',
+    'N_TOP_MESSAGE'
 ]
 
-N_TOP_MESSAGE = (
-    "Showing only the top %s columns, you can change it using n_top_columns param"
-)
+N_TOP_MESSAGE = 'Showing only the top %s columns, you can change it using n_top_columns param'
 
 
 def calculate_feature_importance_or_none(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
-    model_classes,
-    observed_classes,
-    task_type,
-    force_permutation: bool = False,
-    permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+        model_classes,
+        observed_classes,
+        task_type,
+        force_permutation: bool = False,
+        permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Calculate features effect on the label or None if the input is incorrect.
 
@@ -94,11 +88,11 @@ def calculate_feature_importance_or_none(
 
         return fi, calculation_type
     except (
-        errors.DeepchecksValueError,
-        errors.NumberOfFeaturesLimitError,
-        errors.DeepchecksTimeoutError,
-        errors.ModelValidationError,
-        errors.DatasetValidationError,
+            errors.DeepchecksValueError,
+            errors.NumberOfFeaturesLimitError,
+            errors.DeepchecksTimeoutError,
+            errors.ModelValidationError,
+            errors.DatasetValidationError
     ) as error:
         # DeepchecksValueError:
         #     if model validation failed;
@@ -110,18 +104,18 @@ def calculate_feature_importance_or_none(
         # ModelValidationError:
         #     if wrong type of model was provided;
         #     if function failed to predict on model;
-        get_logger().warning("Features importance was not calculated:\n%s", error)
+        get_logger().warning('Features importance was not calculated:\n%s', error)
         return None, None
 
 
 def _calculate_feature_importance(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
-    model_classes,
-    observed_classes,
-    task_type,
-    force_permutation: bool = False,
-    permutation_kwargs: t.Dict[str, t.Any] = None,
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+        model_classes,
+        observed_classes,
+        task_type,
+        force_permutation: bool = False,
+        permutation_kwargs: t.Dict[str, t.Any] = None,
 ) -> t.Tuple[pd.Series, str]:
     """Calculate features effect on the label.
 
@@ -160,7 +154,7 @@ def _calculate_feature_importance(
         if the number of features limit were exceeded.
     """
     permutation_kwargs = permutation_kwargs or {}
-    permutation_kwargs["random_state"] = permutation_kwargs.get("random_state", 42)
+    permutation_kwargs['random_state'] = permutation_kwargs.get('random_state', 42)
     validate_model(dataset, model)
     permutation_failure = None
     calc_type = None
@@ -168,21 +162,13 @@ def _calculate_feature_importance(
 
     if force_permutation:
         if isinstance(dataset, pd.DataFrame):
-            raise errors.DeepchecksValueError(
-                "Cannot calculate permutation feature importance on a pandas Dataframe. "
-                "In order to force permutation feature importance, please use the Dataset"
-                " object."
-            )
+            raise errors.DeepchecksValueError('Cannot calculate permutation feature importance on a pandas Dataframe. '
+                                              'In order to force permutation feature importance, please use the Dataset'
+                                              ' object.')
         else:
-            importance = _calc_permutation_importance(
-                model,
-                dataset,
-                model_classes,
-                observed_classes,
-                task_type,
-                **permutation_kwargs,
-            )
-            calc_type = "permutation_importance"
+            importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
+                                                      task_type, **permutation_kwargs)
+            calc_type = 'permutation_importance'
 
     # If there was no force permutation, or if it failed while trying to calculate importance,
     # we don't take built-in importance in pipelines because the pipeline is changing the features
@@ -196,82 +182,61 @@ def _calculate_feature_importance(
             get_logger().warning(permutation_failure)
 
     # If there was no permutation failure and no importance on the model, using permutation anyway
-    if (
-        importance is None
-        and permutation_failure is None
-        and isinstance(dataset, tabular.Dataset)
-    ):
-        if not permutation_kwargs.get("skip_messages", False):
+    if importance is None and permutation_failure is None and isinstance(dataset, tabular.Dataset):
+        if not permutation_kwargs.get('skip_messages', False):
             if isinstance(model, Pipeline):
-                pre_text = "Cannot use model's built-in feature importance on a Scikit-learn Pipeline,"
+                pre_text = 'Cannot use model\'s built-in feature importance on a Scikit-learn Pipeline,'
             else:
-                pre_text = "Could not find built-in feature importance on the model,"
-            get_logger().warning(
-                "%s using permutation feature importance calculation instead", pre_text
-            )
+                pre_text = 'Could not find built-in feature importance on the model,'
+            get_logger().warning('%s using permutation feature importance calculation instead', pre_text)
 
-        importance = _calc_permutation_importance(
-            model,
-            dataset,
-            model_classes,
-            observed_classes,
-            task_type,
-            **permutation_kwargs,
-        )
-        calc_type = "permutation_importance"
+        importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
+                                                  task_type, **permutation_kwargs)
+        calc_type = 'permutation_importance'
 
     # If after all importance is still none raise error
     if importance is None:
         # FIXME: better message
-        raise errors.DeepchecksValueError(
-            "Was not able to calculate features importance"
-        )
+        raise errors.DeepchecksValueError('Was not able to calculate features importance')
     return importance.fillna(0), calc_type
 
 
 def _built_in_importance(
-    model: t.Any,
-    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+        model: t.Any,
+        dataset: t.Union['tabular.Dataset', pd.DataFrame],
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Get feature importance member if present in model."""
-    features = (
-        dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
-    )
+    features = dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
 
-    if hasattr(model, "feature_importances_"):  # Ensembles
+    if hasattr(model, 'feature_importances_'):  # Ensembles
         if model.feature_importances_ is None:
             return None, None
-        normalized_feature_importance_values = (
-            model.feature_importances_ / model.feature_importances_.sum()
-        )
-        return (
-            pd.Series(normalized_feature_importance_values, index=features),
-            "feature_importances_",
-        )
+        normalized_feature_importance_values = model.feature_importances_ / model.feature_importances_.sum()
+        return pd.Series(normalized_feature_importance_values, index=features), 'feature_importances_'
 
-    if hasattr(model, "coef_"):  # Linear models
+    if hasattr(model, 'coef_'):  # Linear models
         if model.coef_ is None:
             return None, None
         coef = np.abs(model.coef_.flatten())
         coef = coef / coef.sum()
-        return pd.Series(coef, index=features), "coef_"
+        return pd.Series(coef, index=features), 'coef_'
 
     return None, None
 
 
 def _calc_permutation_importance(
-    model: t.Any,
-    dataset: "tabular.Dataset",
-    model_classes,
-    observed_classes,
-    task_type,
-    n_repeats: int = 30,
-    mask_high_variance_features: bool = False,
-    random_state: int = 42,
-    n_samples: int = 10_000,
-    alternative_scorer: t.Optional[DeepcheckScorer] = None,
-    skip_messages: bool = False,
-    timeout: int = None,
+        model: t.Any,
+        dataset: 'tabular.Dataset',
+        model_classes,
+        observed_classes,
+        task_type,
+        n_repeats: int = 30,
+        mask_high_variance_features: bool = False,
+        random_state: int = 42,
+        n_samples: int = 10_000,
+        alternative_scorer: t.Optional[DeepcheckScorer] = None,
+        skip_messages: bool = False,
+        timeout: int = None,
 ) -> pd.Series:
     """Calculate permutation feature importance. Return nonzero value only when std doesn't mask signal.
 
@@ -314,14 +279,12 @@ def _calc_permutation_importance(
         feature importance normalized to 0-1 indexed by feature names
     """
     if not dataset.has_label():
-        raise errors.DatasetValidationError("Expected dataset with label.")
+        raise errors.DatasetValidationError('Expected dataset with label.')
 
     if len(dataset.features) == 1:
         return pd.Series([1], index=dataset.features)
 
-    dataset_sample = dataset.sample(
-        n_samples, drop_na_label=True, random_state=random_state
-    )
+    dataset_sample = dataset.sample(n_samples, drop_na_label=True, random_state=random_state)
 
     # Test score time on the dataset sample
     if alternative_scorer:
@@ -330,39 +293,25 @@ def _calc_permutation_importance(
         default_scorers = get_default_scorers(task_type)
         scorer_name = next(iter(default_scorers))
         single_scorer_dict = {scorer_name: default_scorers[scorer_name]}
-        scorer = init_validate_scorers(
-            single_scorer_dict, model, dataset, model_classes, observed_classes
-        )[0]
+        scorer = init_validate_scorers(single_scorer_dict, model, dataset, model_classes, observed_classes)[0]
 
     start_time = time.time()
     scorer(model, dataset_sample)
     calc_time = time.time() - start_time
 
-    predicted_time_to_run = (
-        int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
-    )
+    predicted_time_to_run = int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
 
     if timeout is not None:
         if predicted_time_to_run > timeout:
             raise errors.DeepchecksTimeoutError(
-                f"Skipping permutation importance calculation: calculation was projected to finish in "
-                f"{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds"
-            )
+                f'Skipping permutation importance calculation: calculation was projected to finish in '
+                f'{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds')
         elif not skip_messages:
-            get_logger().info(
-                "Calculating permutation feature importance. Expected to finish in %s seconds",
-                predicted_time_to_run,
-            )
-    elif timeout == 0 and not skip_messages:
-        raise errors.DeepchecksNotImplementedError(
-            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time."
-        )
+            get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
+                              predicted_time_to_run)
     elif not skip_messages:
-        get_logger().warning(
-            "Calculating permutation feature importance without time limit. Expected to finish in "
-            "%s seconds",
-            predicted_time_to_run,
-        )
+        get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
+                             '%s seconds', predicted_time_to_run)
 
     r = permutation_importance(
         model,
@@ -371,7 +320,7 @@ def _calc_permutation_importance(
         n_repeats=n_repeats,
         random_state=random_state,
         n_jobs=-1,
-        scoring=scorer.scorer,
+        scoring=scorer.scorer
     )
 
     significance_mask = (
@@ -389,9 +338,7 @@ def _calc_permutation_importance(
     return pd.Series(feature_importance, index=dataset.features)
 
 
-def get_importance(
-    name: str, feature_importances: pd.Series, ds: "tabular.Dataset"
-) -> int:
+def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Dataset') -> int:
     """Return importance based on feature importance or label/date/index first."""
     if name in feature_importances.keys():
         return feature_importances[name]
@@ -403,10 +350,10 @@ def get_importance(
 
 
 def column_importance_sorter_dict(
-    cols_dict: t.Dict[Hashable, t.Any],
-    dataset: "tabular.Dataset",
-    feature_importances: t.Optional[pd.Series] = None,
-    n_top: int = 10,
+        cols_dict: t.Dict[Hashable, t.Any],
+        dataset: 'tabular.Dataset',
+        feature_importances: t.Optional[pd.Series] = None,
+        n_top: int = 10
 ) -> t.Dict:
     """Return the dict of columns sorted and limited by feature importance.
 
@@ -438,11 +385,11 @@ def column_importance_sorter_dict(
 
 
 def column_importance_sorter_df(
-    df: pd.DataFrame,
-    ds: "tabular.Dataset",
-    feature_importances: pd.Series,
-    n_top: int = 10,
-    col: t.Optional[Hashable] = None,
+        df: pd.DataFrame,
+        ds: 'tabular.Dataset',
+        feature_importances: pd.Series,
+        n_top: int = 10,
+        col: t.Optional[Hashable] = None
 ) -> pd.DataFrame:
     """Return the dataframe of columns sorted and limited by feature importance.
 

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -309,6 +309,11 @@ def _calc_permutation_importance(
         elif not skip_messages:
             get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
                               predicted_time_to_run)
+    elif timeout == 0 and not skip_messages:
+            raise errors.DeepchecksNotImplementedError(
+                "Timeout of 0 is not supported as feature importance is needed. "
+                "Try setting timeout to None for unlimited time."
+            )
     elif not skip_messages:
         get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
                              '%s seconds', predicted_time_to_run)

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -21,30 +21,36 @@ from sklearn.pipeline import Pipeline
 
 from deepchecks import tabular
 from deepchecks.core import errors
-from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer, get_default_scorers, init_validate_scorers
+from deepchecks.tabular.metric_utils.scorers import (
+    DeepcheckScorer,
+    get_default_scorers,
+    init_validate_scorers,
+)
 from deepchecks.tabular.utils.validation import validate_model
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import Hashable
 
 __all__ = [
-    '_calculate_feature_importance',
-    'calculate_feature_importance_or_none',
-    'column_importance_sorter_dict',
-    'column_importance_sorter_df',
-    'N_TOP_MESSAGE'
+    "_calculate_feature_importance",
+    "calculate_feature_importance_or_none",
+    "column_importance_sorter_dict",
+    "column_importance_sorter_df",
+    "N_TOP_MESSAGE",
 ]
 
-N_TOP_MESSAGE = 'Showing only the top %s columns, you can change it using n_top_columns param'
+N_TOP_MESSAGE = (
+    "Showing only the top %s columns, you can change it using n_top_columns param"
+)
 
 
 def calculate_feature_importance_or_none(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
-        model_classes,
-        observed_classes,
-        task_type,
-        force_permutation: bool = False,
-        permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+    model_classes,
+    observed_classes,
+    task_type,
+    force_permutation: bool = False,
+    permutation_kwargs: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Calculate features effect on the label or None if the input is incorrect.
 
@@ -88,11 +94,11 @@ def calculate_feature_importance_or_none(
 
         return fi, calculation_type
     except (
-            errors.DeepchecksValueError,
-            errors.NumberOfFeaturesLimitError,
-            errors.DeepchecksTimeoutError,
-            errors.ModelValidationError,
-            errors.DatasetValidationError
+        errors.DeepchecksValueError,
+        errors.NumberOfFeaturesLimitError,
+        errors.DeepchecksTimeoutError,
+        errors.ModelValidationError,
+        errors.DatasetValidationError,
     ) as error:
         # DeepchecksValueError:
         #     if model validation failed;
@@ -104,18 +110,18 @@ def calculate_feature_importance_or_none(
         # ModelValidationError:
         #     if wrong type of model was provided;
         #     if function failed to predict on model;
-        get_logger().warning('Features importance was not calculated:\n%s', error)
+        get_logger().warning("Features importance was not calculated:\n%s", error)
         return None, None
 
 
 def _calculate_feature_importance(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
-        model_classes,
-        observed_classes,
-        task_type,
-        force_permutation: bool = False,
-        permutation_kwargs: t.Dict[str, t.Any] = None,
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
+    model_classes,
+    observed_classes,
+    task_type,
+    force_permutation: bool = False,
+    permutation_kwargs: t.Dict[str, t.Any] = None,
 ) -> t.Tuple[pd.Series, str]:
     """Calculate features effect on the label.
 
@@ -154,7 +160,7 @@ def _calculate_feature_importance(
         if the number of features limit were exceeded.
     """
     permutation_kwargs = permutation_kwargs or {}
-    permutation_kwargs['random_state'] = permutation_kwargs.get('random_state', 42)
+    permutation_kwargs["random_state"] = permutation_kwargs.get("random_state", 42)
     validate_model(dataset, model)
     permutation_failure = None
     calc_type = None
@@ -162,13 +168,21 @@ def _calculate_feature_importance(
 
     if force_permutation:
         if isinstance(dataset, pd.DataFrame):
-            raise errors.DeepchecksValueError('Cannot calculate permutation feature importance on a pandas Dataframe. '
-                                              'In order to force permutation feature importance, please use the Dataset'
-                                              ' object.')
+            raise errors.DeepchecksValueError(
+                "Cannot calculate permutation feature importance on a pandas Dataframe. "
+                "In order to force permutation feature importance, please use the Dataset"
+                " object."
+            )
         else:
-            importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
-                                                      task_type, **permutation_kwargs)
-            calc_type = 'permutation_importance'
+            importance = _calc_permutation_importance(
+                model,
+                dataset,
+                model_classes,
+                observed_classes,
+                task_type,
+                **permutation_kwargs,
+            )
+            calc_type = "permutation_importance"
 
     # If there was no force permutation, or if it failed while trying to calculate importance,
     # we don't take built-in importance in pipelines because the pipeline is changing the features
@@ -182,61 +196,82 @@ def _calculate_feature_importance(
             get_logger().warning(permutation_failure)
 
     # If there was no permutation failure and no importance on the model, using permutation anyway
-    if importance is None and permutation_failure is None and isinstance(dataset, tabular.Dataset):
-        if not permutation_kwargs.get('skip_messages', False):
+    if (
+        importance is None
+        and permutation_failure is None
+        and isinstance(dataset, tabular.Dataset)
+    ):
+        if not permutation_kwargs.get("skip_messages", False):
             if isinstance(model, Pipeline):
-                pre_text = 'Cannot use model\'s built-in feature importance on a Scikit-learn Pipeline,'
+                pre_text = "Cannot use model's built-in feature importance on a Scikit-learn Pipeline,"
             else:
-                pre_text = 'Could not find built-in feature importance on the model,'
-            get_logger().warning('%s using permutation feature importance calculation instead', pre_text)
+                pre_text = "Could not find built-in feature importance on the model,"
+            get_logger().warning(
+                "%s using permutation feature importance calculation instead", pre_text
+            )
 
-        importance = _calc_permutation_importance(model, dataset, model_classes, observed_classes,
-                                                  task_type, **permutation_kwargs)
-        calc_type = 'permutation_importance'
+        importance = _calc_permutation_importance(
+            model,
+            dataset,
+            model_classes,
+            observed_classes,
+            task_type,
+            **permutation_kwargs,
+        )
+        calc_type = "permutation_importance"
 
     # If after all importance is still none raise error
     if importance is None:
         # FIXME: better message
-        raise errors.DeepchecksValueError('Was not able to calculate features importance')
+        raise errors.DeepchecksValueError(
+            "Was not able to calculate features importance"
+        )
     return importance.fillna(0), calc_type
 
 
 def _built_in_importance(
-        model: t.Any,
-        dataset: t.Union['tabular.Dataset', pd.DataFrame],
+    model: t.Any,
+    dataset: t.Union["tabular.Dataset", pd.DataFrame],
 ) -> t.Tuple[t.Optional[pd.Series], t.Optional[str]]:
     """Get feature importance member if present in model."""
-    features = dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
+    features = (
+        dataset.features if isinstance(dataset, tabular.Dataset) else dataset.columns
+    )
 
-    if hasattr(model, 'feature_importances_'):  # Ensembles
+    if hasattr(model, "feature_importances_"):  # Ensembles
         if model.feature_importances_ is None:
             return None, None
-        normalized_feature_importance_values = model.feature_importances_ / model.feature_importances_.sum()
-        return pd.Series(normalized_feature_importance_values, index=features), 'feature_importances_'
+        normalized_feature_importance_values = (
+            model.feature_importances_ / model.feature_importances_.sum()
+        )
+        return (
+            pd.Series(normalized_feature_importance_values, index=features),
+            "feature_importances_",
+        )
 
-    if hasattr(model, 'coef_'):  # Linear models
+    if hasattr(model, "coef_"):  # Linear models
         if model.coef_ is None:
             return None, None
         coef = np.abs(model.coef_.flatten())
         coef = coef / coef.sum()
-        return pd.Series(coef, index=features), 'coef_'
+        return pd.Series(coef, index=features), "coef_"
 
     return None, None
 
 
 def _calc_permutation_importance(
-        model: t.Any,
-        dataset: 'tabular.Dataset',
-        model_classes,
-        observed_classes,
-        task_type,
-        n_repeats: int = 30,
-        mask_high_variance_features: bool = False,
-        random_state: int = 42,
-        n_samples: int = 10_000,
-        alternative_scorer: t.Optional[DeepcheckScorer] = None,
-        skip_messages: bool = False,
-        timeout: int = None,
+    model: t.Any,
+    dataset: "tabular.Dataset",
+    model_classes,
+    observed_classes,
+    task_type,
+    n_repeats: int = 30,
+    mask_high_variance_features: bool = False,
+    random_state: int = 42,
+    n_samples: int = 10_000,
+    alternative_scorer: t.Optional[DeepcheckScorer] = None,
+    skip_messages: bool = False,
+    timeout: int = None,
 ) -> pd.Series:
     """Calculate permutation feature importance. Return nonzero value only when std doesn't mask signal.
 
@@ -279,12 +314,14 @@ def _calc_permutation_importance(
         feature importance normalized to 0-1 indexed by feature names
     """
     if not dataset.has_label():
-        raise errors.DatasetValidationError('Expected dataset with label.')
+        raise errors.DatasetValidationError("Expected dataset with label.")
 
     if len(dataset.features) == 1:
         return pd.Series([1], index=dataset.features)
 
-    dataset_sample = dataset.sample(n_samples, drop_na_label=True, random_state=random_state)
+    dataset_sample = dataset.sample(
+        n_samples, drop_na_label=True, random_state=random_state
+    )
 
     # Test score time on the dataset sample
     if alternative_scorer:
@@ -293,25 +330,39 @@ def _calc_permutation_importance(
         default_scorers = get_default_scorers(task_type)
         scorer_name = next(iter(default_scorers))
         single_scorer_dict = {scorer_name: default_scorers[scorer_name]}
-        scorer = init_validate_scorers(single_scorer_dict, model, dataset, model_classes, observed_classes)[0]
+        scorer = init_validate_scorers(
+            single_scorer_dict, model, dataset, model_classes, observed_classes
+        )[0]
 
     start_time = time.time()
     scorer(model, dataset_sample)
     calc_time = time.time() - start_time
 
-    predicted_time_to_run = int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
+    predicted_time_to_run = (
+        int(np.ceil(calc_time * n_repeats * len(dataset.features))) or 1
+    )
 
     if timeout is not None:
         if predicted_time_to_run > timeout:
             raise errors.DeepchecksTimeoutError(
-                f'Skipping permutation importance calculation: calculation was projected to finish in '
-                f'{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds')
+                f"Skipping permutation importance calculation: calculation was projected to finish in "
+                f"{predicted_time_to_run} seconds, but timeout was configured to {timeout} seconds"
+            )
         elif not skip_messages:
-            get_logger().info('Calculating permutation feature importance. Expected to finish in %s seconds',
-                              predicted_time_to_run)
+            get_logger().info(
+                "Calculating permutation feature importance. Expected to finish in %s seconds",
+                predicted_time_to_run,
+            )
+    elif timeout == 0 and not skip_messages:
+        raise errors.DeepchecksNotImplementedError(
+            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time."
+        )
     elif not skip_messages:
-        get_logger().warning('Calculating permutation feature importance without time limit. Expected to finish in '
-                             '%s seconds', predicted_time_to_run)
+        get_logger().warning(
+            "Calculating permutation feature importance without time limit. Expected to finish in "
+            "%s seconds",
+            predicted_time_to_run,
+        )
 
     r = permutation_importance(
         model,
@@ -320,7 +371,7 @@ def _calc_permutation_importance(
         n_repeats=n_repeats,
         random_state=random_state,
         n_jobs=-1,
-        scoring=scorer.scorer
+        scoring=scorer.scorer,
     )
 
     significance_mask = (
@@ -338,7 +389,9 @@ def _calc_permutation_importance(
     return pd.Series(feature_importance, index=dataset.features)
 
 
-def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Dataset') -> int:
+def get_importance(
+    name: str, feature_importances: pd.Series, ds: "tabular.Dataset"
+) -> int:
     """Return importance based on feature importance or label/date/index first."""
     if name in feature_importances.keys():
         return feature_importances[name]
@@ -350,10 +403,10 @@ def get_importance(name: str, feature_importances: pd.Series, ds: 'tabular.Datas
 
 
 def column_importance_sorter_dict(
-        cols_dict: t.Dict[Hashable, t.Any],
-        dataset: 'tabular.Dataset',
-        feature_importances: t.Optional[pd.Series] = None,
-        n_top: int = 10
+    cols_dict: t.Dict[Hashable, t.Any],
+    dataset: "tabular.Dataset",
+    feature_importances: t.Optional[pd.Series] = None,
+    n_top: int = 10,
 ) -> t.Dict:
     """Return the dict of columns sorted and limited by feature importance.
 
@@ -385,11 +438,11 @@ def column_importance_sorter_dict(
 
 
 def column_importance_sorter_df(
-        df: pd.DataFrame,
-        ds: 'tabular.Dataset',
-        feature_importances: pd.Series,
-        n_top: int = 10,
-        col: t.Optional[Hashable] = None
+    df: pd.DataFrame,
+    ds: "tabular.Dataset",
+    feature_importances: pd.Series,
+    n_top: int = 10,
+    col: t.Optional[Hashable] = None,
 ) -> pd.DataFrame:
     """Return the dataframe of columns sorted and limited by feature importance.
 

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ WIN_TESTDIR := tests
 WIN_BIN := $(WIN_ENV)/bin
 
 # System Envs
-BIN := $(ENV)/bin
+BIN := '/opt/homebrew/Caskroom/miniforge/base/envs/deepchecks/bin/'
 pythonpath := PYTHONPATH=.
 OS := $(shell uname -s)
 

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ WIN_TESTDIR := tests
 WIN_BIN := $(WIN_ENV)/bin
 
 # System Envs
-BIN := '/opt/homebrew/Caskroom/miniforge/base/envs/deepchecks/bin/'
+BIN := $(ENV)/bin
 pythonpath := PYTHONPATH=.
 OS := $(shell uname -s)
 

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -238,7 +238,6 @@ def test_raise_zero_timeout(drifted_data):
         calling(check.run).with_args(params),
         raises(
             DeepchecksNotImplementedError,
-            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time.",
         ),
     )
 

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -14,16 +14,7 @@ import string
 
 import numpy as np
 import pandas as pd
-from hamcrest import (
-    assert_that,
-    close_to,
-    greater_than,
-    has_entries,
-    has_length,
-    calling,
-    raises,
-)
-from deepchecks.core.errors import DeepchecksNotImplementedError, DeepchecksTimeoutError
+from hamcrest import assert_that, close_to, greater_than, has_entries, has_length
 
 from deepchecks.tabular.checks import MultivariateDrift
 from deepchecks.tabular.dataset import Dataset
@@ -34,35 +25,24 @@ def test_no_drift(drifted_data):
 
     # Arrange
     train_ds, test_ds = drifted_data
-    train_ds = Dataset(
-        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=train_ds.label_name,
-    )
-    test_ds = Dataset(
-        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=test_ds.label_name,
-    )
+    train_ds = Dataset(train_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
+                       label=train_ds.label_name)
+    test_ds = Dataset(test_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
+                      label=test_ds.label_name)
     check = MultivariateDrift()
 
     # Act
     result = check.run(train_ds, test_ds)
 
     # Assert
-    assert_that(
-        result.value,
-        has_entries(
-            {
-                "domain_classifier_auc": close_to(0.5, 0.03),
-                "domain_classifier_drift_score": close_to(0, 0.01),
-                "domain_classifier_feature_importance": has_entries(
-                    {
-                        "categorical_without_drift": close_to(0.81, 0.001),
-                        "numeric_without_drift": close_to(0.2, 0.02),
-                    }
-                ),
-            }
+    assert_that(result.value, has_entries({
+        'domain_classifier_auc': close_to(0.5, 0.03),
+        'domain_classifier_drift_score': close_to(0, 0.01),
+        'domain_classifier_feature_importance': has_entries(
+            {'categorical_without_drift': close_to(0.81, 0.001),
+             'numeric_without_drift': close_to(0.2, 0.02)}
         ),
-    )
+    }))
 
 
 def test_drift(drifted_data):
@@ -75,23 +55,17 @@ def test_drift(drifted_data):
     result = check.run(train_ds, test_ds)
 
     # Assert
-    assert_that(
-        result.value,
-        has_entries(
-            {
-                "domain_classifier_auc": close_to(0.93, 0.001),
-                "domain_classifier_drift_score": close_to(0.86, 0.01),
-                "domain_classifier_feature_importance": has_entries(
-                    {
-                        "categorical_without_drift": close_to(0, 0.02),
-                        "numeric_without_drift": close_to(0, 0.02),
-                        "categorical_with_drift": close_to(0, 0.02),
-                        "numeric_with_drift": close_to(1, 0.02),
-                    }
-                ),
-            }
+    assert_that(result.value, has_entries({
+        'domain_classifier_auc': close_to(0.93, 0.001),
+        'domain_classifier_drift_score': close_to(0.86, 0.01),
+        'domain_classifier_feature_importance': has_entries(
+            {'categorical_without_drift': close_to(0, 0.02),
+             'numeric_without_drift': close_to(0, 0.02),
+             'categorical_with_drift': close_to(0, 0.02),
+             'numeric_with_drift': close_to(1, 0.02)
+             }
         ),
-    )
+    }))
     assert_that(result.display, has_length(greater_than(0)))
 
 
@@ -105,37 +79,27 @@ def test_drift_without_display(drifted_data):
     result = check.run(train_ds, test_ds, with_display=False)
 
     # Assert
-    assert_that(
-        result.value,
-        has_entries(
-            {
-                "domain_classifier_auc": close_to(0.93, 0.001),
-                "domain_classifier_drift_score": close_to(0.86, 0.01),
-                "domain_classifier_feature_importance": has_entries(
-                    {
-                        "categorical_without_drift": close_to(0, 0.02),
-                        "numeric_without_drift": close_to(0, 0.02),
-                        "categorical_with_drift": close_to(0, 0.02),
-                        "numeric_with_drift": close_to(1, 0.02),
-                    }
-                ),
-            }
+    assert_that(result.value, has_entries({
+        'domain_classifier_auc': close_to(0.93, 0.001),
+        'domain_classifier_drift_score': close_to(0.86, 0.01),
+        'domain_classifier_feature_importance': has_entries(
+            {'categorical_without_drift': close_to(0, 0.02),
+             'numeric_without_drift': close_to(0, 0.02),
+             'categorical_with_drift': close_to(0, 0.02),
+             'numeric_with_drift': close_to(1, 0.02)
+             }
         ),
-    )
+    }))
     assert_that(result.display, has_length(0))
 
 
 def test_max_drift_score_condition_pass(drifted_data):
     # Arrange
     train_ds, test_ds = drifted_data
-    train_ds = Dataset(
-        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=train_ds.label_name,
-    )
-    test_ds = Dataset(
-        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=test_ds.label_name,
-    )
+    train_ds = Dataset(train_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
+                       label=train_ds.label_name)
+    test_ds = Dataset(test_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
+                      label=test_ds.label_name)
     check = MultivariateDrift().add_condition_overall_drift_value_less_than()
 
     # Act
@@ -143,14 +107,11 @@ def test_max_drift_score_condition_pass(drifted_data):
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
-    assert_that(
-        condition_result,
-        equal_condition_result(
-            is_pass=True,
-            details="Found drift value of: 0, corresponding to a domain classifier AUC of: 0.5",
-            name="Drift value is less than 0.25",
-        ),
-    )
+    assert_that(condition_result, equal_condition_result(
+        is_pass=True,
+        details='Found drift value of: 0, corresponding to a domain classifier AUC of: 0.5',
+        name='Drift value is less than 0.25',
+    ))
 
 
 def test_max_drift_score_condition_fail(drifted_data):
@@ -163,55 +124,42 @@ def test_max_drift_score_condition_fail(drifted_data):
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
-    assert_that(
-        condition_result,
-        equal_condition_result(
-            is_pass=False,
-            name="Drift value is less than 0.25",
-            details="Found drift value of: 0.86, corresponding to a domain classifier AUC of: 0.93",
-        ),
-    )
+    assert_that(condition_result, equal_condition_result(
+        is_pass=False,
+        name='Drift value is less than 0.25',
+        details='Found drift value of: 0.86, corresponding to a domain classifier AUC of: 0.93'
+    ))
 
 
 def test_over_255_categories_in_column():
     np.random.seed(42)
 
     letters = string.ascii_letters
-    categories = ["".join(random.choice(letters) for _ in range(5)) for _ in range(300)]
+    categories = [''.join(random.choice(letters) for _ in range(5)) for _ in range(300)]
 
-    train_data = np.concatenate(
-        [np.random.randn(1000, 1), np.random.choice(a=categories, size=(1000, 1))],
-        axis=1,
-    )
-    test_data = np.concatenate(
-        [np.random.randn(1000, 1), np.random.choice(a=categories, size=(1000, 1))],
-        axis=1,
-    )
+    train_data = np.concatenate([np.random.randn(1000, 1),
+                                 np.random.choice(a=categories, size=(1000, 1))],
+                                axis=1)
+    test_data = np.concatenate([np.random.randn(1000, 1),
+                                np.random.choice(a=categories, size=(1000, 1))],
+                               axis=1)
 
-    df_train = pd.DataFrame(
-        train_data,
-        columns=["numeric_without_drift", "categorical_with_many_categories"],
-    )
+    df_train = pd.DataFrame(train_data,
+                            columns=['numeric_without_drift', 'categorical_with_many_categories'])
     df_test = pd.DataFrame(test_data, columns=df_train.columns)
 
-    df_test["categorical_with_many_categories"] = np.random.choice(
-        a=categories[20:280], size=(1000, 1)
-    )
+    df_test['categorical_with_many_categories'] = np.random.choice(a=categories[20:280], size=(1000, 1))
 
-    df_train = df_train.astype({"numeric_without_drift": "float"})
-    df_test = df_test.astype({"numeric_without_drift": "float"})
+    df_train = df_train.astype({'numeric_without_drift': 'float'})
+    df_test = df_test.astype({'numeric_without_drift': 'float'})
 
     label = np.random.randint(0, 2, size=(df_train.shape[0],))
-    df_train["target"] = label
-    train_ds = Dataset(
-        df_train, cat_features=["categorical_with_many_categories"], label="target"
-    )
+    df_train['target'] = label
+    train_ds = Dataset(df_train, cat_features=['categorical_with_many_categories'], label='target')
 
     label = np.random.randint(0, 2, size=(df_test.shape[0],))
-    df_test["target"] = label
-    test_ds = Dataset(
-        df_test, cat_features=["categorical_with_many_categories"], label="target"
-    )
+    df_test['target'] = label
+    test_ds = Dataset(df_test, cat_features=['categorical_with_many_categories'], label='target')
 
     check = MultivariateDrift()
 
@@ -220,59 +168,4 @@ def test_over_255_categories_in_column():
 
     # Assert
     # we only care that it runs
-    assert_that(result.value["domain_classifier_auc"])
-
-
-def test_raise_zero_timeout(drifted_data):
-    # Arrange
-    train_ds, test_ds = drifted_data
-    check = MultivariateDrift()
-
-    # Act
-    params = {
-        "train_dataset": train_ds,
-        "test_dataset": test_ds,
-        "feature_importance_timeout": 0,
-    }
-    assert_that(
-        calling(check.run).with_args(params),
-        raises(
-            DeepchecksNotImplementedError,
-            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time.",
-        ),
-    )
-
-
-def test_runs_with_Nonetimeout(drifted_data):
-
-    # Arrange
-    train_ds, test_ds = drifted_data
-    train_ds = Dataset(
-        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=train_ds.label_name,
-    )
-    test_ds = Dataset(
-        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
-        label=test_ds.label_name,
-    )
-    check = MultivariateDrift()
-
-    # Act
-    result = check.run(train_ds, test_ds, feature_importance_timeout=None)
-
-    # Assert
-    assert_that(
-        result.value,
-        has_entries(
-            {
-                "domain_classifier_auc": close_to(0.5, 0.03),
-                "domain_classifier_drift_score": close_to(0, 0.01),
-                "domain_classifier_feature_importance": has_entries(
-                    {
-                        "categorical_without_drift": close_to(0.81, 0.001),
-                        "numeric_without_drift": close_to(0.2, 0.02),
-                    }
-                ),
-            }
-        ),
-    )
+    assert_that(result.value['domain_classifier_auc'])

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -238,6 +238,7 @@ def test_raise_zero_timeout(drifted_data):
         calling(check.run).with_args(params),
         raises(
             DeepchecksNotImplementedError,
+            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time.",
         ),
     )
 

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -171,25 +171,6 @@ def test_over_255_categories_in_column():
     assert_that(result.value['domain_classifier_auc'])
 
 
-def test_raise_zero_timeout(drifted_data):
-    # Arrange
-    train_ds, test_ds = drifted_data
-    check = MultivariateDrift()
-
-    # Act
-    params = {
-        "train_dataset": train_ds,
-        "test_dataset": test_ds,
-        "feature_importance_timeout": 0,
-    }
-    assert_that(
-        calling(check.run).with_args(params),
-        raises(
-            DeepchecksNotImplementedError,
-        ),
-    )
-
-
 def test_runs_with_Nonetimeout(drifted_data):
 
     # Arrange

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -14,7 +14,7 @@ import string
 
 import numpy as np
 import pandas as pd
-from hamcrest import assert_that, close_to, greater_than, has_entries, has_length, calling, raises
+from hamcrest import assert_that, close_to, greater_than, has_entries, has_length
 from deepchecks.tabular.checks import MultivariateDrift
 from deepchecks.tabular.dataset import Dataset
 from tests.base.utils import equal_condition_result

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -14,7 +14,16 @@ import string
 
 import numpy as np
 import pandas as pd
-from hamcrest import assert_that, close_to, greater_than, has_entries, has_length
+from hamcrest import (
+    assert_that,
+    close_to,
+    greater_than,
+    has_entries,
+    has_length,
+    calling,
+    raises,
+)
+from deepchecks.core.errors import DeepchecksNotImplementedError, DeepchecksTimeoutError
 
 from deepchecks.tabular.checks import MultivariateDrift
 from deepchecks.tabular.dataset import Dataset
@@ -25,24 +34,35 @@ def test_no_drift(drifted_data):
 
     # Arrange
     train_ds, test_ds = drifted_data
-    train_ds = Dataset(train_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
-                       label=train_ds.label_name)
-    test_ds = Dataset(test_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
-                      label=test_ds.label_name)
+    train_ds = Dataset(
+        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=train_ds.label_name,
+    )
+    test_ds = Dataset(
+        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=test_ds.label_name,
+    )
     check = MultivariateDrift()
 
     # Act
     result = check.run(train_ds, test_ds)
 
     # Assert
-    assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.5, 0.03),
-        'domain_classifier_drift_score': close_to(0, 0.01),
-        'domain_classifier_feature_importance': has_entries(
-            {'categorical_without_drift': close_to(0.81, 0.001),
-             'numeric_without_drift': close_to(0.2, 0.02)}
+    assert_that(
+        result.value,
+        has_entries(
+            {
+                "domain_classifier_auc": close_to(0.5, 0.03),
+                "domain_classifier_drift_score": close_to(0, 0.01),
+                "domain_classifier_feature_importance": has_entries(
+                    {
+                        "categorical_without_drift": close_to(0.81, 0.001),
+                        "numeric_without_drift": close_to(0.2, 0.02),
+                    }
+                ),
+            }
         ),
-    }))
+    )
 
 
 def test_drift(drifted_data):
@@ -55,17 +75,23 @@ def test_drift(drifted_data):
     result = check.run(train_ds, test_ds)
 
     # Assert
-    assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.93, 0.001),
-        'domain_classifier_drift_score': close_to(0.86, 0.01),
-        'domain_classifier_feature_importance': has_entries(
-            {'categorical_without_drift': close_to(0, 0.02),
-             'numeric_without_drift': close_to(0, 0.02),
-             'categorical_with_drift': close_to(0, 0.02),
-             'numeric_with_drift': close_to(1, 0.02)
-             }
+    assert_that(
+        result.value,
+        has_entries(
+            {
+                "domain_classifier_auc": close_to(0.93, 0.001),
+                "domain_classifier_drift_score": close_to(0.86, 0.01),
+                "domain_classifier_feature_importance": has_entries(
+                    {
+                        "categorical_without_drift": close_to(0, 0.02),
+                        "numeric_without_drift": close_to(0, 0.02),
+                        "categorical_with_drift": close_to(0, 0.02),
+                        "numeric_with_drift": close_to(1, 0.02),
+                    }
+                ),
+            }
         ),
-    }))
+    )
     assert_that(result.display, has_length(greater_than(0)))
 
 
@@ -79,27 +105,37 @@ def test_drift_without_display(drifted_data):
     result = check.run(train_ds, test_ds, with_display=False)
 
     # Assert
-    assert_that(result.value, has_entries({
-        'domain_classifier_auc': close_to(0.93, 0.001),
-        'domain_classifier_drift_score': close_to(0.86, 0.01),
-        'domain_classifier_feature_importance': has_entries(
-            {'categorical_without_drift': close_to(0, 0.02),
-             'numeric_without_drift': close_to(0, 0.02),
-             'categorical_with_drift': close_to(0, 0.02),
-             'numeric_with_drift': close_to(1, 0.02)
-             }
+    assert_that(
+        result.value,
+        has_entries(
+            {
+                "domain_classifier_auc": close_to(0.93, 0.001),
+                "domain_classifier_drift_score": close_to(0.86, 0.01),
+                "domain_classifier_feature_importance": has_entries(
+                    {
+                        "categorical_without_drift": close_to(0, 0.02),
+                        "numeric_without_drift": close_to(0, 0.02),
+                        "categorical_with_drift": close_to(0, 0.02),
+                        "numeric_with_drift": close_to(1, 0.02),
+                    }
+                ),
+            }
         ),
-    }))
+    )
     assert_that(result.display, has_length(0))
 
 
 def test_max_drift_score_condition_pass(drifted_data):
     # Arrange
     train_ds, test_ds = drifted_data
-    train_ds = Dataset(train_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
-                       label=train_ds.label_name)
-    test_ds = Dataset(test_ds.data.drop(columns=['numeric_with_drift', 'categorical_with_drift']),
-                      label=test_ds.label_name)
+    train_ds = Dataset(
+        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=train_ds.label_name,
+    )
+    test_ds = Dataset(
+        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=test_ds.label_name,
+    )
     check = MultivariateDrift().add_condition_overall_drift_value_less_than()
 
     # Act
@@ -107,11 +143,14 @@ def test_max_drift_score_condition_pass(drifted_data):
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
-    assert_that(condition_result, equal_condition_result(
-        is_pass=True,
-        details='Found drift value of: 0, corresponding to a domain classifier AUC of: 0.5',
-        name='Drift value is less than 0.25',
-    ))
+    assert_that(
+        condition_result,
+        equal_condition_result(
+            is_pass=True,
+            details="Found drift value of: 0, corresponding to a domain classifier AUC of: 0.5",
+            name="Drift value is less than 0.25",
+        ),
+    )
 
 
 def test_max_drift_score_condition_fail(drifted_data):
@@ -124,42 +163,55 @@ def test_max_drift_score_condition_fail(drifted_data):
     condition_result, *_ = check.conditions_decision(result)
 
     # Assert
-    assert_that(condition_result, equal_condition_result(
-        is_pass=False,
-        name='Drift value is less than 0.25',
-        details='Found drift value of: 0.86, corresponding to a domain classifier AUC of: 0.93'
-    ))
+    assert_that(
+        condition_result,
+        equal_condition_result(
+            is_pass=False,
+            name="Drift value is less than 0.25",
+            details="Found drift value of: 0.86, corresponding to a domain classifier AUC of: 0.93",
+        ),
+    )
 
 
 def test_over_255_categories_in_column():
     np.random.seed(42)
 
     letters = string.ascii_letters
-    categories = [''.join(random.choice(letters) for _ in range(5)) for _ in range(300)]
+    categories = ["".join(random.choice(letters) for _ in range(5)) for _ in range(300)]
 
-    train_data = np.concatenate([np.random.randn(1000, 1),
-                                 np.random.choice(a=categories, size=(1000, 1))],
-                                axis=1)
-    test_data = np.concatenate([np.random.randn(1000, 1),
-                                np.random.choice(a=categories, size=(1000, 1))],
-                               axis=1)
+    train_data = np.concatenate(
+        [np.random.randn(1000, 1), np.random.choice(a=categories, size=(1000, 1))],
+        axis=1,
+    )
+    test_data = np.concatenate(
+        [np.random.randn(1000, 1), np.random.choice(a=categories, size=(1000, 1))],
+        axis=1,
+    )
 
-    df_train = pd.DataFrame(train_data,
-                            columns=['numeric_without_drift', 'categorical_with_many_categories'])
+    df_train = pd.DataFrame(
+        train_data,
+        columns=["numeric_without_drift", "categorical_with_many_categories"],
+    )
     df_test = pd.DataFrame(test_data, columns=df_train.columns)
 
-    df_test['categorical_with_many_categories'] = np.random.choice(a=categories[20:280], size=(1000, 1))
+    df_test["categorical_with_many_categories"] = np.random.choice(
+        a=categories[20:280], size=(1000, 1)
+    )
 
-    df_train = df_train.astype({'numeric_without_drift': 'float'})
-    df_test = df_test.astype({'numeric_without_drift': 'float'})
+    df_train = df_train.astype({"numeric_without_drift": "float"})
+    df_test = df_test.astype({"numeric_without_drift": "float"})
 
     label = np.random.randint(0, 2, size=(df_train.shape[0],))
-    df_train['target'] = label
-    train_ds = Dataset(df_train, cat_features=['categorical_with_many_categories'], label='target')
+    df_train["target"] = label
+    train_ds = Dataset(
+        df_train, cat_features=["categorical_with_many_categories"], label="target"
+    )
 
     label = np.random.randint(0, 2, size=(df_test.shape[0],))
-    df_test['target'] = label
-    test_ds = Dataset(df_test, cat_features=['categorical_with_many_categories'], label='target')
+    df_test["target"] = label
+    test_ds = Dataset(
+        df_test, cat_features=["categorical_with_many_categories"], label="target"
+    )
 
     check = MultivariateDrift()
 
@@ -168,4 +220,59 @@ def test_over_255_categories_in_column():
 
     # Assert
     # we only care that it runs
-    assert_that(result.value['domain_classifier_auc'])
+    assert_that(result.value["domain_classifier_auc"])
+
+
+def test_raise_zero_timeout(drifted_data):
+    # Arrange
+    train_ds, test_ds = drifted_data
+    check = MultivariateDrift()
+
+    # Act
+    params = {
+        "train_dataset": train_ds,
+        "test_dataset": test_ds,
+        "feature_importance_timeout": 0,
+    }
+    assert_that(
+        calling(check.run).with_args(params),
+        raises(
+            DeepchecksNotImplementedError,
+            "Timeout of 0 is not supported as feature importance is needed. Try setting timeout to None for unlimited time.",
+        ),
+    )
+
+
+def test_runs_with_Nonetimeout(drifted_data):
+
+    # Arrange
+    train_ds, test_ds = drifted_data
+    train_ds = Dataset(
+        train_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=train_ds.label_name,
+    )
+    test_ds = Dataset(
+        test_ds.data.drop(columns=["numeric_with_drift", "categorical_with_drift"]),
+        label=test_ds.label_name,
+    )
+    check = MultivariateDrift()
+
+    # Act
+    result = check.run(train_ds, test_ds, feature_importance_timeout=None)
+
+    # Assert
+    assert_that(
+        result.value,
+        has_entries(
+            {
+                "domain_classifier_auc": close_to(0.5, 0.03),
+                "domain_classifier_drift_score": close_to(0, 0.01),
+                "domain_classifier_feature_importance": has_entries(
+                    {
+                        "categorical_without_drift": close_to(0.81, 0.001),
+                        "numeric_without_drift": close_to(0.2, 0.02),
+                    }
+                ),
+            }
+        ),
+    )

--- a/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
+++ b/tests/tabular/checks/train_test_validation/multivariate_drift_test.py
@@ -15,7 +15,6 @@ import string
 import numpy as np
 import pandas as pd
 from hamcrest import assert_that, close_to, greater_than, has_entries, has_length, calling, raises
-from deepchecks.core.errors import DeepchecksNotImplementedError
 from deepchecks.tabular.checks import MultivariateDrift
 from deepchecks.tabular.dataset import Dataset
 from tests.base.utils import equal_condition_result


### PR DESCRIPTION
Quick fix to pass timeout variable for feature importance.
Raises error if set to 0 (since this is not supported by the algorithm).

Added tests for this case, and for None timeout. 

#### Reference Issues/PRs

Fixes #2110. 

#### What does this implement/fix? Explain your changes.

The "feature_importance_timeout" parameter was hard coded

#### Any other comments?

I was unable to install the dev requirements and run a test locally!!!
This is just to get the ball rolling on this issue. 
