### PR TITLE
remove need for labels in prediction drift

### DIFF
--- a/deepchecks/tabular/checks/model_evaluation/prediction_drift.py
+++ b/deepchecks/tabular/checks/model_evaluation/prediction_drift.py
@@ -182,7 +182,7 @@ class PredictionDrift(TrainTestCheck, ReduceMixin):
         model = context.model
 
         drift_score_dict, drift_display_dict = {}, {}
-        method, classes = None, train_dataset.classes_in_label_col
+        method = None
 
         # Flag for computing drift on the probabilities rather than the predicted labels
         proba_drift = \
@@ -196,11 +196,29 @@ class PredictionDrift(TrainTestCheck, ReduceMixin):
             if test_prediction.shape[1] == 2:
                 train_prediction = train_prediction[:, [1]]
                 test_prediction = test_prediction[:, [1]]
+
+            # Get the classes in the same order as the model's predictions
+            train_converted_from_proba = train_prediction.argmax(axis=1)
+            test_converted_from_proba = test_prediction.argmax(axis=1)
+            samples_per_class = pd.Series(np.concatenate([train_converted_from_proba, test_converted_from_proba], axis=0
+                                                         ).squeeze()).value_counts().sort_index()
+
+            # If label exists, get classes from it and map the samples_per_class index to these classes
+            if context.model_classes is not None:
+                classes = context.model_classes
+                class_dict = dict(zip(range(len(classes)), classes))
+                samples_per_class.index = samples_per_class.index.to_series().map(class_dict).values
+            else:
+                classes = list(sorted(samples_per_class.keys()))
+            samples_per_class = samples_per_class.to_dict()
         else:
             train_prediction = np.array(model.predict(train_dataset.features_columns)).reshape((-1, 1))
             test_prediction = np.array(model.predict(test_dataset.features_columns)).reshape((-1, 1))
 
-        samples_per_class = train_dataset.label_col.value_counts().to_dict()
+            # Get the classes in the same order as the model's predictions
+            samples_per_class = pd.Series(np.concatenate([train_prediction, test_prediction], axis=0
+                                                         ).squeeze()).value_counts().to_dict()
+            classes = list(sorted(samples_per_class.keys()))
 
         for class_idx in range(train_prediction.shape[1]):
             class_name = classes[class_idx]


### PR DESCRIPTION
#### Reference Issues/PRs

Remove need for labels by either using model class or counting the instances in the prediction rather than the label


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
