### PR TITLE
[FIX] Update array_math.py

### DIFF
--- a/deepchecks/utils/array_math.py
+++ b/deepchecks/utils/array_math.py
@@ -28,6 +28,6 @@ def sequence_to_numpy(sequence: t.Sequence):
     elif isinstance(sequence, t.List):
         return np.asarray(sequence).flatten()
     elif isinstance(sequence, pd.Series):
-       return sequence.to_numpy().flatten()
+        return sequence.to_numpy().flatten()
     else:
         raise DeepchecksValueError('Trying to convert a non sequence into a flat list.')

--- a/deepchecks/utils/array_math.py
+++ b/deepchecks/utils/array_math.py
@@ -9,9 +9,9 @@
 # ----------------------------------------------------------------------------
 #
 """Utils module with methods for fast calculations."""
-import typing as t
-
 import numpy as np
+import pandas as pd
+import typing as t
 
 from deepchecks.core.errors import DeepchecksValueError
 
@@ -27,5 +27,7 @@ def sequence_to_numpy(sequence: t.Sequence):
         return sequence.flatten()
     elif isinstance(sequence, t.List):
         return np.asarray(sequence).flatten()
+    elif isinstance(sequence, pd.Series):
+       return sequence.to_numpy().flatten()
     else:
         raise DeepchecksValueError('Trying to convert a non sequence into a flat list.')

--- a/deepchecks/utils/array_math.py
+++ b/deepchecks/utils/array_math.py
@@ -9,9 +9,10 @@
 # ----------------------------------------------------------------------------
 #
 """Utils module with methods for fast calculations."""
+import typing as t
+
 import numpy as np
 import pandas as pd
-import typing as t
 
 from deepchecks.core.errors import DeepchecksValueError
 


### PR DESCRIPTION
Provide support for models that return pandas series for predict, predict_proba (e.g. autogluon) by fixing `sequence_to_numpy`  function from `utils/array_math.py`

#### Reference Issues/PRs
Partially Fixes #2364 as discussed with @noamzbr 

#### What does this implement/fix? Explain your changes.
Fixing is just by adding additional case for `pd.Series`. Pandas series has method to `to_numpy` after this just `flatten`.

I didn't find specific test for `sequence_to_numpy`, so I've locally tested it end-to-end with autogluon:
https://colab.research.google.com/gist/mglowacki100/49ba6dca46f75ab494068d5b26a6a39c/autogluon_with_deepchecks_test.ipynb
