### PR TITLE
Solve issue with pps inferring label type from dtype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       with:
         requirements: 'requirements-all.txt'
         fail: 'Copyleft,Other,Error'
-        exclude: '(pyzmq.*23\.2\.1|debugpy.*1\.6\.6|certifi.*2022\.12\.7|tqdm.*4\.64\.1|webencodings.*0\.5\.1|torch.*1\.10\.2.*|torchvision.*0\.11\.3.*|terminado.*0\.15\.0.*|urllib3.*1\.26\.11.*|imageio.*2\.20\.0.*|jsonschema.*4\.8\.0.*|debugpy.*1\.6\.3|qudida.*0\.0\.4)'
+        exclude: '(pyzmq.*23\.2\.1|debugpy.*1\.6\.6|certifi.*2022\.12\.7|tqdm.*4\.65\.0|webencodings.*0\.5\.1|torch.*1\.10\.2.*|torchvision.*0\.11\.3.*|terminado.*0\.15\.0.*|urllib3.*1\.26\.11.*|imageio.*2\.20\.0.*|jsonschema.*4\.8\.0.*|debugpy.*1\.6\.3|qudida.*0\.0\.4)'
         # pyzmq is Revised BSD https://github.com/zeromq/pyzmq/blob/main/examples/LICENSE
         # debugpy is MIT https://github.com/microsoft/debugpy/blob/main/LICENSE
         # certifi is MPL-2.0 https://github.com/certifi/python-certifi/blob/master/LICENSE

--- a/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
@@ -11,6 +11,8 @@
 """The feature label correlation check module."""
 import typing as t
 
+from deepchecks.tabular.utils.task_type import TaskType
+
 import deepchecks.ppscore as pps
 from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
 from deepchecks.core.check_utils.feature_label_correlation_utils import get_pps_figure, pd_series_to_trace
@@ -82,6 +84,10 @@ class FeatureLabelCorrelation(SingleDatasetCheck):
         dataset = context.get_data_by_kind(dataset_kind).sample(self.n_samples, random_state=self.random_state)
         dataset.assert_features()
         relevant_columns = dataset.features + [dataset.label_name]
+
+        # ppscore infers the task type from the label dtype, so we need to convert it to object
+        if context.task_type != TaskType.REGRESSION:
+            dataset._data[dataset.label_name] = dataset._data[dataset.label_name].astype(object)
 
         df_pps = pps.predictors(df=dataset.data[relevant_columns], y=dataset.label_name, random_seed=self.random_state,
                                 **self.ppscore_params)

--- a/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
@@ -85,10 +85,11 @@ class FeatureLabelCorrelation(SingleDatasetCheck):
         relevant_columns = dataset.features + [dataset.label_name]
 
         # ppscore infers the task type from the label dtype, so we need to convert it to object
+        data_df = dataset.data[relevant_columns]
         if context.task_type != TaskType.REGRESSION:
-            dataset._data[dataset.label_name] = dataset._data[dataset.label_name].astype(object)
+            data_df[dataset.label_name] = data_df[dataset.label_name].astype(object)
 
-        df_pps = pps.predictors(df=dataset.data[relevant_columns], y=dataset.label_name, random_seed=self.random_state,
+        df_pps = pps.predictors(df=data_df, y=dataset.label_name, random_seed=self.random_state,
                                 **self.ppscore_params)
         s_ppscore = df_pps.set_index('x', drop=True)['ppscore']
 

--- a/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
@@ -11,13 +11,12 @@
 """The feature label correlation check module."""
 import typing as t
 
-from deepchecks.tabular.utils.task_type import TaskType
-
 import deepchecks.ppscore as pps
 from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
 from deepchecks.core.check_utils.feature_label_correlation_utils import get_pps_figure, pd_series_to_trace
 from deepchecks.tabular import Context, SingleDatasetCheck
 from deepchecks.tabular.utils.messages import get_condition_passed_message
+from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.strings import format_number
 from deepchecks.utils.typing import Hashable
 

--- a/deepchecks/tabular/checks/data_integrity/identifier_label_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/identifier_label_correlation.py
@@ -20,6 +20,7 @@ from deepchecks.core.errors import DatasetValidationError
 from deepchecks.tabular import Context, SingleDatasetCheck
 from deepchecks.tabular.dataset import _get_dataset_docs_tag
 from deepchecks.tabular.utils.messages import get_condition_passed_message
+from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.strings import format_number
 
 __all__ = ['IdentifierLabelCorrelation']
@@ -76,6 +77,10 @@ class IdentifierLabelCorrelation(SingleDatasetCheck):
                 'Dataset does not contain an index or a datetime',
                 html=f'Dataset does not contain an index or a datetime. see {_get_dataset_docs_tag()}'
             )
+
+        # ppscore infers the task type from the label dtype, so we need to convert it to object
+        if context.task_type != TaskType.REGRESSION:
+            relevant_data[dataset.label_name] = relevant_data[dataset.label_name].astype(object)
 
         df_pps = pps.predictors(
             df=relevant_data,

--- a/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
+++ b/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
@@ -95,9 +95,11 @@ class FeatureLabelCorrelationChange(TrainTestCheck):
         relevant_columns = train_dataset.features + [train_dataset.label_name]
 
         # ppscore infers the task type from the label dtype, so we need to convert it to object
+        train_df = train_dataset.data[relevant_columns]
+        test_df = test_dataset.data[relevant_columns]
         if context.task_type != TaskType.REGRESSION:
-            train_dataset._data[train_dataset.label_name] = train_dataset._data[train_dataset.label_name].astype(object)
-            test_dataset._data[test_dataset.label_name] = test_dataset._data[test_dataset.label_name].astype(object)
+            train_df[train_dataset.label_name] = train_df[train_dataset.label_name].astype(object)
+            test_df[test_dataset.label_name] = test_df[test_dataset.label_name].astype(object)
 
         text = [
             'The Predictive Power Score (PPS) is used to estimate the ability of a feature to predict the '
@@ -117,9 +119,9 @@ class FeatureLabelCorrelationChange(TrainTestCheck):
             'the target label.'
         ]
 
-        ret_value, display = get_feature_label_correlation(train_dataset.data[relevant_columns],
+        ret_value, display = get_feature_label_correlation(train_df,
                                                            train_dataset.label_name,
-                                                           test_dataset.data[relevant_columns],
+                                                           test_df,
                                                            test_dataset.label_name, self.ppscore_params,
                                                            self.n_top_features,
                                                            min_pps_to_show=self.min_pps_to_show,

--- a/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
+++ b/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
@@ -19,6 +19,7 @@ from deepchecks.core.check_utils.feature_label_correlation_utils import get_feat
 from deepchecks.core.condition import ConditionCategory
 from deepchecks.tabular import Context, TrainTestCheck
 from deepchecks.tabular.utils.messages import get_condition_passed_message
+from deepchecks.tabular.utils.task_type import TaskType
 from deepchecks.utils.strings import format_number
 from deepchecks.utils.typing import Hashable
 
@@ -92,6 +93,11 @@ class FeatureLabelCorrelationChange(TrainTestCheck):
 
         train_dataset.assert_features()
         relevant_columns = train_dataset.features + [train_dataset.label_name]
+
+        # ppscore infers the task type from the label dtype, so we need to convert it to object
+        if context.task_type != TaskType.REGRESSION:
+            train_dataset._data[train_dataset.label_name] = train_dataset._data[train_dataset.label_name].astype(object)
+            test_dataset._data[test_dataset.label_name] = test_dataset._data[test_dataset.label_name].astype(object)
 
         text = [
             'The Predictive Power Score (PPS) is used to estimate the ability of a feature to predict the '

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -23,6 +23,7 @@ Matplotlib
 backends
 params
 PCA
+ppscore
 encodings
 plotly
 Multiclass

--- a/tests/tabular/checks/train_test_validation/feature_label_correlation_test.py
+++ b/tests/tabular/checks/train_test_validation/feature_label_correlation_test.py
@@ -42,6 +42,24 @@ def util_generate_second_similar_dataframe_and_expected():
                      'x4': close_to(0, 0.1), 'x5': close_to(0, 0.1)}
 
 
+def test_categorical_int_target():
+    df = pd.DataFrame({'x': list(range(1000)), 'y': list(range(1000))})
+
+    # Test for regression
+    dataset = Dataset(df, label='y', label_type='regression')
+    check = FeatureLabelCorrelation(random_state=42)
+
+    result = check.run(dataset)
+    assert_that(result.value, has_entries({'x': close_to(0.99, 0.01)}))
+
+    # Test for classification
+    dataset = Dataset(df, label='y', label_type='multiclass')
+    check = FeatureLabelCorrelation(random_state=42)
+
+    result = check.run(dataset)
+    assert_that(result.value, has_entries({'x': close_to(0.0, 0.01)}))
+
+
 def test_assert_feature_label_correlation():
     df, expected = util_generate_dataframe_and_expected()
     result = FeatureLabelCorrelation(n_samples=None, random_state=42).run(dataset=Dataset(df, label='label'))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
pps infers the label type from the dtype (int / float is regression, other are classification).

In order to make that comply with our framework, the dtype is cast according to task type
