### PR TITLE
Make sure we know what the classes are when only proba are passed

### DIFF
--- a/deepchecks/tabular/suite.py
+++ b/deepchecks/tabular/suite.py
@@ -10,7 +10,7 @@
 #
 """Module for base tabular abstractions."""
 # pylint: disable=broad-except
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, List
 
 import numpy as np
 import pandas as pd
@@ -51,7 +51,8 @@ class Suite(BaseSuite):
         y_pred_test: Optional[np.ndarray] = None,
         y_proba_train: Optional[np.ndarray] = None,
         y_proba_test: Optional[np.ndarray] = None,
-        run_single_dataset: Optional[str] = None
+        run_single_dataset: Optional[str] = None,
+        model_classes: Optional[List] = None
     ) -> SuiteResult:
         """Run all checks.
 
@@ -84,6 +85,7 @@ class Suite(BaseSuite):
             y_pred_test=y_pred_test,
             y_proba_train=y_proba_train,
             y_proba_test=y_proba_test,
+            model_classes=model_classes
         )
 
         progress_bar = create_progress_bar(


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #2090 

#### What does this implement/fix? Explain your changes.
If only proba are passed, make sure we either can see all the classes we need in the labels, or the user has passed model_classes.
