### PR TITLE
Add return statement to the validate_format function

### DIFF
--- a/deepchecks/vision/utils/validation.py
+++ b/deepchecks/vision/utils/validation.py
@@ -48,7 +48,7 @@ def set_seeds(seed: int):
 
 
 def validate_extractors(dataset: VisionData, model, device=None, image_save_location: str = None,
-                        save_images: bool = True):
+                        save_images: bool = True) -> bool:
     """Validate for given data_loader and model that the extractors are valid.
 
     Parameters
@@ -65,6 +65,11 @@ def validate_extractors(dataset: VisionData, model, device=None, image_save_loca
     save_images : bool , default: True
         if the machine doesn't support GUI the displayed images will be saved
         if the value is True.
+
+    Returns
+    -------
+    bool
+        The validation result.
     """
     print('Deepchecks will try to validate the extractors given...')
     batch = apply_to_tensor(next(iter(dataset.data_loader)), lambda it: it.to(device))
@@ -190,3 +195,8 @@ def validate_extractors(dataset: VisionData, model, device=None, image_save_loca
                     print('*******************************************************************************')
             else:
                 image.show()
+
+    if label_formatter_error or prediction_formatter_error or image_formatter_error:
+        return False
+    else:
+        return True

--- a/deepchecks/vision/vision_data.py
+++ b/deepchecks/vision/vision_data.py
@@ -501,7 +501,7 @@ class VisionData:
         if not all((all((isinstance(x, int) for x in inner_ids)) for inner_ids in class_ids)):
             raise ValidationError('The samples sequence must contain only int values.')
 
-    def validate_format(self, model, device=None):
+    def validate_format(self, model, device=None) -> bool:
         """Validate the correctness of the data class implementation according to the expected format.
 
         Parameters
@@ -510,9 +510,15 @@ class VisionData:
             Model to validate the data class implementation against.
         device
             Device to run the model on.
+
+        Returns
+        -------
+        bool
+            The validation result.
         """
         from deepchecks.vision.utils.validation import validate_extractors  # pylint: disable=import-outside-toplevel
-        validate_extractors(self, model, device=device)
+        validation_result = validate_extractors(self, model, device=device)
+        return validation_result
 
     def __iter__(self):
         """Return an iterator over the dataset."""

--- a/tests/vision/utils_tests/formatters_test.py
+++ b/tests/vision/utils_tests/formatters_test.py
@@ -22,6 +22,7 @@ from deepchecks.vision.utils import image_properties
 from deepchecks.vision.utils.detection_formatters import (convert_batch_of_bboxes, convert_bbox,
                                                           verify_bbox_format_notation)
 from deepchecks.vision.vision_data import VisionData
+from deepchecks.vision.utils.validation import validate_extractors
 
 
 class SimpleImageData(VisionData):
@@ -470,3 +471,12 @@ def test_convert_bbox_function_with_ambiguous_combination_of_parameters():
         image_width=image_width,
         image_height=image_height
     )
+
+def test_validator(mnist_dataset_train, coco_test_visiondata, mock_trained_yolov5_object_detection):
+    # verify the correctness of the data class and return True if data is the expected format
+    output = validate_extractors(coco_test_visiondata, mock_trained_yolov5_object_detection)
+    assert_that(output is True)
+
+    # verify the correctness of the data class and return False if data is NOT in the expected format
+    output = validate_extractors(mnist_dataset_train, mock_trained_yolov5_object_detection)
+    assert_that(output is  False)


### PR DESCRIPTION
#### Reference Issues/PRs

resolves #2131

#### What does this implement/fix? Explain your changes.

The [validate_format](https://docs.deepchecks.com/stable/api/deepchecks.vision.html#deepchecks.vision.DetectionData.validate_format) function did not return anything and only prints a message indicating whether the test passed or failed. This PR added a return statement to the [`validate_format`](https://github.com/deepchecks/deepchecks/blob/main/deepchecks/vision/vision_data.py#L504) function from the DetectionData class and a return statement to the [`validate_extractors`](https://github.com/deepchecks/deepchecks/blob/main/deepchecks/vision/utils/validation.py#L50) function in validation.py