### PR TITLE
Improve vision data head display

### DIFF
--- a/deepchecks/core/serialization/abc.py
+++ b/deepchecks/core/serialization/abc.py
@@ -36,7 +36,8 @@ __all__ = [
     'WidgetSerializer',
     'WandbSerializer',
     'ABCDisplayItemsHandler',
-    'JunitSerializer'
+    'JunitSerializer',
+    'IPythonSerializer'
 ]
 
 

--- a/deepchecks/core/serialization/html_display.py
+++ b/deepchecks/core/serialization/html_display.py
@@ -10,6 +10,7 @@ from deepchecks.utils.strings import create_new_file_name
 
 
 class HtmlDisplayableResult(DisplayableResult):
+    """Class which accepts html string and support displaying it in different environments."""
 
     def __init__(self, html: str):
         self.html = html
@@ -17,7 +18,7 @@ class HtmlDisplayableResult(DisplayableResult):
     @property
     def widget_serializer(self) -> WidgetSerializer[t.Any]:
         class _WidgetSerializer(WidgetSerializer[t.Any]):
-            def serialize(self, **kwargs) -> Widget:
+            def serialize(self, **kwargs) -> Widget:  # pylint: disable=unused-argument
                 return normalize_widget_style(VBox(children=[HTML(self.value)]))
 
         return _WidgetSerializer(self.html)
@@ -25,7 +26,7 @@ class HtmlDisplayableResult(DisplayableResult):
     @property
     def ipython_serializer(self) -> IPythonSerializer[t.Any]:
         class _IPythonSerializer(IPythonSerializer[t.Any]):
-            def serialize(self, **kwargs) -> t.Any:
+            def serialize(self, **kwargs) -> t.Any:  # pylint: disable=unused-argument
                 return HTML(self.value)
 
         return _IPythonSerializer(self.html)
@@ -33,7 +34,7 @@ class HtmlDisplayableResult(DisplayableResult):
     @property
     def html_serializer(self) -> HtmlSerializer[t.Any]:
         class _HtmlSerializer(HtmlSerializer[t.Any]):
-            def serialize(self, **kwargs) -> str:
+            def serialize(self, **kwargs) -> str:  # pylint: disable=unused-argument
                 return self.value
 
         return _HtmlSerializer(self.html)
@@ -41,10 +42,10 @@ class HtmlDisplayableResult(DisplayableResult):
     def to_widget(self, **kwargs) -> Widget:
         return self.widget_serializer.serialize(**kwargs)
 
-    def to_json(self, **kwargs) -> str:
+    def to_json(self, **kwargs):
         raise NotImplementedError()
 
-    def to_wandb(self, **kwargs) -> 'WBValue':
+    def to_wandb(self, **kwargs):
         raise NotImplementedError()
 
     def save_as_html(self, file: t.Union[str, io.TextIOWrapper, None] = None, **kwargs) -> t.Optional[str]:

--- a/deepchecks/core/serialization/html_display.py
+++ b/deepchecks/core/serialization/html_display.py
@@ -1,0 +1,62 @@
+import io
+import typing as t
+
+from ipywidgets import HTML, VBox, Widget
+
+from deepchecks.core.display import DisplayableResult
+from deepchecks.core.serialization.abc import HtmlSerializer, IPythonSerializer, WidgetSerializer
+from deepchecks.core.serialization.common import normalize_widget_style
+from deepchecks.utils.strings import create_new_file_name
+
+
+class HtmlDisplayableResult(DisplayableResult):
+
+    def __init__(self, html: str):
+        self.html = html
+
+    @property
+    def widget_serializer(self) -> WidgetSerializer[t.Any]:
+        class _WidgetSerializer(WidgetSerializer[t.Any]):
+            def serialize(self, **kwargs) -> Widget:
+                return normalize_widget_style(VBox(children=[HTML(self.value)]))
+
+        return _WidgetSerializer(self.html)
+
+    @property
+    def ipython_serializer(self) -> IPythonSerializer[t.Any]:
+        class _IPythonSerializer(IPythonSerializer[t.Any]):
+            def serialize(self, **kwargs) -> t.Any:
+                return HTML(self.value)
+
+        return _IPythonSerializer(self.html)
+
+    @property
+    def html_serializer(self) -> HtmlSerializer[t.Any]:
+        class _HtmlSerializer(HtmlSerializer[t.Any]):
+            def serialize(self, **kwargs) -> str:
+                return self.value
+
+        return _HtmlSerializer(self.html)
+
+    def to_widget(self, **kwargs) -> Widget:
+        return self.widget_serializer.serialize(**kwargs)
+
+    def to_json(self, **kwargs) -> str:
+        raise NotImplementedError()
+
+    def to_wandb(self, **kwargs) -> 'WBValue':
+        raise NotImplementedError()
+
+    def save_as_html(self, file: t.Union[str, io.TextIOWrapper, None] = None, **kwargs) -> t.Optional[str]:
+        if file is None:
+            file = 'output.html'
+        if isinstance(file, str):
+            file = create_new_file_name(file)
+
+        if isinstance(file, str):
+            with open(file, 'w', encoding='utf-8') as f:
+                f.write(self.html)
+        elif isinstance(file, io.TextIOWrapper):
+            file.write(self.html)
+
+        return file

--- a/deepchecks/core/serialization/html_display.py
+++ b/deepchecks/core/serialization/html_display.py
@@ -1,3 +1,14 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Module for html displayable result."""
 import io
 import typing as t
 
@@ -17,6 +28,7 @@ class HtmlDisplayableResult(DisplayableResult):
 
     @property
     def widget_serializer(self) -> WidgetSerializer[t.Any]:
+        """Return widget serializer."""
         class _WidgetSerializer(WidgetSerializer[t.Any]):
             def serialize(self, **kwargs) -> Widget:  # pylint: disable=unused-argument
                 return normalize_widget_style(VBox(children=[HTML(self.value)]))
@@ -25,6 +37,7 @@ class HtmlDisplayableResult(DisplayableResult):
 
     @property
     def ipython_serializer(self) -> IPythonSerializer[t.Any]:
+        """Return IPython serializer."""
         class _IPythonSerializer(IPythonSerializer[t.Any]):
             def serialize(self, **kwargs) -> t.Any:  # pylint: disable=unused-argument
                 return HTML(self.value)
@@ -33,6 +46,7 @@ class HtmlDisplayableResult(DisplayableResult):
 
     @property
     def html_serializer(self) -> HtmlSerializer[t.Any]:
+        """Return HTML serializer."""
         class _HtmlSerializer(HtmlSerializer[t.Any]):
             def serialize(self, **kwargs) -> str:  # pylint: disable=unused-argument
                 return self.value
@@ -40,15 +54,19 @@ class HtmlDisplayableResult(DisplayableResult):
         return _HtmlSerializer(self.html)
 
     def to_widget(self, **kwargs) -> Widget:
+        """Return the widget representation of the result."""
         return self.widget_serializer.serialize(**kwargs)
 
     def to_json(self, **kwargs):
+        """Not implemented."""
         raise NotImplementedError()
 
     def to_wandb(self, **kwargs):
+        """Not implemented."""
         raise NotImplementedError()
 
     def save_as_html(self, file: t.Union[str, io.TextIOWrapper, None] = None, **kwargs) -> t.Optional[str]:
+        """Save the html to a file."""
         if file is None:
             file = 'output.html'
         if isinstance(file, str):

--- a/deepchecks/vision/vision_data/vision_data.py
+++ b/deepchecks/vision/vision_data/vision_data.py
@@ -13,11 +13,10 @@ import typing as t
 from collections import defaultdict
 
 import numpy as np
-from IPython.core.display import display
-from ipywidgets import HTML
 from typing_extensions import Literal
 
 from deepchecks.core.errors import DeepchecksValueError, ValidationError
+from deepchecks.core.serialization.html_display import HtmlDisplayableResult
 from deepchecks.utils.ipython import is_notebook, is_sphinx
 from deepchecks.vision.utils.detection_formatters import DEFAULT_PREDICTION_FORMAT
 from deepchecks.vision.utils.image_functions import draw_bboxes, draw_masks, prepare_thumbnail, random_color_dict
@@ -355,11 +354,4 @@ class VisionData:
             """
         html += '</div>'
 
-        if is_notebook():
-            display(HTML(html))
-        else:
-            class TempSphinx:
-                def _repr_html_(self):
-                    return html
-
-            return TempSphinx()
+        return HtmlDisplayableResult(html)


### PR DESCRIPTION
Using `DisplayableResult` from `core` in order to give better options for the head display like `show_in_window`:

```
from deepchecks.vision.datasets.classification.mnist_torch import load_dataset
load_dataset(object_type='VisionData').head().show_in_window()
```