### PR TITLE
changed plotly version to the latest

### DIFF
--- a/docs/source/user-guide/general/showing_results.rst
+++ b/docs/source/user-guide/general/showing_results.rst
@@ -75,6 +75,8 @@ options to resolve them:
 - | Verifying that the ``jupyter-widgets`` extension is installed and enabled.
   | If you're working on jupyterlab, same for ``jupyterlab-plotly`` extension.
   | Restart your jupter server after these changes so that they will have an effect.
+  | For more information and instructions take a look at a plotly `JupeterLab Troubleshooting<https://plotly.com/python/troubleshooting/#jupyterlab-problems>`_ 
+  | documentation section.
 
 - Exporting the results (e.g. :doc:`saving them to html </user-guide/general/export_save_results>`) 
   and viewing the output file.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -27,8 +27,7 @@ statsmodels>=0.11.0; python_version < '3.7'
 statsmodels>=0.13.5; python_version >= '3.7'
 scipy>=1.4.1
 dataclasses>=0.6; python_version < '3.7'
-# jupyterlab-plotly extension that is used to display plotly figures
-plotly>=5.8.0
+plotly>=5.13.1
 matplotlib>=3.3.4
 pyzmq<24.0.0
 beautifulsoup4>=4.11.1


### PR DESCRIPTION
looks like this issue is not actual anymore with latest plotly version, therefore pinning it to `>=5.13.1` 

@ItayGabbay do we have a FAQ docs page?
I think we need to link this plotly docs page there - [Plotly FAQ - JupyterLab problems](https://plotly.com/python/troubleshooting/#jupyterlab-problems) 