### PR TITLE
Implement PerformanceDisparityReport

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/__init__.py
+++ b/deepchecks/tabular/checks/model_evaluation/__init__.py
@@ -15,6 +15,7 @@ from .confusion_matrix_report import ConfusionMatrixReport
 from .model_inference_time import ModelInferenceTime
 from .model_info import ModelInfo
 from .multi_model_performance_report import MultiModelPerformanceReport
+from .performance_disparity_report import PerformanceDisparityReport
 from .regression_error_distribution import RegressionErrorDistribution
 from .regression_systematic_error import RegressionSystematicError
 from .roc_report import RocReport
@@ -25,7 +26,6 @@ from .train_test_performance import TrainTestPerformance
 from .train_test_prediction_drift import TrainTestPredictionDrift
 from .unused_features import UnusedFeatures
 from .weak_segments_performance import WeakSegmentsPerformance
-from .performance_disparity_report import PerformanceDisparityReport
 
 __all__ = [
     'BoostingOverfit',

--- a/deepchecks/tabular/checks/model_evaluation/__init__.py
+++ b/deepchecks/tabular/checks/model_evaluation/__init__.py
@@ -44,5 +44,5 @@ __all__ = [
     'WeakSegmentsPerformance',
     'UnusedFeatures',
     'SingleDatasetPerformance',
-    "PerformanceDisparityReport"
+    'PerformanceDisparityReport'
 ]

--- a/deepchecks/tabular/checks/model_evaluation/__init__.py
+++ b/deepchecks/tabular/checks/model_evaluation/__init__.py
@@ -25,6 +25,7 @@ from .train_test_performance import TrainTestPerformance
 from .train_test_prediction_drift import TrainTestPredictionDrift
 from .unused_features import UnusedFeatures
 from .weak_segments_performance import WeakSegmentsPerformance
+from .performance_disparity_report import PerformanceDisparityReport
 
 __all__ = [
     'BoostingOverfit',
@@ -42,5 +43,6 @@ __all__ = [
     'TrainTestPredictionDrift',
     'WeakSegmentsPerformance',
     'UnusedFeatures',
-    'SingleDatasetPerformance'
+    'SingleDatasetPerformance',
+    "PerformanceDisparityReport"
 ]

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -103,9 +103,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         self.validate_attributes()
 
     def validate_attributes(self):
-        """
-        Validate attributes passed to the check.
-        """
+        """Validate attributes passed to the check."""
         if self.max_categories < 2:
             raise DeepchecksValueError("Maximum number of categories must be at least 2.")
 
@@ -126,6 +124,8 @@ class PerformanceDisparityReport(SingleDatasetCheck):
 
     def run_logic(self, context: Context, dataset_kind: DatasetKind) -> CheckResult:
         """
+        Run the check logic.
+
         Returns
         -------
         CheckResult
@@ -160,9 +160,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         return CheckResult(value=scores_df, display=fig)
 
     def _validate_run_arguments(self, data):
-        """
-        Validate arguments passed to `run_logic` method.
-        """
+        """Validate arguments passed to `run_logic` method."""
         if self.protected_feature not in data.columns:
             raise DeepchecksValueError(f"Feature {self.protected_feature} not found in dataset.")
 
@@ -175,9 +173,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             )
 
     def _make_partitions(self, dataset):
-        """
-        Define partitions of a given dataset based on `feature` and `control_feature`
-        """
+        """Define partitions of a given dataset based on `feature` and `control_feature`."""
         partitions = {}
 
         if dataset.is_categorical(self.protected_feature):
@@ -195,7 +191,9 @@ class PerformanceDisparityReport(SingleDatasetCheck):
 
     def _make_scores_df(self, model, dataset, scorer, partitions, model_classes):
         """
-        Computes performance scores disaggregated by `feature` and `control_feature` categories,
+        Compute performance scores.
+
+        Compute performance scores disaggregated by `feature` and `control_feature` categories,
         and averaged over `feature` for each `control_feature` level. Also computes subgroup size.
         """
         classwise = is_classwise(scorer, model, dataset)
@@ -244,7 +242,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         # Drop subgroup dataset
         scores_df.drop(labels=["_dataset"], axis=1, inplace=True)
 
-        # For classwise prediction, explode the scores to a row per class
+        # For class-wise prediction, explode the scores to a row per class
         if classwise:
             scores_df.insert(len(scores_df.columns) - 3, "_class", scores_df.apply(lambda x: list(x["_score"]), axis=1))
             scores_df["_score"] = scores_df.apply(lambda x: list(x["_score"].values()), axis=1)
@@ -328,7 +326,6 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         Figure
             Figure showing subgroups with the largest performance disparities.
         """
-
         visual_df = scores_df.copy().dropna()
         if len(visual_df) == 0:
             # Return text figure: "No scores to display"
@@ -438,8 +435,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         return fig
 
     def add_condition_bounded_performance_difference(self, lower_bound, upper_bound=np.Inf):
-        """Add condition - require performance difference between baseline and subgroups to be
-        between the given bounds.
+        """Add condition - require performance difference to be between the given bounds.
 
         Performance difference is defined as (score - baseline).
 
@@ -466,8 +462,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         )
 
     def add_condition_bounded_relative_performance_difference(self, lower_bound, upper_bound=np.Inf):
-        """Add condition - require relative performance difference between baseline and
-        subgroups to be between the given bounds.
+        """Add condition - require relative performance difference to be between the given bounds.
 
         Relative performance difference is defined as (score - baseline) / baseline.
 
@@ -502,6 +497,8 @@ class PerformanceDisparityReport(SingleDatasetCheck):
 
 def expand_grid(**kwargs):
     """
+    Create combination of parameter values.
+
     Create a dataframe with one column for each named argument and rows corresponding to all
     possible combinations of the given arguments.
     """
@@ -510,7 +507,7 @@ def expand_grid(**kwargs):
 
 def combine_filters(filters, dataframe):
     """
-    Combine segment filters
+    Combine segment filters.
 
     Parameters
     ----------
@@ -535,8 +532,6 @@ def combine_filters(filters, dataframe):
 
 
 def is_classwise(scorer, model, dataset):
-    """
-    Check whether a given scorer provides an average score or a score for each class.
-    """
+    """Check whether a given scorer provides an average score or a score for each class."""
     test_result = scorer(model, dataset.copy(dataset.data.head()))
     return isinstance(test_result, dict)

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -149,7 +149,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             scorer = context.get_single_scorer(self.scorer)
         else:
             raise DeepchecksValueError(f"Invalid scorer: {self.scorer}")
-        
+
         self._validate_run_arguments(dataset.data)
 
         partitions = self._make_partitions(dataset)

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -273,8 +273,8 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             baseline = df_row["_baseline"]
             score = df_row["_score"]
             color = "orangered" if df_row["_diff"] < 0 else "limegreen"
-            legendgroup = "Negative difference" if df_row["_diff"] < 0 else "Positive difference"
-            extra_label = "<extra></extra>" # Hide extra label in hover
+            legendgroup = "Negative differences" if df_row["_diff"] < 0 else "Positive differences"
+            extra_label = "<extra></extra>"  # Hide extra label in hover
 
             fig.add_trace(
                 go.Scatter(
@@ -299,7 +299,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             )
 
     def _add_legend(self, fig):
-        for outline, title in [("orangered", "Negative difference"), ("limegreen", "Positive difference")]:
+        for outline, title in [("orangered", "Negative differences"), ("limegreen", "Positive differences")]:
             for color, label in [("white", "subgroup score"), ("#222222", "baseline score")]:
                 fig.add_traces(
                     go.Scatter(
@@ -334,17 +334,8 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         """
         visual_df = scores_df.copy().dropna()
         if len(visual_df) == 0:
-            # Return text figure: "No scores to display"
-            fig = go.Figure()
-            fig.update_layout(xaxis_visible=False, yaxis_visible=False)
-            fig.add_annotation(
-                text="No scores to display",
-                xref="paper",
-                yref="paper",
-                showarrow=False,
-                font=dict(size=28),
-            )
-            return fig
+            return ("No scores to display. "
+                f"Subgroups may be smaller than the minimum size of {self.min_subgroup_size}.")
 
         has_control = self.control_feature is not None
         has_model_classes = "_class" in visual_df.columns.values
@@ -418,7 +409,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         n_cat = 1
         if has_control or has_model_classes:
             n_cat = len(visual_df[subplot_grouping].drop_duplicates())
-            title += f" per plot and {rows}/{n_cat} "
+            title += f" per subplot and {rows}/{n_cat} "
             if has_control and not has_model_classes:
                 title += f"{self.control_feature}"
             elif has_model_classes and not has_control:

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -9,20 +9,20 @@
 # ----------------------------------------------------------------------------
 #
 """The performance_disparity_report check module."""
-from deepchecks.tabular import Context, SingleDatasetCheck
-from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
-from deepchecks.core.errors import DeepchecksProcessError, DeepchecksValueError
-from deepchecks.core.checks import DatasetKind
-from deepchecks.utils.typing import Hashable
-from typing import Union, Callable, Tuple
-from deepchecks.utils.performance.partition import partition_column
+import itertools
+from typing import Callable, Tuple, Union
 
+import numpy as np
+import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-import pandas as pd
-import numpy as np
-import itertools
+from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
+from deepchecks.core.checks import DatasetKind
+from deepchecks.core.errors import DeepchecksProcessError, DeepchecksValueError
+from deepchecks.tabular import Context, SingleDatasetCheck
+from deepchecks.utils.performance.partition import partition_column
+from deepchecks.utils.typing import Hashable
 
 
 class PerformanceDisparityReport(SingleDatasetCheck):
@@ -274,7 +274,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             score = df_row["_score"]
             color = "orangered" if df_row["_diff"] < 0 else "limegreen"
             legendgroup = "Negative difference" if df_row["_diff"] < 0 else "Positive difference"
-            extra_label = "<extra></extra>"
+            extra_label = "<extra></extra>" # Hide extra label in hover
 
             fig.add_trace(
                 go.Scatter(

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -1,15 +1,13 @@
 from deepchecks.tabular import Context, SingleDatasetCheck
 from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
-from deepchecks.tabular import Dataset
-from deepchecks.core.errors import DeepchecksValueError, DeepchecksNotImplementedError
+from deepchecks.core.errors import DeepchecksProcessError, DeepchecksValueError
 from deepchecks.core.check_result import CheckResult
 from deepchecks.core.checks import DatasetKind
 from deepchecks.utils.typing import Hashable
-from typing import Union, Callable
 from deepchecks.utils.performance.partition import partition_column
 
-import plotly.express as px
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 import pandas as pd
 import numpy as np
@@ -20,11 +18,15 @@ class PerformanceDisparityReport(SingleDatasetCheck):
     """
     Check for performance disparities across subgroups, while optionally accounting for a control variable.
 
-    The check compares performance scores within subgroups defined by a given feature to average performance scores. Subgroups with large performance disparities are displayed. Conditions can be added to flag performance disparities above a given threshold. If a control feature is provided, then the data is first split across the groups defined by this feature. Then, subgroup performance is compared to average performance at the corresponding control feature level.
+    The check identifies "performance disparities": large performance difference for a subgroup compared to the baseline performance for the full population.
+
+    Subgroups are defined by the levels of a "protected" feature. Numerical features are first binned into quantiles, while categorical features are preserved as-is. The baseline score is the overall score when all subgroups are combined. You can add conditions to flag performance differences outside of given bounds. A visual display is also provided to identify subgroups with the largest performance disparities.
+
+    Additionally, the analysis may be separated across the levels of a "control" feature. Numerical features are binned and categorical features are re-binned into `max_number` categories. To account for the control feature, baseline scores and subgroup scores are be computed within each of its levels.
 
     Parameters
     ----------
-    feature : Hashable
+    protected_feature : Hashable
         Feature evaluated for performance disparities. Numerical features are binned into `max_segments` quantiles. Categorical features are not transformed.
     control_feature : Hashable, default: None
         Feature used to group data prior to evaluating performance disparities (disparities are only assessed within the groups defined by this feature). Numerical features are binned into `max_segments` quantiles. Categorical features are re-grouped into at most `max_segments` groups if necessary.
@@ -34,8 +36,10 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         Maximum number of segments into which `control_feature` is binned.
     min_subgroup_size : int, default: 5
         Minimum size of a subgroup for which to compute a performance score.
-    max_subgroups_to_display : int, default: 5
-        Maximum number of subgroups to display in the "largest performance disparity" plot.
+    max_subgroups_per_category_to_display : int, default: 3
+        Maximum number of subgroups to display.
+    max_categories_to_display: int, default: 3
+        Maximum number of `control_feature` categories to display.
     use_avg_defaults : bool, default: True
         If no scorer was provided, determines whether to return an average score (if True) or a score per class (if False).
     n_samples : int, default: 1_000_000
@@ -48,10 +52,11 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         self,
         protected_feature: Hashable,
         control_feature: Hashable = None,
-        scorer: str = None,  # TODO: Allow for Callable or DeepCheckScorer
+        scorer: str = None,  # TODO: Question: should we allow for Callable or DeepCheckScorer?
         max_segments: int = 10,
         min_subgroup_size: int = 5,
-        max_subgroups_to_display: int = 5,
+        max_subgroups_per_category_to_display: int = 3,
+        max_categories_to_display: int = 3,
         use_avg_defaults: bool = True,
         n_samples: int = 1_000_000,
         random_state: int = 42,
@@ -63,10 +68,35 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         self.max_segments = max_segments
         self.min_subgroup_size = min_subgroup_size
         self.scorer = scorer
-        self.max_subgroups_to_display = max_subgroups_to_display
+        self.max_subgroups_per_category_to_display = max_subgroups_per_category_to_display
+        self.max_categories_to_display = max_categories_to_display
         self.use_avg_defaults = use_avg_defaults
         self.n_samples = n_samples
         self.random_state = random_state
+
+        self.validate_attributes()
+
+    def validate_attributes(self):
+        """
+        Validate attributes passed to the check.
+        """
+        if self.max_segments < 2:
+            raise DeepchecksValueError("Maximum number of segments must be at least 2.")
+
+        if self.min_subgroup_size < 1:
+            raise DeepchecksValueError("Minimum subgroup size must be at least 1.")
+
+        if self.max_subgroups_per_category_to_display < 1:
+            raise DeepchecksValueError("Maximum number of subgroups to display must be at least 1.")
+
+        if self.max_categories_to_display < 1:
+            raise DeepchecksValueError("Maximum number of categories to display must be at least 1.")
+
+        if self.n_samples < 1:
+            raise DeepchecksValueError("Number of samples must be at least 1.")
+
+        if not isinstance(self.random_state, int):
+            raise DeepchecksValueError(f"Random state must be an integer, got {self.random_state}.")
 
     def run_logic(self, context: Context, dataset_kind: DatasetKind) -> CheckResult:
         """
@@ -83,16 +113,31 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         else:
             scorer = context.get_single_scorer(use_avg_defaults=self.use_avg_defaults)
 
+        self.validate_run_arguments(dataset.data, model, scorer)
+
         partitions = self.make_partitions(dataset)
 
-        scores_df = self.make_scores_df(model, dataset, scorer, partitions)
+        scores_df = self.make_scores_df(model, dataset, scorer, partitions, context.model_classes)
 
         if context.with_display:
-            fig = self.make_largest_difference_figure2(scores_df)
+            fig = self.make_largest_difference_figure(scores_df)
         else:
             fig = None
 
         return CheckResult(value=scores_df, display=fig)
+
+    def validate_run_arguments(self, data, model, scorer):
+        """
+        Validate arguments passed to `run_logic` method.
+        """
+        if self.protected_feature not in data.columns:
+            raise DeepchecksValueError(f"Feature {self.protected_feature} not found in dataset.")
+
+        if self.control_feature is not None and self.control_feature not in data.columns:
+            raise DeepchecksValueError(f"Feature {self.control_feature} not found in dataset.")
+
+        if self.control_feature is not None and self.control_feature == self.protected_feature:
+            raise DeepchecksValueError(f"protected_feature {self.control_feature} and control_feature {self.protected_feature} are the same.")
 
     def make_partitions(self, dataset):
         """
@@ -113,7 +158,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
 
         return partitions
 
-    def make_scores_df(self, model, dataset, scorer, partitions):
+    def make_scores_df(self, model, dataset, scorer, partitions, model_classes):
         """
         Computes performance scores disaggregated by `feature` and `control_feature` levels, and averaged over `feature` for each `control_feature` level. Also computes subgroup size.
         """
@@ -122,23 +167,39 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         scores_df = expand_grid(**partitions, _scorer=[scorer])
 
         scores_df["_dataset"] = scores_df.apply(lambda x: combine_filters(x[partitions.keys()], dataset.data), axis=1)
-        scores_df["_score"] = scores_df.apply(lambda x: x._scorer(model, dataset.copy(x._dataset)), axis=1)
+
+        def score(data, model, scorer):
+            if len(data) == 0:
+                if classwise:
+                    return {cls: np.nan for cls in model_classes}
+                else:
+                    return np.nan
+            return scorer(model, dataset.copy(data))
+        def apply_scorer(x):
+            return score(x["_dataset"], model, x["_scorer"])
+
+        scores_df["_score"] = scores_df.apply(apply_scorer, axis=1)
         if self.control_feature is not None:
             control_scores = {
-                x.label: scorer(model, dataset.copy(x.filter(dataset.data)))
+                x.label: score(x.filter(dataset.data), model, scorer) 
                 for x in scores_df[self.control_feature].unique()
             }
+            control_count = {x.label: len(x.filter(dataset.data)) for x in scores_df[self.control_feature].unique()}
             scores_df["_baseline"] = scores_df.apply(lambda x: control_scores[x[self.control_feature].label], axis=1)
+            scores_df["_baseline_count"] = scores_df.apply(
+                lambda x: control_count[x[self.control_feature].label], axis=1
+            )
         else:
             overall_score = scorer(model, dataset)
+            overall_len = len(dataset.data)
             scores_df["_baseline"] = scores_df.apply(lambda x: overall_score, axis=1)
-        scores_df["_scorer"] = scores_df.apply(lambda x: x._scorer.name, axis=1)
-        scores_df["_count"] = scores_df.apply(lambda x: len(x._dataset), axis=1)
+            scores_df["_baseline_count"] = scores_df.apply(lambda x: overall_len, axis=1)
+        scores_df["_scorer"] = scores_df.apply(lambda x: x["_scorer"].name, axis=1)
+        scores_df["_count"] = scores_df.apply(lambda x: len(x["_dataset"]), axis=1)
         for col_name in partitions.keys():
             scores_df[col_name] = scores_df.apply(lambda x: x[col_name].label, axis=1)
 
         scores_df.drop(labels=["_dataset"], axis=1, inplace=True)
-
         if classwise:
             scores_df.insert(len(scores_df.columns) - 3, "_class", scores_df.apply(lambda x: list(x["_score"]), axis=1))
             scores_df["_score"] = scores_df.apply(lambda x: list(x["_score"].values()), axis=1)
@@ -147,49 +208,42 @@ class PerformanceDisparityReport(SingleDatasetCheck):
 
         scores_df["_score"] = scores_df["_score"].astype(float)
         scores_df["_baseline"] = scores_df["_baseline"].astype(float)
-
-        scores_df = scores_df.loc[scores_df._count >= self.min_subgroup_size]
+        
+        scores_df["_diff"] = scores_df["_score"] - scores_df["_baseline"]
+        scores_df.sort_values("_diff", inplace=True)
 
         return scores_df
 
-    def make_visual_df(self, scores_df: pd.DataFrame):
-        """
-        Make visualization-ready dataframe.
-        """
-        visual_df = scores_df.copy()
-        visual_df["_diff"] = visual_df["_score"] - visual_df["_baseline"]
-        visual_df["_group"] = visual_df[self.protected_feature]
-        visual_df["_avg_group"] = "All"
-        if self.control_feature is not None:
-            visual_df["_group"] += " (" + visual_df[self.control_feature] + ")"
-            visual_df["_avg_group"] = visual_df[self.control_feature]
-        if "_class" in visual_df.columns:
-            visual_df["_group"] += ", " + visual_df["_class"].astype(str)
-        visual_df["_count"] = "(" + visual_df._count.astype(str) + ")"
-        class_string = ""
-        if "_class" in scores_df.columns:
-            class_string = ", " + scores_df._class.astype(str)
-        control_feature_string = ""
-        if self.control_feature is not None:
-            control_feature_string = visual_df[self.control_feature]
+    def _add_differences_traces(self, sub_visual_df, fig, row=1, col=1):
+        sub_visual_df = sub_visual_df.sort_values("_diff").head(self.max_subgroups_per_category_to_display)
+        sub_visual_df = sub_visual_df.sort_values("_diff", ascending=False)
+        for _, df_row in sub_visual_df.iterrows():
+            subgroup = df_row[self.protected_feature]
+            baseline = df_row["_baseline"]
+            score = df_row["_score"]
+            color = "orangered" if df_row["_diff"] < 0 else "limegreen"
+            extra_label = "<extra></extra>"
 
-        visual_df["_details"] = (
-            'Score difference between average "'
-            + control_feature_string
-            + class_string
-            + '" ('
-            + visual_df["_baseline"].round(3).astype(str)
-            + ') and "'
-            + visual_df["_group"]
-            + '" ('
-            + visual_df._score.round(3).astype(str)
-            + ")."
-        )
-        visual_df = visual_df.sort_values(by="_diff", ascending=True)
-        visual_df = visual_df.head(self.max_subgroups_to_display)
-        visual_df = visual_df.sort_values(by="_diff", ascending=False)
-
-        return visual_df
+            fig.add_trace(
+                go.Scatter(
+                    x=[score, baseline],
+                    y=[subgroup, subgroup],
+                    hovertemplate=[
+                        "%{y}: %{x} (group size: " + str(df_row["_count"]) + ")" + extra_label,
+                        "baseline: %{x} (group size: " + str(df_row["_baseline_count"]) + ")" + extra_label,
+                    ],
+                    marker=dict(
+                        color=["white", "#222222"], symbol=0, size=6, line=dict(width=[2, 2], color=[color, color])
+                    ),
+                    line=dict(color=color, width=8),
+                    opacity=1,
+                    showlegend=False,
+                    mode="lines+text+markers",
+                    cliponaxis=False,
+                ),
+                row=row,
+                col=1,
+            )
 
     def make_largest_difference_figure(self, scores_df: pd.DataFrame):
         """
@@ -206,146 +260,125 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             Figure showing subgroups with the largest performance disparities.
         """
 
-        title = f"Largest differences between average score and subgroup score"
-        if self.control_feature is not None:
-            title += f" at a given {self.control_feature} level"
+        visual_df = scores_df.copy().dropna()
 
-        visual_df = self.make_visual_df(scores_df)
+        has_control = self.control_feature is not None
+        has_model_classes = "_class" in visual_df.columns.values
 
-        title += f"<br><sup>(Group size indicated in parenthesis)</sup>"
-        fig = px.bar(
-            visual_df,
-            x="_diff",
-            y="_group",
-            barmode="group",
-            text="_count",
-            hover_data=["_details"],
-            title=title,
-            labels={"_diff": "Score difference", "_group": "Group"},
-        )
-        return fig
-
-    def make_largest_difference_figure2(self, scores_df: pd.DataFrame):
-        """
-        Create "largest performance disparity" figure, version 2.
-
-        Parameters
-        ----------
-        scores_df : DataFrame
-            Dataframe of performance scores, as returned by `make_scores_df()`, disaggregated by feature and control_feature, and with average scores for each control_feature level. Columns named after `feature` and (optionally) `control_feature` are expected, as well as columns named "_scorer", "_score", "_baseline", and "_count".
-
-        Returns
-        -------
-        Figure
-            Figure showing subgroups with the largest performance disparities.
-        """
-        visual_df = self.make_visual_df(scores_df)
-
-        fig = go.Figure()
-
-        for _, row in visual_df.iterrows():
-            x = row["_group"]
-            y0 = row["_baseline"]
-            y1 = row["_score"]
-            color = "orangered" if row["_diff"] < 0 else "limegreen"
-            textposition = ["top left", "top right"] if row["_diff"] < 0 else ["top right", "top left"]
-
-            baseline_pt_label = "baseline"
-            if self.control_feature is not None:
-                baseline_pt_label = "(" + row[self.control_feature] + ")"
-            if "_class" in visual_df.columns:
-                baseline_pt_label += ", " + row["_class"]
-            fig.add_traces(
-                go.Scatter(
-                    x=[y1, y0],
-                    y=[x, x],
-                    text=[row._group, baseline_pt_label],
-                    textposition=textposition,
-                    textfont=dict(size=11),
-                    marker=dict(
-                        color=["white", "#222222"], 
-                        symbol=0, 
-                        size=7, 
-                        line=dict(width=[3, 3], 
-                        color=[color, color])
-                    ),
-                    line=dict(color=color, width=10),
-                    opacity=0.9,
-                    showlegend=False,
-                    hoverinfo=["x+y", "x+text"],
-                    customdata=visual_df._group,
-                    mode="lines+text+markers",
-                    cliponaxis=False,
-                ),
+        subplot_grouping = []
+        if has_control:
+            subplot_grouping += [self.control_feature]
+        if has_model_classes:
+            subplot_grouping += ["_class"]
+        # Get distinct subplot categories with the largest observed differences
+        if len(subplot_grouping) > 0:
+            subplots_categories = (
+                visual_df.sort_values("_diff", ascending=True)[subplot_grouping]
+                .drop_duplicates()
+                .head(self.max_categories_to_display)
             )
-
-        title = f"Top {len(visual_df)} largest differences between baseline score and subgroup score"
-        xaxis_title = f"{self.protected_feature}"
-        if self.control_feature is not None:
-            title += f" (controlling for {self.control_feature})"
-            title += (
-                f"<br><sup>(Black point is the baseline score for the corresponding {self.control_feature} group)</sup>"
-            )
-            xaxis_title += f" ({self.control_feature})"
+            rows = len(subplots_categories)
+            if rows == 0:
+                raise DeepchecksProcessError("Nothing to display.")
         else:
-            title += f"<br><sup>(Black point is the baseline score)</sup>"
-        if "_class" in visual_df.columns:
-            xaxis_title += ", model_class"
+            subplots_categories = None
+            rows = 1
 
-        fig.update_layout(
-            title=title,
-            yaxis_title=xaxis_title,
-            xaxis_title=f"Score",
-            yaxis_showticklabels=False,
-            yaxis_showgrid=False,
+        subplot_titles = ""
+        if has_control:
+            subplot_titles += f"{self.control_feature}=" + subplots_categories[self.control_feature]
+        if has_control and has_model_classes:
+            subplot_titles += f", model_class=" + subplots_categories["_class"]
+        if has_model_classes and not has_control:
+            subplot_titles = f"model_class=" + subplots_categories["_class"]
+
+        fig = make_subplots(
+            rows=rows,
+            cols=1,
+            shared_xaxes=True,
+            subplot_titles=subplot_titles.values if isinstance(subplot_titles, pd.Series) else None,
+            vertical_spacing=0.7 / rows**1.5,
         )
+
+        if subplots_categories is not None:
+            i = 0
+            for _, cat in subplots_categories.iterrows():
+                i += 1
+                if has_control and not has_model_classes:
+                    I = visual_df[self.control_feature] == cat[self.control_feature]
+                elif has_model_classes and not has_control:
+                    I = visual_df["_class"] == cat["_class"]
+                elif has_control and has_model_classes:
+                    I = (visual_df[self.control_feature] == cat[self.control_feature]) & (
+                        visual_df["_class"] == cat["_class"]
+                    )
+                else:
+                    raise DeepchecksProcessError(
+                        "Cannot use subplot categories without control_feature or model classes."
+                    )
+
+                sub_visual_df = visual_df[I]
+                self._add_differences_traces(sub_visual_df, fig, row=i, col=1)
+        else:
+            self._add_differences_traces(visual_df, fig, row=1, col=1)
+
+        title = f"Largest performance differences"
+        if has_control and not has_model_classes:
+            title += f" within {self.control_feature} categories"
+        elif has_model_classes and not has_control:
+            title += " model_class categories"
+        if has_control and has_model_classes:
+            title += f" within {self.control_feature} and model_class categories"
+
+        n_subgroups = len(visual_df[self.protected_feature].unique())
+        n_subgroups_shown = min(n_subgroups, self.max_subgroups_per_category_to_display)
+        title += f"<br><sup>(Showing {n_subgroups_shown}/{n_subgroups} {self.protected_feature} levels"
+        n_cat = 1
+        if has_control or has_model_classes:
+            n_cat = len(visual_df[subplot_grouping].drop_duplicates())
+            title += f" per plot and {rows}/{n_cat} "
+            if has_control and not has_model_classes:
+                title += f"{self.control_feature}"
+            elif has_model_classes and not has_control:
+                title += "model_classes"
+            else:
+                title += f"({self.control_feature}, model_classes)"
+            title += " categories"
+        title += ")</sup>"
+
+        fig.update_layout(title_text=title)
+        fig.update_annotations(x=0, xanchor="left", font_size=12)
+        fig.update_layout({f"xaxis{rows}_title": f"{self.scorer} score"})
+        fig.update_layout({f"yaxis{i}_title": self.protected_feature for i in range(1, rows + 1)})
+        fig.update_layout({f"yaxis{i}_tickmode": "linear" for i in range(1, rows + 1)})
+
+        fig.update_layout(height=150 + 50 * rows + 20 * rows * n_subgroups_shown)
 
         return fig
 
     def add_condition_bounded_performance_difference(self, lower_bound, upper_bound=np.Inf):
-        """Add condition - require performance difference between baselines and subgroups to be within the given bounds.
+        """Add condition - require performance difference between baseline and subgroups to be between the given bounds.
 
         Parameters
         ----------
         lower_bound : float
-            Lower bound on (score - baseline). 
+            Lower bound on (score - baseline).
         upper_bound : float, default: Infinity
             Upper bound on (score - baseline). Infinite by default (large scores do no trigger the condition).
         """
+
         def bounded_performance_difference_condition(scores_df: pd.DataFrame) -> ConditionResult:
             differences = scores_df["_score"] - scores_df["_baseline"]
             I = (differences < lower_bound) | (differences > upper_bound)
 
-            details = f'Found {sum(I)} subgroups with performance differences outside of the given bounds.'
+            details = f"Found {sum(I)} subgroups with performance differences outside of the given bounds."
             category = ConditionCategory.PASS if sum(I) == 0 else ConditionCategory.FAIL
             return ConditionResult(category, details)
 
-        return self.add_condition(f'Performance differences are bounded between {lower_bound} and {upper_bound}.',
-                                  bounded_performance_difference_condition)
-    
-    def add_condition_bounded_relative_performance_difference(self, lower_bound, upper_bound=np.Inf):
-        """Add condition - require relative performance difference between baselines and subgroups to be within the given bounds.
-
-        Parameters
-        ----------
-        lower_bound : float
-            Lower bound on (score - baseline)/baseline. 
-        upper_bound : float, default: Infinity
-            Upper bound on (score - baseline)/baseline. Infinite by default (large scores do no trigger the condition).
-        """
-        def bounded_performance_difference_condition(scores_df: pd.DataFrame) -> ConditionResult:
-            differences = scores_df["_score"] - scores_df["_baseline"]
-            I_zero = scores_df["_baseline"] == 0
-            differences[I_zero] = differences * np.Inf
-            differences[~I_zero] = differences[~I_zero]/scores_df["_baseline"][~I_zero]
-            I = (differences < lower_bound) | (differences > upper_bound)
-
-            details = f'Found {sum(I)} subgroups with relative performance differences outside of the given bounds.'
-            category = ConditionCategory.PASS if sum(I) == 0 else ConditionCategory.FAIL
-            return ConditionResult(category, details)
-
-        return self.add_condition(f'Relative performance differences are bounded between {lower_bound} and {upper_bound}.',
-                                  bounded_performance_difference_condition)
+        return self.add_condition(
+            f"Performance differences are bounded between {lower_bound} and {upper_bound}.",
+            bounded_performance_difference_condition,
+        )
 
 
 def expand_grid(**kwargs):
@@ -384,5 +417,5 @@ def is_classwise(scorer, model, dataset):
     """
     Check whether a given scorer provides an average score or a score for each class.
     """
-    test_result = scorer(model, dataset.copy(dataset.data.head(5)))
+    test_result = scorer(model, dataset.copy(dataset.data.head()))
     return isinstance(test_result, dict)

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -1,0 +1,229 @@
+from deepchecks.tabular import Context, SingleDatasetCheck
+from deepchecks.core import CheckResult
+from deepchecks.tabular import Dataset
+from deepchecks.core.errors import DeepchecksValueError, DeepchecksNotImplementedError
+from deepchecks.core.check_result import CheckResult
+from deepchecks.core.checks import DatasetKind
+from deepchecks.utils.typing import Hashable
+from typing import Union, Callable
+from deepchecks.utils.performance.partition import partition_column
+
+import plotly.express as px
+
+import pandas as pd
+import numpy as np
+import itertools
+
+class PerformanceDisparityReport(SingleDatasetCheck):
+    """
+    Check for performance disparities across subgroups, while optionally accounting for a control variable.
+
+    The check compares performance scores within subgroups defined by a given feature to average performance scores. Subgroups with large performance disparities are displayed. Conditions can be added to flag performance disparities above a given threshold. If a control feature is provided, then the data is first split across the groups defined by this feature. Then, subgroup performance is compared to average performance at the corresponding control feature level.
+
+    Parameters
+    ----------
+    feature : Hashable
+        Feature evaluated for performance disparities. Numerical features are binned into `max_segments` quantiles. Categorical features are not transformed.
+    control_feature : Hashable, default: None
+        Feature used to group data prior to evaluating performance disparities (disparities are only assessed within the groups defined by this feature). Numerical features are binned into `max_segments` quantiles. Categorical features are not transformed.
+    scorer : str, default: None
+        Name of the performance score function to use.
+    max_segments : int, default: 10
+        Maximum number of segments into which numerical features (`target_feature` or `control_feature`) are binned.
+    min_subgroup_size : int, default: 5
+        Minimum size of a subgroup for which to compute a performance score.
+    max_subgroups_to_display : int, default: 5
+        Maximum number of subgroups to display in the "largest performance disparity" plot.
+    use_avg_defaults : bool, default: True
+        If no scorer was provided, determines whether to return an average score (if True) or a score per class (if False).
+    n_samples : int, default: 1_000_000
+        Number of samples from the dataset to use.
+    random_state : int, default: 42
+        Random state to use for probability sampling.
+    """
+
+
+    def __init__(self, 
+        feature: Hashable,
+        control_feature: Hashable = None,
+        scorer: str = None, # TODO: Allow for Callable or DeepCheckScorer
+        max_segments: int = 10,
+        min_subgroup_size: int = 5,
+        max_subgroups_to_display: int = 5,
+        use_avg_defaults: bool = True,
+        n_samples: int = 1_000_000,
+        random_state: int = 42,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.protected_feature = feature
+        self.control_feature = control_feature
+        self.max_segments = max_segments
+        self.min_subgroup_size = min_subgroup_size
+        self.scorer = scorer
+        self.max_subgroups_to_display = max_subgroups_to_display
+        self.use_avg_defaults = use_avg_defaults
+        self.n_samples = n_samples
+        self.random_state = random_state
+
+    def run_logic(self, context: Context, dataset_kind: DatasetKind) -> CheckResult:
+        """
+        Returns
+        -------
+        CheckResult
+            value is a dataframe with performance scores for within each subgroup defined by `feature` and average scores across these subgroups. If `control_feature` was provided, then performance scores are further disaggregated by the gruops defined by this feature.
+            display is a Figure showing the subgroups with the largest performance disparities.
+        """
+        model = context.model
+        dataset = context.get_data_by_kind(dataset_kind).sample(self.n_samples, random_state=self.random_state)
+        if self.scorer is not None:
+            scorer = context.get_single_scorer({self.scorer:self.scorer}, use_avg_defaults=self.use_avg_defaults)
+        else:
+            scorer = context.get_single_scorer(use_avg_defaults=self.use_avg_defaults)
+
+        partitions = self.make_partitions(dataset)
+        
+        scores_df = self.make_scores_df(model, dataset, scorer, partitions)
+
+        if context.with_display:
+            display = [self.make_largest_difference_figure(scores_df)]
+        else:
+            display = []
+        
+        return CheckResult(value=scores_df, display=display)
+    
+
+    def make_largest_difference_figure(self, scores_df: pd.DataFrame):
+        """
+        Create "largest performance disparity" figure.
+
+        Parameters
+        ----------
+        scores_df : DataFrame
+            Dataframe of performance scores, as returned by `make_scores_df()`, disaggregated by feature and control_feature, and with average scores for each control_feature level. Columns named after `feature` and (optionally) `control_feature` are expected, as well as columns named "_scorer", "_score", "_avg", and "_count".
+
+        Returns
+        -------
+        Figure
+            Figure showing subgroups with the largest performance disparities.
+        """
+        title=f"Largest differences between average score and subgroup score"
+        visual_df = scores_df.copy()
+        visual_df["_diff"] = visual_df._score - visual_df._avg
+        if self.control_feature is None:
+            visual_df["_group"] = visual_df[self.protected_feature]
+        else:
+            title += f" at a given {self.control_feature} level"
+            visual_df["_group"] = visual_df[self.protected_feature] + ", " + visual_df[self.control_feature]
+        visual_df["_count"] = "(" + visual_df._count.astype(str) + ")"
+        visual_df["_details"] = 'Score difference between "'+visual_df[self.control_feature]+'" ('+visual_df._avg.round(3).astype(str)+') and "' +visual_df["_group"] + '" ('+visual_df._score.round(3).astype(str)+').'
+        visual_df = visual_df.sort_values(by="_diff", ascending=True)
+        visual_df = visual_df.head(self.max_subgroups_to_display)
+        visual_df = visual_df.sort_values(by="_diff", ascending=False)
+        
+        title += f"<br><sup>(Group size indicated in parenthesis)</sup>"
+        fig = px.bar(
+            visual_df, 
+            x="_diff", 
+            y="_group", 
+            barmode="group", 
+            text="_count", 
+            hover_data = ["_details"],
+            title=title, 
+            labels={"_diff":"Score difference", "_group":"Group"})
+        return fig
+
+
+    def make_partitions(self, dataset):
+        """
+        Define partitions of a given dataset based on `feature` and `control_feature`
+        """
+        partitions = {}
+
+        if dataset.is_categorical(self.protected_feature):
+            partitions[self.protected_feature] = partition_column(dataset, self.protected_feature, max_segments=np.Inf)
+        else:
+            partitions[self.protected_feature] = partition_column(dataset, self.protected_feature, max_segments=self.max_segments)
+        if self.control_feature is not None:
+            if dataset.is_categorical(self.control_feature):
+                partitions[self.control_feature] = partition_column(dataset, self.control_feature, max_segments=np.Inf)
+            else:
+                partitions[self.control_feature] = partition_column(dataset, self.control_feature, max_segments=self.max_segments)
+
+        return partitions
+
+    def make_scores_df(self, model, dataset, scorer, partitions):
+        """
+        Computes performance scores disaggregated by `feature` and `control_feature` levels, and averaged over `feature` for each `control_feature` level. Also computes subgroup size.
+        """
+        classwise = is_classwise(scorer, model, dataset)
+        
+        scores_df = expand_grid(**partitions, _scorer=[scorer])
+
+        scores_df["_dataset"] = scores_df.apply(lambda x: combine_filters(x[partitions.keys()], dataset.data), axis=1)
+        scores_df["_score"] = scores_df.apply(lambda x: x._scorer(model, dataset.copy(x._dataset)), axis=1)
+        if self.control_feature is not None:
+            control_scores = {x.label: scorer(model, dataset.copy(x.filter(dataset.data))) for x in scores_df[self.control_feature].unique()}
+            scores_df["_avg"] = scores_df.apply(lambda x: control_scores[x[self.control_feature].label], axis=1)
+        else:
+            overall_score = scorer(model, dataset)
+            scores_df["_avg"] = scores_df.apply(lambda x: overall_score, axis=1)
+        scores_df["_scorer"] = scores_df.apply(lambda x: x._scorer.name, axis=1)
+        scores_df["_count"] = scores_df.apply(lambda x: len(x._dataset), axis=1)
+        for col_name in partitions.keys():
+            scores_df[col_name] = scores_df.apply(lambda x: x[col_name].label, axis=1)
+
+        scores_df.drop(labels=["_dataset"], axis=1, inplace=True)
+
+        if classwise:
+            scores_df.insert(len(scores_df.columns)-3, "_class", scores_df.apply(lambda x: list(x["_score"]), axis=1))
+            scores_df["_score"] = scores_df.apply(lambda x: list(x["_score"].values()), axis=1)
+            scores_df["_avg"] = scores_df.apply(lambda x: list(x["_avg"].values()), axis=1)
+            scores_df = scores_df.explode(column=["_score", "_class", "_avg"])
+
+        scores_df = scores_df.loc[scores_df._count >= self.min_subgroup_size]
+
+        return scores_df
+
+
+def expand_grid(**kwargs):
+    """
+    Create a dataframe with one column for each named argument and rows corresponding to all possible combinations of the given arguments.
+    """
+    return pd.DataFrame.from_records(
+        itertools.product(*kwargs.values()), columns=kwargs.keys()
+    )
+
+
+def combine_filters(filters, dataframe):
+    """
+    Combine segment filters
+
+    Parameters
+    ----------
+    filters: Series 
+        Series indexed by segment names and with values corresponding to segment filters to be applied to the data.
+    dataframe: DataFrame
+        DataFrame to which filters are applied.
+
+    Returns
+    -------
+    DataFrame
+        Data filtered to the given combination of segments.
+    """
+    segments = filters.index.values
+    filtered_data = filters[segments[0]].filter(dataframe)
+    if len(segments) > 1:
+        for i in range(1, len(segments)):
+            filtered_data = filters[segments[i]].filter(filtered_data)
+    
+
+    return filtered_data
+
+
+def is_classwise(scorer, model, dataset: Dataset):
+    """
+    Check whether a given scorer provides an average score or a score for each class.
+    """
+    test_result = scorer(model, dataset.copy(dataset.data.head(2)))
+    return isinstance(test_result, dict)

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -334,8 +334,9 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         """
         visual_df = scores_df.copy().dropna()
         if len(visual_df) == 0:
-            return ("No scores to display. "
-                f"Subgroups may be smaller than the minimum size of {self.min_subgroup_size}.")
+            return (
+                "No scores to display. " f"Subgroups may be smaller than the minimum size of {self.min_subgroup_size}."
+            )
 
         has_control = self.control_feature is not None
         has_model_classes = "_class" in visual_df.columns.values
@@ -370,7 +371,7 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             cols=1,
             shared_xaxes=True,
             subplot_titles=subplot_titles.values if isinstance(subplot_titles, pd.Series) else None,
-            vertical_spacing=0.7 / rows**1.5,
+            vertical_spacing=0.7 / rows ** 1.5,
         )
 
         if subplots_categories is not None:

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -1,5 +1,5 @@
 from deepchecks.tabular import Context, SingleDatasetCheck
-from deepchecks.core import CheckResult
+from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
 from deepchecks.tabular import Dataset
 from deepchecks.core.errors import DeepchecksValueError, DeepchecksNotImplementedError
 from deepchecks.core.check_result import CheckResult
@@ -9,10 +9,12 @@ from typing import Union, Callable
 from deepchecks.utils.performance.partition import partition_column
 
 import plotly.express as px
+import plotly.graph_objects as go
 
 import pandas as pd
 import numpy as np
 import itertools
+
 
 class PerformanceDisparityReport(SingleDatasetCheck):
     """
@@ -25,11 +27,11 @@ class PerformanceDisparityReport(SingleDatasetCheck):
     feature : Hashable
         Feature evaluated for performance disparities. Numerical features are binned into `max_segments` quantiles. Categorical features are not transformed.
     control_feature : Hashable, default: None
-        Feature used to group data prior to evaluating performance disparities (disparities are only assessed within the groups defined by this feature). Numerical features are binned into `max_segments` quantiles. Categorical features are not transformed.
+        Feature used to group data prior to evaluating performance disparities (disparities are only assessed within the groups defined by this feature). Numerical features are binned into `max_segments` quantiles. Categorical features are re-grouped into at most `max_segments` groups if necessary.
     scorer : str, default: None
         Name of the performance score function to use.
     max_segments : int, default: 10
-        Maximum number of segments into which numerical features (`target_feature` or `control_feature`) are binned.
+        Maximum number of segments into which `control_feature` is binned.
     min_subgroup_size : int, default: 5
         Minimum size of a subgroup for which to compute a performance score.
     max_subgroups_to_display : int, default: 5
@@ -42,18 +44,18 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         Random state to use for probability sampling.
     """
 
-
-    def __init__(self, 
+    def __init__(
+        self,
         protected_feature: Hashable,
         control_feature: Hashable = None,
-        scorer: str = None, # TODO: Allow for Callable or DeepCheckScorer
+        scorer: str = None,  # TODO: Allow for Callable or DeepCheckScorer
         max_segments: int = 10,
         min_subgroup_size: int = 5,
         max_subgroups_to_display: int = 5,
         use_avg_defaults: bool = True,
         n_samples: int = 1_000_000,
         random_state: int = 42,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.protected_feature = protected_feature
@@ -77,63 +79,20 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         model = context.model
         dataset = context.get_data_by_kind(dataset_kind).sample(self.n_samples, random_state=self.random_state)
         if self.scorer is not None:
-            scorer = context.get_single_scorer({self.scorer:self.scorer}, use_avg_defaults=self.use_avg_defaults)
+            scorer = context.get_single_scorer({self.scorer: self.scorer}, use_avg_defaults=self.use_avg_defaults)
         else:
             scorer = context.get_single_scorer(use_avg_defaults=self.use_avg_defaults)
 
         partitions = self.make_partitions(dataset)
-        
+
         scores_df = self.make_scores_df(model, dataset, scorer, partitions)
 
         if context.with_display:
-            fig = self.make_largest_difference_figure(scores_df)
+            fig = self.make_largest_difference_figure2(scores_df)
         else:
             fig = None
-        
+
         return CheckResult(value=scores_df, display=fig)
-    
-
-    def make_largest_difference_figure(self, scores_df: pd.DataFrame):
-        """
-        Create "largest performance disparity" figure.
-
-        Parameters
-        ----------
-        scores_df : DataFrame
-            Dataframe of performance scores, as returned by `make_scores_df()`, disaggregated by feature and control_feature, and with average scores for each control_feature level. Columns named after `feature` and (optionally) `control_feature` are expected, as well as columns named "_scorer", "_score", "_avg", and "_count".
-
-        Returns
-        -------
-        Figure
-            Figure showing subgroups with the largest performance disparities.
-        """
-        title=f"Largest differences between average score and subgroup score"
-        visual_df = scores_df.copy()
-        visual_df["_diff"] = visual_df._score - visual_df._avg
-        visual_df["_group"] = visual_df[self.protected_feature]
-        if self.control_feature is not None:
-            title += f" at a given {self.control_feature} level"
-            visual_df["_group"] += ", " + visual_df[self.control_feature]
-        if "_class" in visual_df.columns:
-            visual_df["_group"] += ", " + visual_df["_class"].astype(str)
-        visual_df["_count"] = "(" + visual_df._count.astype(str) + ")"
-        visual_df["_details"] = 'Score difference between "'+visual_df[self.control_feature]+'" ('+visual_df._avg.round(3).astype(str)+') and "' +visual_df["_group"] + '" ('+visual_df._score.round(3).astype(str)+').'
-        visual_df = visual_df.sort_values(by="_diff", ascending=True)
-        visual_df = visual_df.head(self.max_subgroups_to_display)
-        visual_df = visual_df.sort_values(by="_diff", ascending=False)
-        
-        title += f"<br><sup>(Group size indicated in parenthesis)</sup>"
-        fig = px.bar(
-            visual_df, 
-            x="_diff", 
-            y="_group", 
-            barmode="group", 
-            text="_count", 
-            hover_data = ["_details"],
-            title=title, 
-            labels={"_diff":"Score difference", "_group":"Group"})
-        return fig
-
 
     def make_partitions(self, dataset):
         """
@@ -144,32 +103,35 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         if dataset.is_categorical(self.protected_feature):
             partitions[self.protected_feature] = partition_column(dataset, self.protected_feature, max_segments=np.Inf)
         else:
-            partitions[self.protected_feature] = partition_column(dataset, self.protected_feature, max_segments=self.max_segments)
+            partitions[self.protected_feature] = partition_column(
+                dataset, self.protected_feature, max_segments=self.max_segments
+            )
         if self.control_feature is not None:
-            if dataset.is_categorical(self.control_feature):
-                partitions[self.control_feature] = partition_column(dataset, self.control_feature, max_segments=np.Inf)
-            else:
-                partitions[self.control_feature] = partition_column(dataset, self.control_feature, max_segments=self.max_segments)
+            partitions[self.control_feature] = partition_column(
+                dataset, self.control_feature, max_segments=self.max_segments
+            )
 
         return partitions
 
-    # TODO: Computation of group avg also needs to account for classes
     def make_scores_df(self, model, dataset, scorer, partitions):
         """
         Computes performance scores disaggregated by `feature` and `control_feature` levels, and averaged over `feature` for each `control_feature` level. Also computes subgroup size.
         """
         classwise = is_classwise(scorer, model, dataset)
-        
+
         scores_df = expand_grid(**partitions, _scorer=[scorer])
 
         scores_df["_dataset"] = scores_df.apply(lambda x: combine_filters(x[partitions.keys()], dataset.data), axis=1)
         scores_df["_score"] = scores_df.apply(lambda x: x._scorer(model, dataset.copy(x._dataset)), axis=1)
         if self.control_feature is not None:
-            control_scores = {x.label: scorer(model, dataset.copy(x.filter(dataset.data))) for x in scores_df[self.control_feature].unique()}
-            scores_df["_avg"] = scores_df.apply(lambda x: control_scores[x[self.control_feature].label], axis=1)
+            control_scores = {
+                x.label: scorer(model, dataset.copy(x.filter(dataset.data)))
+                for x in scores_df[self.control_feature].unique()
+            }
+            scores_df["_baseline"] = scores_df.apply(lambda x: control_scores[x[self.control_feature].label], axis=1)
         else:
             overall_score = scorer(model, dataset)
-            scores_df["_avg"] = scores_df.apply(lambda x: overall_score, axis=1)
+            scores_df["_baseline"] = scores_df.apply(lambda x: overall_score, axis=1)
         scores_df["_scorer"] = scores_df.apply(lambda x: x._scorer.name, axis=1)
         scores_df["_count"] = scores_df.apply(lambda x: len(x._dataset), axis=1)
         for col_name in partitions.keys():
@@ -178,26 +140,195 @@ class PerformanceDisparityReport(SingleDatasetCheck):
         scores_df.drop(labels=["_dataset"], axis=1, inplace=True)
 
         if classwise:
-            scores_df.insert(len(scores_df.columns)-3, "_class", scores_df.apply(lambda x: list(x["_score"]), axis=1))
+            scores_df.insert(len(scores_df.columns) - 3, "_class", scores_df.apply(lambda x: list(x["_score"]), axis=1))
             scores_df["_score"] = scores_df.apply(lambda x: list(x["_score"].values()), axis=1)
-            scores_df["_avg"] = scores_df.apply(lambda x: list(x["_avg"].values()), axis=1)
-            scores_df = scores_df.explode(column=["_score", "_class", "_avg"])
+            scores_df["_baseline"] = scores_df.apply(lambda x: list(x["_baseline"].values()), axis=1)
+            scores_df = scores_df.explode(column=["_score", "_class", "_baseline"])
 
         scores_df["_score"] = scores_df["_score"].astype(float)
-        scores_df["_avg"] = scores_df["_avg"].astype(float)
+        scores_df["_baseline"] = scores_df["_baseline"].astype(float)
 
         scores_df = scores_df.loc[scores_df._count >= self.min_subgroup_size]
 
         return scores_df
+
+    def make_visual_df(self, scores_df: pd.DataFrame):
+        """
+        Make visualization-ready dataframe.
+        """
+        visual_df = scores_df.copy()
+        visual_df["_diff"] = visual_df["_score"] - visual_df["_baseline"]
+        visual_df["_group"] = visual_df[self.protected_feature]
+        visual_df["_avg_group"] = "All"
+        if self.control_feature is not None:
+            visual_df["_group"] += " (" + visual_df[self.control_feature] + ")"
+            visual_df["_avg_group"] = visual_df[self.control_feature]
+        if "_class" in visual_df.columns:
+            visual_df["_group"] += ", " + visual_df["_class"].astype(str)
+        visual_df["_count"] = "(" + visual_df._count.astype(str) + ")"
+        class_string = ""
+        if "_class" in scores_df.columns:
+            class_string = ", " + scores_df._class.astype(str)
+        control_feature_string = ""
+        if self.control_feature is not None:
+            control_feature_string = visual_df[self.control_feature]
+
+        visual_df["_details"] = (
+            'Score difference between average "'
+            + control_feature_string
+            + class_string
+            + '" ('
+            + visual_df["_baseline"].round(3).astype(str)
+            + ') and "'
+            + visual_df["_group"]
+            + '" ('
+            + visual_df._score.round(3).astype(str)
+            + ")."
+        )
+        visual_df = visual_df.sort_values(by="_diff", ascending=True)
+        visual_df = visual_df.head(self.max_subgroups_to_display)
+        visual_df = visual_df.sort_values(by="_diff", ascending=False)
+
+        return visual_df
+
+    def make_largest_difference_figure(self, scores_df: pd.DataFrame):
+        """
+        Create "largest performance disparity" figure.
+
+        Parameters
+        ----------
+        scores_df : DataFrame
+            Dataframe of performance scores, as returned by `make_scores_df()`, disaggregated by feature and control_feature, and with average scores for each control_feature level. Columns named after `feature` and (optionally) `control_feature` are expected, as well as columns named "_scorer", "_score", "_baseline", and "_count".
+
+        Returns
+        -------
+        Figure
+            Figure showing subgroups with the largest performance disparities.
+        """
+
+        title = f"Largest differences between average score and subgroup score"
+        if self.control_feature is not None:
+            title += f" at a given {self.control_feature} level"
+
+        visual_df = self.make_visual_df(scores_df)
+
+        title += f"<br><sup>(Group size indicated in parenthesis)</sup>"
+        fig = px.bar(
+            visual_df,
+            x="_diff",
+            y="_group",
+            barmode="group",
+            text="_count",
+            hover_data=["_details"],
+            title=title,
+            labels={"_diff": "Score difference", "_group": "Group"},
+        )
+        return fig
+
+    def make_largest_difference_figure2(self, scores_df: pd.DataFrame):
+        """
+        Create "largest performance disparity" figure, version 2.
+
+        Parameters
+        ----------
+        scores_df : DataFrame
+            Dataframe of performance scores, as returned by `make_scores_df()`, disaggregated by feature and control_feature, and with average scores for each control_feature level. Columns named after `feature` and (optionally) `control_feature` are expected, as well as columns named "_scorer", "_score", "_baseline", and "_count".
+
+        Returns
+        -------
+        Figure
+            Figure showing subgroups with the largest performance disparities.
+        """
+        visual_df = self.make_visual_df(scores_df)
+
+        fig = go.Figure()
+
+        for _, row in visual_df.iterrows():
+            x = row["_group"]
+            y0 = row["_baseline"]
+            y1 = row["_score"]
+            color = "orangered" if row["_diff"] < 0 else "limegreen"
+            textposition = ["top left", "top right"] if row["_diff"] < 0 else ["top right", "top left"]
+
+            baseline_pt_label = "baseline"
+            if self.control_feature is not None:
+                baseline_pt_label = "(" + row[self.control_feature] + ")"
+            if "_class" in visual_df.columns:
+                baseline_pt_label += ", " + row["_class"]
+            fig.add_traces(
+                go.Scatter(
+                    x=[y1, y0],
+                    y=[x, x],
+                    text=[row._group, baseline_pt_label],
+                    textposition=textposition,
+                    textfont=dict(size=11),
+                    marker=dict(
+                        color=["white", "#222222"], 
+                        symbol=0, 
+                        size=7, 
+                        line=dict(width=[3, 3], 
+                        color=[color, color])
+                    ),
+                    line=dict(color=color, width=10),
+                    opacity=0.9,
+                    showlegend=False,
+                    hoverinfo=["x+y", "x+text"],
+                    customdata=visual_df._group,
+                    mode="lines+text+markers",
+                    cliponaxis=False,
+                ),
+            )
+
+        title = f"Top {len(visual_df)} largest differences between baseline score and subgroup score"
+        xaxis_title = f"{self.protected_feature}"
+        if self.control_feature is not None:
+            title += f" (controlling for {self.control_feature})"
+            title += (
+                f"<br><sup>(Black point is the baseline score for the corresponding {self.control_feature} group)</sup>"
+            )
+            xaxis_title += f" ({self.control_feature})"
+        else:
+            title += f"<br><sup>(Black point is the baseline score)</sup>"
+        if "_class" in visual_df.columns:
+            xaxis_title += ", model_class"
+
+        fig.update_layout(
+            title=title,
+            yaxis_title=xaxis_title,
+            xaxis_title=f"Score",
+            yaxis_showticklabels=False,
+            yaxis_showgrid=False,
+        )
+
+        return fig
+
+    def add_condition_bounded_performance_difference(self, lower_bound, upper_bound=np.Inf):
+        """Add condition - require performance difference between baselines and subgroups to be within the given bounds.
+
+        Parameters
+        ----------
+        lower_bound : float
+            Lower bound on (score - baseline). 
+        upper_bound : float, default: Infinity
+            Upper bound on (score - baseline). Infinite by default (large scores do no trigger the condition).
+        """
+        def bounded_performance_difference_condition(scores_df: pd.DataFrame) -> ConditionResult:
+            differences = scores_df["_score"] - scores_df["_baseline"]
+            I = (differences < lower_bound) | (differences > upper_bound)
+
+            details = f'Found {sum(I)} subgroups with performance differences outside of the given bounds.'
+            category = ConditionCategory.PASS if sum(I) == 0 else ConditionCategory.FAIL
+            return ConditionResult(category, details)
+
+        return self.add_condition(f'Performance differences are bounded between {lower_bound} and {upper_bound}.',
+                                  bounded_performance_difference_condition)
 
 
 def expand_grid(**kwargs):
     """
     Create a dataframe with one column for each named argument and rows corresponding to all possible combinations of the given arguments.
     """
-    return pd.DataFrame.from_records(
-        itertools.product(*kwargs.values()), columns=kwargs.keys()
-    )
+    return pd.DataFrame.from_records(itertools.product(*kwargs.values()), columns=kwargs.keys())
 
 
 def combine_filters(filters, dataframe):
@@ -206,7 +337,7 @@ def combine_filters(filters, dataframe):
 
     Parameters
     ----------
-    filters: Series 
+    filters: Series
         Series indexed by segment names and with values corresponding to segment filters to be applied to the data.
     dataframe: DataFrame
         DataFrame to which filters are applied.
@@ -221,12 +352,11 @@ def combine_filters(filters, dataframe):
     if len(segments) > 1:
         for i in range(1, len(segments)):
             filtered_data = filters[segments[i]].filter(filtered_data)
-    
 
     return filtered_data
 
 
-def is_classwise(scorer, model, dataset: Dataset):
+def is_classwise(scorer, model, dataset):
     """
     Check whether a given scorer provides an average score or a score for each class.
     """

--- a/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/performance_disparity_report.py
@@ -141,9 +141,15 @@ class PerformanceDisparityReport(SingleDatasetCheck):
             scorer = context.get_single_scorer()
         elif isinstance(self.scorer, str):
             scorer = context.get_single_scorer({self.scorer: self.scorer})
-        else:
+        elif isinstance(self.scorer, tuple):
             scorer = context.get_single_scorer(dict([self.scorer]))
-
+        elif isinstance(self.scorer, dict):
+            if len(self.scorer) > 1:
+                raise DeepchecksValueError("Only one scorer can be passed to the check.")
+            scorer = context.get_single_scorer(self.scorer)
+        else:
+            raise DeepchecksValueError(f"Invalid scorer: {self.scorer}")
+        
         self._validate_run_arguments(dataset.data)
 
         partitions = self._make_partitions(dataset)

--- a/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
@@ -15,7 +15,7 @@ This notebook provides an overview for using and understanding the Performance D
 What is the purpose of the check?
 ==================================
 
-The check is designed to help you identify subgroups for which the model has a much lower performance score than its baseline score (its overall performance). The subgroups are defined by a chosen *protected* feature (e.g., "sex", "race") and you can specify a *control* feature (e.g., "education") by which to group the data before computing performance differences.
+The check is designed to help you identify subgroups for which the model has a much lower performance score than its baseline score (its overall performance). The subgroups are defined by a chosen *protected* feature (e.g., "sex", "race") and you can specify a *control* feature (e.g., "education") by which to group the data before computing performance differences. This is primarily useful for fairness analyses, but can also be used to identify other types of performance disparities.
 
 Large performance disparities can indicate a problem with the model. The training data may not be sufficient for certain subgroups or may contain biases, or the model may need to be re-calibrated when applied to certain subgroups. When using appropriate scoring functions, looking at performance disparities can help uncover issues of these kinds.
 

--- a/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+Performance Disparity Report
+*************************
+
+This notebook provides an overview for using and understanding the Performance Disparity Report check.
+
+**Structure:**
+
+* `What is the purpose of the check? <#what-is-the-purpose-of-the-check>`__
+* `Automatically detecting weak segments <#automatically-detecting-weak-segments>`__
+* `Generate data & model <#generate-data-model>`__
+* `Run the check <#run-the-check>`__
+* `Define a condition <#define-a-condition>`__
+
+What is the purpose of the check?
+==================================
+
+The check is designed to help you identify subgroups for which the model has a much lower performance score than its baseline score (its overall performance). The subgroups are defined by a chosen *protected* feature (e.g., "sex", "race") and you can specify a *control* feature (e.g., "education") by which to group the data before computing performance differences.
+
+Large performance disparities can indicate a problem with the model. The training data may not be sufficient for certain subgroups or may contain biases, or the model may need to be re-calibrated when applied to certain subgroups. When using appropriate scoring functions, looking at performance disparities can help uncover issues of these kinds.
+
+Remember that this check relies on labeled data provided in the dataset. As such, it can only assess performance disparities to the extent that the labeled data is accurate and representative of the population of interest. Using scoring functions that are robust to class imbalance or that are computed for each model class can help mitigate this issue.
+"""
+
+#%%
+# Generate data & model
+# =====================
+
+from deepchecks.tabular.datasets.classification.adult import (
+    load_data, load_fitted_model)
+
+train_dataset, test_dataset = load_data()
+model = load_fitted_model()
+
+#%%
+# Run the check
+# =============
+#
+# The check requires the argument ``protected_feature`` identifying a column that defines the subgroups
+# for which performance disparities are assessed. In addition, the check has several optional parameters
+# that affect its behavior and output.
+# 
+# ``control_feature``: Column to use to split the data by groups prior to computing performance disparities.
+# 
+# ``scorer``: Scoring function to measure performance.
+# 
+# ``max_segments``: Maximum number of segments into which numerical features are binned. This is also a
+# maximum on the number of levels for a categorical ``control_feature``.
+#
+# ``min_subgroup_size``: Minimum size of a subgroup for which to compute a performance score.
+# 
+# ``max_subgroups_per_category_to_display``: Maximum number of subgroups (per ``control_feature`` category)
+# to display.
+# 
+# ``max_categories_to_display``: Maximum number of ``control_feature`` levels to display.
+# 
+# ``use_avg_defaults``: If no scorer was provided, determines whether to return an average score (if True) 
+# or a score per class (if False).
+# 
+# see :class:`API reference <deepchecks.tabular.checks.model_evaluation.PerformanceDisparityReport>` for 
+# more details.
+
+from deepchecks.tabular.checks.model_evaluation import PerformanceDisparityReport
+
+check = PerformanceDisparityReport(
+   protected_feature="race",
+   control_feature="education",
+   scorer="f1",
+   max_segments=3)
+result = check.run(test_dataset, model)
+result.show()
+
+#%%
+# Observe the check's output
+# --------------------------
+# 
+# We see in the results that the check identified the largest performance disparity for the subgroup 
+# "Others" within the category of "HS-grad" for the control feature "education". The model performance 
+# on this subgroup is 0.095 versus 0.258 for this entire education category.
+
+result.value.head(3)
+
+#%%
+# Define a condition
+# ==================
+#
+# We can define on our check a condition that will validate all performance disparities fall within
+# a certain threshold. If the condition is not met, the check will fail.
+# 
+# Let's add a condition and re-run the check:
+
+check.add_condition_bounded_performance_difference(lower_bound=-0.1)
+result = check.run(test_dataset, model)
+result.show(show_additional_outputs=False)
+
+# %%

--- a/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_performance_disparity_report.py
@@ -8,7 +8,6 @@ This notebook provides an overview for using and understanding the Performance D
 **Structure:**
 
 * `What is the purpose of the check? <#what-is-the-purpose-of-the-check>`__
-* `Automatically detecting weak segments <#automatically-detecting-weak-segments>`__
 * `Generate data & model <#generate-data-model>`__
 * `Run the check <#run-the-check>`__
 * `Define a condition <#define-a-condition>`__
@@ -41,22 +40,15 @@ model = load_fitted_model()
 # for which performance disparities are assessed. In addition, the check has several optional parameters
 # that affect its behavior and output.
 # 
-# ``control_feature``: Column to use to split the data by groups prior to computing performance disparities.
+# * ``control_feature``: Column to use to split the data by groups prior to computing performance disparities.
 # 
-# ``scorer``: Scoring function to measure performance.
+# * ``scorer``: Scoring function to measure performance. Default to "accuracy" for classification tasks 
+# and "r2" for regression tasks.
 # 
-# ``max_segments``: Maximum number of segments into which numerical features are binned. This is also a
-# maximum on the number of levels for a categorical ``control_feature``.
-#
-# ``min_subgroup_size``: Minimum size of a subgroup for which to compute a performance score.
-# 
-# ``max_subgroups_per_category_to_display``: Maximum number of subgroups (per ``control_feature`` category)
+# * ``max_subgroups_per_control_cat_to_display``: Maximum number of subgroups (per ``control_feature`` category)
 # to display.
 # 
-# ``max_categories_to_display``: Maximum number of ``control_feature`` levels to display.
-# 
-# ``use_avg_defaults``: If no scorer was provided, determines whether to return an average score (if True) 
-# or a score per class (if False).
+# * ``max_control_cat_to_display``: Maximum number of ``control_feature`` categories to display.
 # 
 # see :class:`API reference <deepchecks.tabular.checks.model_evaluation.PerformanceDisparityReport>` for 
 # more details.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=1.1.5
+pandas>=1.3
 numpy>=1.19
 scikit-learn>=0.23.2
 jsonpickle>=2

--- a/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
+++ b/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
@@ -159,7 +159,30 @@ def test_numeric_values(adult_split_dataset_and_model):
 
     # Assert
     assert_that(result.display, has_length(1))
-    assert_that(result.display[0].data, has_length(2))
+    assert_that(result.value.round(3).to_dict(), has_entries(expected_value.round(3).to_dict()))
+
+
+def test_numeric_values_classwise(adult_split_dataset_and_model):
+    # Arrange
+    _, test, model = adult_split_dataset_and_model
+    check = PerformanceDisparityReport("sex", scorer="f1_per_class")
+
+    expected_value = pd.DataFrame({
+        'sex': {1: ' Female', 0: ' Male'},
+        '_scorer': {1: 'f1_per_class', 0: 'f1_per_class'},
+        '_score': {1: 0.9557802895102122, 0: 0.6198331788693234},
+        '_class': {1: ' <=50K', 0: ' >50K'},
+        '_baseline': {1: 0.9054560599750104, 0: 0.5940497480084539},
+        '_baseline_count': {1: 16281, 0: 16281},
+        '_count': {1: 5421, 0: 10860},
+        '_diff': {1: 0.05032422953520177, 0: 0.02578343086086954}
+    })
+
+    # Act
+    result = check.run(test, model)
+
+    # Assert
+    assert_that(result.display, has_length(1))
     assert_that(result.value.round(3).to_dict(), has_entries(expected_value.round(3).to_dict()))
 
 

--- a/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
+++ b/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
@@ -186,6 +186,66 @@ def test_numeric_values_classwise(adult_split_dataset_and_model):
     assert_that(result.value.round(3).to_dict(), has_entries(expected_value.round(3).to_dict()))
 
 
+def test_numeric_values_classwise_with_control(adult_split_dataset_and_model):
+    # Arrange
+    _, test, model = adult_split_dataset_and_model
+    check = PerformanceDisparityReport("sex", control_feature="race", scorer="f1_per_class")
+
+    expected_value = pd.DataFrame({
+        'sex': {5: ' Female',
+                3: ' Female',
+                4: ' Female',
+                0: ' Male',
+                2: ' Male',
+                1: ' Male'},
+        'race': {5: 'Others',
+                3: ' White',
+                4: ' Black',
+                0: ' White',
+                2: 'Others',
+                1: ' Black'},
+        '_scorer': {5: 'f1_per_class',
+                3: 'f1_per_class',
+                4: 'f1_per_class',
+                0: 'f1_per_class',
+                2: 'f1_per_class',
+                1: 'f1_per_class'},
+        '_score': {5: 0.9447619047619047,
+                3: 0.9524044389642415,
+                4: 0.9786354238456237,
+                0: 0.621011989433042,
+                2: 0.6484375,
+                1: 0.5596330275229359},
+        '_class': {5: ' <=50K',
+                3: ' <=50K',
+                4: ' <=50K',
+                0: ' >50K',
+                2: ' >50K',
+                1: ' >50K'},
+        '_baseline': {5: 0.9048760991207034,
+                3: 0.8991080632871679,
+                4: 0.9554229554229555,
+                0: 0.5966672639311952,
+                2: 0.5993265993265993,
+                1: 0.5347985347985348},
+        '_baseline_count': {5: 774, 3: 13946, 4: 1561, 0: 13946, 2: 774, 1: 1561},
+        '_count': {5: 283, 3: 4385, 4: 753, 0: 9561, 2: 491, 1: 808},
+        '_diff': {5: 0.039885805641201255,
+                3: 0.05329637567707368,
+                4: 0.02321246842266822,
+                0: 0.024344725501846853,
+                2: 0.04911090067340074,
+                1: 0.02483449272440108}
+    })
+
+    # Act
+    result = check.run(test, model)
+
+    # Assert
+    assert_that(result.display, has_length(1))
+    assert_that(result.value.round(3).to_dict(), has_entries(expected_value.round(3).to_dict()))
+
+
 def test_na_scores_on_small_subgroups(adult_split_dataset_and_model):
     # Arrange
     _, test, model = adult_split_dataset_and_model

--- a/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
+++ b/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
@@ -174,3 +174,22 @@ def test_na_scores_on_small_subgroups(adult_split_dataset_and_model):
     # Assert
     assert_that(result.value["_score"].isna().all())
     assert_that(result.value["_baseline"].isna().all())
+
+
+def test_scorers_types_no_error(adult_split_dataset_and_model):
+    # Arrange
+    _, test, model = adult_split_dataset_and_model
+    scorer_types = [
+        None,
+        "f1",
+        ('f1_score', make_scorer(f1_score, average='micro')),
+        {'f1_score': make_scorer(f1_score, average='micro')},
+    ]
+    
+    # Act
+    for scorer in scorer_types:
+        check = PerformanceDisparityReport("sex", scorer=scorer)
+        check.run(test, model)
+
+    # Assert
+    pass # no error

--- a/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
+++ b/tests/tabular/checks/model_evaluation/performance_disparity_report_test.py
@@ -11,13 +11,14 @@
 """Tests for weak segment performance check."""
 import numpy as np
 import pandas as pd
-from hamcrest import assert_that, close_to, equal_to, has_items, has_length, calling, raises, any_of, all_of, has_property, has_properties
+from hamcrest import assert_that, close_to, equal_to, has_items, has_length, calling, raises, any_of, all_of, has_property, has_properties, has_entries
 from sklearn.metrics import f1_score, make_scorer
 
 from deepchecks.core.errors import DeepchecksValueError, DeepchecksNotSupportedError
 from deepchecks import ConditionCategory
 from deepchecks.tabular.checks.model_evaluation import PerformanceDisparityReport
 from tests.base.utils import equal_condition_result
+
 
 def test_no_error(adult_split_dataset_and_model, avocado_split_dataset_and_model):
     # Arrange
@@ -110,6 +111,7 @@ def test_condition_fail(adult_split_dataset_and_model):
         details="Found 1 subgroups with relative performance differences outside of the given bounds."
     )))
 
+
 def test_condition_pass(adult_split_dataset_and_model):
     # Arrange
     _, test, model = adult_split_dataset_and_model
@@ -135,3 +137,40 @@ def test_condition_pass(adult_split_dataset_and_model):
         name="Relative performance differences are bounded between -0.042 and inf.",
         details="Found 0 subgroups with relative performance differences outside of the given bounds."
     )))
+
+
+def test_numeric_values(adult_split_dataset_and_model):
+    # Arrange
+    _, test, model = adult_split_dataset_and_model
+    check = PerformanceDisparityReport("sex")
+
+    expected_value = pd.DataFrame({
+        'sex': {0: ' Male', 1: ' Female'},
+        '_scorer': {0: 'Accuracy', 1: 'Accuracy'},
+        '_score': {0: 0.8111418047882136, 1: 0.9177273565762775},
+        '_baseline': {0: 0.8466310423192679, 1: 0.8466310423192679},
+        '_baseline_count': {0: 16281, 1: 16281},
+        '_count': {0: 10860, 1: 5421},
+        '_diff': {0: -0.03548923753105426, 1: 0.07109631425700957}
+    })
+
+    # Act
+    result = check.run(test, model)
+
+    # Assert
+    assert_that(result.display, has_length(1))
+    assert_that(result.display[0].data, has_length(2))
+    assert_that(result.value.round(3).to_dict(), has_entries(expected_value.round(3).to_dict()))
+
+
+def test_na_scores_on_small_subgroups(adult_split_dataset_and_model):
+    # Arrange
+    _, test, model = adult_split_dataset_and_model
+    check = PerformanceDisparityReport("sex", min_subgroup_size=1_000_000_000)
+
+    # Act
+    result = check.run(test, model)
+
+    # Assert
+    assert_that(result.value["_score"].isna().all())
+    assert_that(result.value["_baseline"].isna().all())


### PR DESCRIPTION
#### Reference Issues/PRs

Implements PerformanceDisparityReport (see #2208).

#### Any other comments?

See https://github.com/OlivierBinette/PerformanceDisparityReport-test/blob/main/test_plots.ipynb for plot tests

A few potential features have not yet been implemented:
1. Alternative choice of baseline score (best possible score or best subgroup score).
2. Alternative ranking by *relative* score difference
3. Allowing lists of protected_feature and control_feature
4. Allowing multiple scorers (there could be a tab for each scorer).

**Note:** I wasn't able to run `make test` or `make tox` locally (I get the error "Could not find a version that satisfies the requirement torch==1.10.2+cpu"). I'm opening the PR to trigger CI/CD and there will probable be a few issues to fix with the tests.
