### PR TITLE
Remove reduce from TrainTestPerformance

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/train_test_performance.py
+++ b/deepchecks/tabular/checks/model_evaluation/train_test_performance.py
@@ -10,7 +10,7 @@
 #
 """Module containing the train test performance check."""
 from numbers import Number
-from typing import Callable, Dict, List, Mapping, TypeVar, Union, cast
+from typing import Callable, List, Mapping, TypeVar, Union, cast
 
 import pandas as pd
 import plotly.express as px
@@ -19,8 +19,7 @@ from deepchecks.core import CheckResult
 from deepchecks.core.check_utils.class_performance_utils import (
     get_condition_class_performance_imbalance_ratio_less_than, get_condition_test_performance_greater_than,
     get_condition_train_test_relative_degradation_less_than)
-from deepchecks.core.checks import CheckConfig, DatasetKind
-from deepchecks.core.reduce_classes import ReduceMixin
+from deepchecks.core.checks import CheckConfig
 from deepchecks.tabular import Context, TrainTestCheck
 from deepchecks.tabular.metric_utils import MULTICLASS_SCORERS_NON_AVERAGE
 from deepchecks.utils.docref import doclink
@@ -156,8 +155,6 @@ class TrainTestPerformance(TrainTestCheck):
 
     def config(self, include_version: bool = True) -> CheckConfig:
         """Return check configuration."""
-        name = type(self).__name__
-
         if isinstance(self.scorers, dict):
             for k, v in self.scorers.items():
                 if not isinstance(v, str):

--- a/docs/source/checks/tabular/train_test_validation/plot_train_test_feature_drift.py
+++ b/docs/source/checks/tabular/train_test_validation/plot_train_test_feature_drift.py
@@ -169,7 +169,12 @@ result.show(show_additional_outputs=False)
 #
 # We can define the type of aggregation we want to use via the `aggregation_method` parameter. The possible values are:
 #
-# ``weighted``: The default. Weighted mean of drift scores based on each feature's feature importance. This method
+# ``l2_weighted`` (Default): L2 norm over the combination of drift scores and feature importance, minus the L2 norm of
+# feature importance alone, specifically, ||FI + DRIFT|| - ||FI||. This method returns a value between 0 and
+# sqrt(n_features). This method is built to give greater weight to features with high importance and high drift, while
+# not zeroing out features with low importance and high drift.
+#
+# ``weighted``: Weighted mean of drift scores based on each feature's feature importance. This method
 # underlying logic is that drift in a feature with a higher feature importance will have a greater effect on the model's
 # performance.
 #

--- a/tests/tabular/checks/model_evaluation/train_test_performance_test.py
+++ b/tests/tabular/checks/model_evaluation/train_test_performance_test.py
@@ -270,19 +270,6 @@ def test_condition_class_performance_imbalance_ratio_less_than_passed(iris_split
     ))
 
 
-def test_classification_alt_scores_list(iris_split_dataset_and_model):
-    # Arrange
-    train, test, model = iris_split_dataset_and_model
-    check = TrainTestPerformance(scorers=['recall_per_class',
-                                 'f1_per_class', make_scorer(jaccard_score, average=None)])
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['f1'], close_to(0.913, 0.001))
-    assert_that(result['recall'], close_to(0.916, 0.001))
-    assert_that(result['jaccard_score'], close_to(0.846, 0.001))
-
-
 def test_classification_deepchecks_scorers(iris_split_dataset_and_model):
     # Arrange
     train, test, model = iris_split_dataset_and_model
@@ -291,40 +278,7 @@ def test_classification_deepchecks_scorers(iris_split_dataset_and_model):
     # Act
     check_result = check.run(train, test, model)
     check_value = check_result.value
-    result = check_result.reduce_output()
-    # Assert
-    assert_that(result['fpr'], close_to(0.070, 0.001))
-    assert_that(result['fnr'], close_to(0.035, 0.001))
-    assert_that(result['specificity'], close_to(0.929, 0.001))
-    assert_that(result['fnr_macro'], close_to(result['fnr'], 0.001))
-    assert_that(result['roc_auc'], close_to(0.992, 0.001))
 
     per_class_df = check_value[check_value['Metric'] == 'roc_auc']
     assert_that(per_class_df.loc[per_class_df.Dataset == 'Train', 'Class'].values[1], equal_to(1.))
     assert_that(per_class_df.loc[per_class_df.Dataset == 'Train', 'Value'].values[1], close_to(0.997, 0.001))
-
-
-def test_regression_alt_scores_list(diabetes_split_dataset_and_model):
-    # Arrange
-    train, test, model = diabetes_split_dataset_and_model
-    check = TrainTestPerformance(scorers=['max_error', 'r2', 'neg_mean_absolute_error'])
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['max_error'], close_to(-171.719, 0.001))
-    assert_that(result['r2'], close_to(0.427, 0.001))
-    assert_that(result['neg_mean_absolute_error'], close_to(-45.564, 0.001))
-
-
-def test_classification_alt_scores_per_class_and_macro(iris_split_dataset_and_model):
-    # Arrange
-    train, test, model = iris_split_dataset_and_model
-    check = TrainTestPerformance(scorers=['recall_per_class', 'f1_per_class', 'f1_macro', 'recall_micro'])
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['f1'], close_to(0.913, 0.001))
-    assert_that(result['f1_macro'], close_to(result['f1'], 0.001))
-    assert_that(result['recall'], close_to(0.916, 0.001))
-    assert_that(result['recall_micro'], close_to(0.92, 0.001))
-

--- a/tests/tabular/checks/model_evaluation/train_test_performance_test.py
+++ b/tests/tabular/checks/model_evaluation/train_test_performance_test.py
@@ -155,42 +155,6 @@ def test_regression(diabetes_split_dataset_and_model):
             assert_that(metric_col['Value'].iloc[0], instance_of(float))
 
 
-def test_regression_reduced(diabetes_split_dataset_and_model):
-    # Arrange
-    train, test, model = diabetes_split_dataset_and_model
-    check = TrainTestPerformance()
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['Neg RMSE'], close_to(-57.412, 0.001))
-    assert_that(result['Neg MAE'], close_to(-45.5645, 0.001))
-    assert_that(result['R2'], close_to(0.427, 0.001))
-
-
-def test_classification_reduced(iris_split_dataset_and_model):
-    # Arrange
-    train, test, model = iris_split_dataset_and_model
-    check = TrainTestPerformance()
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['F1'], close_to(0.913, 0.001))
-    assert_that(result['Precision'], close_to(0.929, 0.001))
-    assert_that(result['Recall'], close_to(0.916, 0.001))
-
-
-def test_classification_reduced_param(iris_split_dataset_and_model):
-    # Arrange
-    train, test, model = iris_split_dataset_and_model
-    check = TrainTestPerformance(reduce=np.min)
-    # Act
-    result = check.run(train, test, model).reduce_output()
-    # Assert
-    assert_that(result['F1'], close_to(0.857, 0.001))
-    assert_that(result['Precision'], close_to(0.789, 0.001))
-    assert_that(result['Recall'], close_to(0.75, 0.001))
-
-
 def test_condition_min_score_not_passed(iris_split_dataset_and_model):
     # Arrange
     train, test, model = iris_split_dataset_and_model


### PR DESCRIPTION
Current reduce value is the performance on Test, which can be achieved by the SingleDatasetPerformance check. No need for that one only for it's display.
