### PR TITLE
Fix calculate feature importance for regression

### DIFF
--- a/deepchecks/tabular/feature_importance.py
+++ b/deepchecks/tabular/feature_importance.py
@@ -32,14 +32,15 @@ def calculate_feature_importance(
         mask_high_variance_features: bool = False,
         n_samples: int = 10_000,
         alternative_scorer: t.Optional[DeepcheckScorer] = None,
+        force_permutation: bool = False,
         random_state: int = 42
 ) -> pd.Series:
     """
-    Calculate feature importance outside of check and suite.
+    Get or calculate feature importance outside of check and suite.
 
     Many checks and suites in deepchecks use feature importance as part of its calculation or output. If your model
     does not have built-in feature importance, the check or suite will calculate it for you. This calculation is done
-    in every call to the check or suite ``run`` function. Therefore, when running different checks outside of a suite,
+    in every call to the check or suite ``run`` function. Therefore, when running different checks outside a suite,
     or running the same suite several times, this calculation will be done every time.
 
     The recalculation can be avoided by calculating the feature importance in advance. Use this function to calculate
@@ -52,6 +53,11 @@ def calculate_feature_importance(
     >>> iris_model = load_fitted_model()
     >>> fi = calculate_feature_importance(model=iris_model, dataset=iris_test_dataset)
     >>> result = UnusedFeatures().run(iris_test_dataset, model=iris_model, feature_importance=fi)
+
+    By defualt this function will attempt to get the feature importance from the model. If the model does not have
+    built-in feature importance, it will calculate it using permutation importance. If you want to force the
+    calculation of the feature importance, even if the model has built-in feature importance, use the
+    ``force_permutation`` parameter.
 
     Parameters
     ----------
@@ -70,6 +76,8 @@ def calculate_feature_importance(
     alternative_scorer: t.Optional[DeepcheckScorer], default: None
         Scorer to use for evaluation of the model performance in the permutation_importance function. If not defined,
         the default deepchecks scorers are used.
+    force_permutation : bool, default: False
+        Force permutation importance calculation.
     random_state: int, default: 42
         Random seed for permutation importance calculation.
 
@@ -109,6 +117,6 @@ def calculate_feature_importance(
                                           model_classes=model_classes or observed_classes,
                                           observed_classes=observed_classes,
                                           task_type=task_type,
-                                          force_permutation=True,
+                                          force_permutation=force_permutation,
                                           permutation_kwargs=permutation_kwargs)
     return fi

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -176,7 +176,7 @@ def _calculate_feature_importance(
     # If there was no force permutation, or if it failed while trying to calculate importance,
     # we don't take built-in importance in pipelines because the pipeline is changing the features
     # (for example one-hot encoding) which leads to the inner model features
-    # being different than the original dataset features
+    # being different from the original dataset features
     if importance is None and not isinstance(model, Pipeline):
         # Get the actual model in case of pipeline
         importance, calc_type = _built_in_importance(model, dataset)

--- a/deepchecks/tabular/utils/feature_importance.py
+++ b/deepchecks/tabular/utils/feature_importance.py
@@ -23,6 +23,7 @@ from deepchecks import tabular
 from deepchecks.core import errors
 from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer, get_default_scorers, init_validate_scorers
+from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.tabular.utils.validation import validate_model
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import Hashable
@@ -156,6 +157,10 @@ def _calculate_feature_importance(
     NumberOfFeaturesLimitError
         if the number of features limit were exceeded.
     """
+    if task_type == TaskType.REGRESSION:
+        model_classes = None
+        observed_classes = None
+
     permutation_kwargs = permutation_kwargs or {}
     permutation_kwargs['random_state'] = permutation_kwargs.get('random_state', 42)
     validate_model(dataset, model)

--- a/tests/utils/metrics_test.py
+++ b/tests/utils/metrics_test.py
@@ -138,6 +138,15 @@ def test_iris_true_negative_rate_scorer_multiclass(iris_split_dataset_and_model)
     assert_that(score_weighted, close_to(0.936, 0.01))
 
 
+def test_regression_metrics(diabetes, diabetes_model):
+    ds, _ = diabetes
+
+    # Act & Assert
+    r_2_deepchecks_scorer = DeepcheckScorer('R2', model_classes=None, observed_classes=None)
+    score_r_2 = r_2_deepchecks_scorer(diabetes_model, ds)
+    assert_that(score_r_2, close_to(0.85, 0.01))
+
+
 def test_auc_on_regression_task_raises_error(diabetes, diabetes_model):
     ds, _ = diabetes
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2345 

1. Regression / classification relies on model_classes, needs to be Nulled for Regression. 
2. Default FI method in user facing FI func should not be permutation. 
