### PR TITLE
initial commit for imbalanced datasets

### DIFF
--- a/docs/source/user-guide/general/drift_guide.rst
+++ b/docs/source/user-guide/general/drift_guide.rst
@@ -118,6 +118,23 @@ In general, it is recommended to use Cramer's V, unless your variable includes c
 However, in cases of a variable with many categories with few samples, it is still recommended to use Cramer's V, as PSI will not be able to detect change in the smaller categories.
 
 
+Detecting Drift in Unbalanced Classification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In classification problems, it is common to have unbalanced data, meaning that the number of samples in each class is
+highly skewed. For example, in a dataset of credit card transactions, the number of fraudulent transactions is usually
+much lower than the number of non-fraudulent transactions, and can be way below 1% of the total number of samples.
+
+In such cases, running the :doc:`TrainTestLabelDrift </checks_gallery/tabular/train_test_validation/plot_train_test_label_drift>`:
+or :doc:`TrainTestPredictionDrift </checks_gallery/tabular/train_test_validation/plot_train_test_prediction_drift>` checks
+with the default parameters will likely lead to a false negative, as for example a change in the percent of fraudulent
+transactions from 0.2% to 0.4% will not be detected, but may in fact be very significant for our business.
+
+To detect this kind of drift, set the ``relative_change`` parameter of these checks to True. This will cause the check
+to consider all classes equally, regardless of their size.
+
+**Note**: You must also set the ``categorical_drift_method`` parameter to ``'psi'`` in order to use this method.
+
 .. _drift_detection_by_domain_classifier:
 
 Detection by Domain Classifier


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The current drift methods are un-sensitive to highly imbalanced labels. This method is intended to calculate PSI while giving all classes equal weight, looking only at the relative change. 
