### PR TITLE
Mixed null reduce now ignores a single null type

### DIFF
--- a/deepchecks/tabular/checks/data_integrity/mixed_nulls.py
+++ b/deepchecks/tabular/checks/data_integrity/mixed_nulls.py
@@ -156,9 +156,13 @@ class MixedNulls(SingleDatasetCheck, ReduceFeatureMixin):
         feature_importance = check_result.value['feature_importance']
 
         if check_result.value['columns']:
-            total_mixed_nulls = {column: sum([check_result.value['columns'][column][null_value]['count']
-                                              for null_value in check_result.value['columns'][column]])
+            total_mixed_nulls = {column: [check_result.value['columns'][column][null_value]['count']
+                                          for null_value in check_result.value['columns'][column]]
                                  for column in check_result.value['columns']}
+            # If there is only one kind of null value in the column, then the total_mixed_nulls will be 0 for that
+            # column
+            total_mixed_nulls = {column: sum(total_mixed_nulls[column]) if len(total_mixed_nulls[column]) > 1
+                                 else 0 for column in total_mixed_nulls}
         else:
             total_mixed_nulls = {column: 0 for column in check_result.value['columns']}
 

--- a/tests/tabular/checks/integrity/mixed_nulls_test.py
+++ b/tests/tabular/checks/integrity/mixed_nulls_test.py
@@ -213,19 +213,19 @@ def test_dataset_2_columns_single_nulls():
 
 def test_dataset_2_columns_multi_nulls_reduce():
     # Arrange
-    data = {'col1': ['foo', 'bar', 'null'], 'col2': ['Nan', 'bar', 1], 'col3': [1, 2, 'NA']}
+    data = {'col1': ['foo', 'na', 'null'], 'col2': ['Nan', 'bar', 1], 'col3': ['', 2, 'NA']}
     dataframe = pd.DataFrame(data=data)
     # Act
     check = MixedNulls()
     result = check.run(dataframe)
     reduce_result = check.reduce_output(result)
     # Assert
-    assert_that(reduce_result['Max Percent Mixed Nulls'], close_to(0.33, 0.01))
+    assert_that(reduce_result['Max Percent Mixed Nulls'], close_to(0.66, 0.01))
 
 
 def test_dataset_2_columns_multi_nulls_additional_data_reduce():
     # Arrange
-    data = {'col1': ['foo', 'bar', 'null'], 'col2': ['Nan', 'bar', 1], 'col3': [1, 2, 'NA']}
+    data = {'col1': ['foo', 'na', 'null'], 'col2': ['Nan', 'bar', 1], 'col3': ['', 2, 'NA']}
     dataframe = pd.DataFrame(data=data)
     dataset = Dataset(dataframe, features=['col1', 'col2'])
 
@@ -233,17 +233,17 @@ def test_dataset_2_columns_multi_nulls_additional_data_reduce():
     check = MixedNulls()
     result = check.run(dataset, feature_importance=pd.Series({'col1': 0.5, 'col2': 0.5}))
     reduce_result = check.reduce_output(result)
-    assert_that(reduce_result['Max Percent Mixed Nulls'], close_to(0.33, 0.01))
+    assert_that(reduce_result['Max Percent Mixed Nulls'], close_to(0.66, 0.01))
 
     check = MixedNulls(aggregation_method='l2_weighted')
     result = check.run(dataset, feature_importance=pd.Series({'col1': 0.5, 'col2': 0.5}))
     reduce_result = check.reduce_output(result)
-    assert_that(reduce_result['L2 Weighted Percent Mixed Nulls'], close_to(0.33, 0.01))
+    assert_that(reduce_result['L2 Weighted Percent Mixed Nulls'], close_to(0.47, 0.01))
 
 
-def test_dataset_2_columns_no_nulls_reduce():
+def test_dataset_2_columns_no_mixed_nulls_reduce():
     # Arrange
-    data = {'col1': ['foo', 'bar', '2'], 'col2': ['3', 'bar', 1], 'col3': [1, 2, 3]}
+    data = {'col1': ['foo', 'bar', 'null'], 'col2': ['Nan', 'bar', 1], 'col3': [1, 2, 'NA']}
     dataframe = pd.DataFrame(data=data)
     # Act
     check = MixedNulls()


### PR DESCRIPTION
There was a bug when the reduce would return nonzero values for columns with a single kind of null