### PR TITLE
refactor text data

### DIFF
--- a/deepchecks/nlp/checks/data_integrity/property_label_correlation.py
+++ b/deepchecks/nlp/checks/data_integrity/property_label_correlation.py
@@ -94,7 +94,7 @@ class PropertyLabelCorrelation(SingleDatasetCheck):
         """
         text_data = context.get_data_by_kind(dataset_kind).sample(self.n_samples, random_state=context.random_state)
 
-        label = pd.Series(text_data.label, name='label', index=text_data.index)
+        label = pd.Series(text_data.label, name='label', index=text_data.get_original_text_indexes())
 
         # Classification labels should be of type object (and not int, for example)
         if context.task_type in [TaskType.TEXT_CLASSIFICATION, TaskType.TOKEN_CLASSIFICATION]:

--- a/deepchecks/nlp/checks/data_integrity/text_property_outliers.py
+++ b/deepchecks/nlp/checks/data_integrity/text_property_outliers.py
@@ -119,7 +119,7 @@ class TextPropertyOutliers(SingleDatasetCheck):
             text_outliers = np.concatenate([bottom_outliers, top_outliers])
 
             result[name] = {
-                'indices': [dataset.index[i] for i in text_outliers],
+                'indices': [dataset.get_original_text_indexes()[i] for i in text_outliers],
                 # For the upper and lower limits doesn't show values that are smaller/larger than the actual values
                 # we have in the data
                 'lower_limit': max(lower_limit, min(values_arr)),

--- a/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
@@ -73,7 +73,7 @@ class WeakSegmentsAbstractText(SingleDatasetCheck, WeakSegmentAbstract):
         predictions = context.model.predict(text_data)
 
         if self.loss_per_sample is not None:
-            loss_per_sample = self.loss_per_sample[list(text_data.index)]
+            loss_per_sample = self.loss_per_sample[text_data.get_original_text_indexes()]
             proba_values = None
         elif not hasattr(context.model, 'predict_proba'):
             raise DeepchecksNotSupportedError('Predicted probabilities not supplied. The weak segment checks relies'

--- a/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
@@ -87,7 +87,7 @@ class WeakSegmentsAbstractText(SingleDatasetCheck, WeakSegmentAbstract):
         if features.shape[1] < 2:
             raise DeepchecksNotSupportedError('Check requires meta data to have at least two columns in order to run.')
         # label is not used in the check, just here to avoid errors
-        dataset = Dataset(features, label=pd.Series(text_data.label, index=text_data.index), cat_features=cat_features)
+        dataset = Dataset(features, label=pd.Series(text_data.label), cat_features=cat_features)
         encoded_dataset = self._target_encode_categorical_features_fill_na(dataset, list(np.unique(text_data.label)))
 
         dummy_model = _DummyModel(test=encoded_dataset, y_pred_test=np.asarray(predictions),

--- a/deepchecks/nlp/context.py
+++ b/deepchecks/nlp/context.py
@@ -14,6 +14,7 @@ import typing as t
 from operator import itemgetter
 
 import numpy as np
+
 from deepchecks.core.context import BaseContext
 from deepchecks.core.errors import (DatasetValidationError, DeepchecksNotSupportedError, DeepchecksValueError,
                                     ModelValidationError, ValidationError)

--- a/deepchecks/nlp/datasets/classification/tweet_emotion.py
+++ b/deepchecks/nlp/datasets/classification/tweet_emotion.py
@@ -114,7 +114,7 @@ def load_data(data_format: str = 'TextData', as_train_test: bool = True,
                 properties = None
             dataset = TextData(dataset.text, label=dataset[_target], task_type='text_classification',
                                metadata=dataset.drop(columns=[_target, 'text']),
-                               properties=properties, index=dataset.index)
+                               properties=properties)
         return dataset
     else:
         # train has more sport and Customer Complains but less Terror and Optimism
@@ -128,10 +128,10 @@ def load_data(data_format: str = 'TextData', as_train_test: bool = True,
                 train_properties, test_properties = None, None
 
             train = TextData(train.text, label=train[_target], task_type='text_classification',
-                             index=train.index, metadata=train.drop(columns=[_target, 'text']),
+                             metadata=train.drop(columns=[_target, 'text']),
                              properties=train_properties)
             test = TextData(test.text, label=test[_target], task_type='text_classification',
-                            index=test.index, metadata=test.drop(columns=[_target, 'text']),
+                            metadata=test.drop(columns=[_target, 'text']),
                             properties=test_properties)
         return train, test
 
@@ -147,7 +147,8 @@ def load_embeddings() -> np.ndarray:
     return pd.read_csv(_EMBEDDINGS_URL, index_col=0).to_numpy()
 
 
-def load_precalculated_predictions(pred_format: str = 'predictions') -> np.array:
+def load_precalculated_predictions(pred_format: str = 'predictions',
+                                   as_train_test: bool = False) -> np.array:
     """Load and return a precalculated predictions for the dataset.
 
     Parameters
@@ -156,7 +157,11 @@ def load_precalculated_predictions(pred_format: str = 'predictions') -> np.array
         Represent the format of the returned value. Can be 'predictions' or 'probabilities'.
         'predictions' will return the predicted class for each sample.
         'probabilities' will return the predicted probabilities for each sample.
-
+    as_train_test : bool, default: True
+        If True, the returned data is split into train and test exactly like the toy model
+        was trained. The first return value is the train data and the second is the test data.
+        In order to get this model, call the load_fitted_model() function.
+        Otherwise, returns a single object.
     Returns
     -------
     predictions : np.ndarray
@@ -165,16 +170,27 @@ def load_precalculated_predictions(pred_format: str = 'predictions') -> np.array
     """
     os.makedirs(ASSETS_DIR, exist_ok=True)
     if (ASSETS_DIR / 'tweet_emotion_probabilities.csv').exists():
-        preds = pd.read_csv(ASSETS_DIR / 'tweet_emotion_probabilities.csv', index_col=0)
+        all_preds = pd.read_csv(ASSETS_DIR / 'tweet_emotion_probabilities.csv', index_col=0)
     else:
-        preds = pd.read_csv(_PREDICTIONS_URL, index_col=0)
-        preds.to_csv(ASSETS_DIR / 'tweet_emotion_probabilities.csv')
-
-    preds = preds.to_numpy()
+        all_preds = pd.read_csv(_PREDICTIONS_URL, index_col=0)
+        all_preds.to_csv(ASSETS_DIR / 'tweet_emotion_probabilities.csv')
+    all_preds = all_preds.to_numpy()
 
     if pred_format == 'predictions':
-        return np.array([_LABEL_MAP[x] for x in np.argmax(preds, axis=1)])
-    elif pred_format == 'probabilities':
-        return preds
-    else:
+        all_preds = np.array([_LABEL_MAP[x] for x in np.argmax(all_preds, axis=1)])
+    elif pred_format != 'probabilities':
         raise ValueError('pred_format must be either "predictions" or "probabilities"')
+
+    if not as_train_test:
+        return all_preds
+
+    # Load indexes of train and test
+    if (ASSETS_DIR / 'tweet_emotion_data.csv').exists():
+        dataset = pd.read_csv(ASSETS_DIR / 'tweet_emotion_data.csv', index_col=0,
+                              usecols=['Unnamed: 0', 'train_test_split'])
+    else:
+        dataset = pd.read_csv(_FULL_DATA_URL, index_col=0, usecols=['Unnamed: 0', 'train_test_split'])
+
+    train_indexes = dataset[dataset['train_test_split'] == 'Train'].index
+    test_indexes = dataset[dataset['train_test_split'] == 'Test'].index
+    return all_preds[train_indexes], all_preds[test_indexes]

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -13,6 +13,7 @@ from typing import Dict, Optional, Sequence
 
 import numpy as np
 import pandas as pd
+
 from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.nlp.task_type import TaskType, TTextLabel
 from deepchecks.utils.logger import get_logger

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -1,0 +1,109 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Module containing input validation functions."""
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from deepchecks.core.errors import DeepchecksValueError
+from deepchecks.nlp.task_type import TaskType, TTextLabel
+from deepchecks.utils.logger import get_logger
+from deepchecks.utils.type_inference import infer_categorical_features
+from deepchecks.utils.validation import is_sequence_not_str
+
+
+def validate_tokenized_text(tokenized_text: Optional[Sequence[Sequence[str]]]):
+    """Validate tokenized text format."""
+    error_string = 'tokenized_text must be a Sequence of sequences of strings'
+    if not is_sequence_not_str(tokenized_text):
+        raise DeepchecksValueError(error_string)
+    if not all(is_sequence_not_str(x) for x in tokenized_text):
+        raise DeepchecksValueError(error_string)
+    if not all(isinstance(x, str) for tokens in tokenized_text for x in tokens):
+        raise DeepchecksValueError(error_string)
+
+
+def validate_raw_text(raw_text: Optional[Sequence[str]]):
+    """Validate text format."""
+    error_string = 'raw_text must be a Sequence of strings'
+    if not is_sequence_not_str(raw_text):
+        raise DeepchecksValueError(error_string)
+    if not all(isinstance(x, str) for x in raw_text):
+        raise DeepchecksValueError(error_string)
+
+
+def validate_modify_label(labels: Optional[TTextLabel], task_type: TaskType, expected_size: int,
+                          tokenized_text: Optional[Sequence[Sequence[str]]]) -> Optional[TTextLabel]:
+    """Validate and process label to accepted formats."""
+    if labels is None or is_sequence_not_str(labels) and all(x is None for x in labels):
+        return None
+
+    if not is_sequence_not_str(labels):
+        raise DeepchecksValueError('label must be a Sequence')
+    if not len(labels) == expected_size:
+        raise DeepchecksValueError(f'Label length ({len(labels)}) does not match expected length ({expected_size})')
+
+    if task_type == TaskType.TEXT_CLASSIFICATION:
+        if all(is_sequence_not_str(x) for x in labels):  # Multilabel
+            multilabel_error = 'multilabel was identified. It must be a Sequence of Sequences of 0 or 1.'
+            if not all(all(y in (0, 1) for y in x) for x in labels):
+                raise DeepchecksValueError(multilabel_error)
+            if any(len(labels[0]) != len(labels[i]) for i in range(len(labels))):
+                raise DeepchecksValueError('All multilabel entries must be of the same length, which is the number'
+                                           ' of possible classes.')
+            labels = [[int(x) for x in label_per_sample] for label_per_sample in labels]
+        elif not all(isinstance(x, (str, int)) for x in labels):  # Classic classification
+            raise DeepchecksValueError('label must be a Sequence of strings or ints (multiclass classification) '
+                                       'or a Sequence of Sequences of strings or ints (multilabel classification)')
+        else:
+            labels = [str(x) for x in labels]
+    elif task_type == TaskType.TOKEN_CLASSIFICATION:
+        token_class_error = 'label must be a Sequence of Sequences of either strings or integers.'
+        if not is_sequence_not_str(labels):
+            raise DeepchecksValueError(token_class_error)
+
+        result = []
+        for idx, (tokens, label) in enumerate(zip(tokenized_text, labels)):  # TODO: Runs on all labels, very costly
+            if not is_sequence_not_str(label):
+                raise DeepchecksValueError(token_class_error + f' label at {idx} was of type {type(label)}')
+            if not len(tokens) == len(label):
+                raise DeepchecksValueError(f'label must be the same length as tokenized_text. '
+                                           f'However, for sample index {idx} received token list of length '
+                                           f'{len(tokens)} and label list of length {len(label)}')
+            result.append([str(x) for x in label])
+        labels = result
+
+    return np.asarray(labels)
+
+
+def validate_length_and_calculate_column_types(data_table: pd.DataFrame, data_table_name: str, expected_size: int,
+                                               column_types: Optional[Dict[str, str]] = None) -> \
+        Optional[Dict[str, str]]:
+    """Validate length of data table and calculate column types."""
+    if data_table is None:
+        return None
+
+    if not isinstance(data_table, pd.DataFrame):
+        raise DeepchecksValueError(f'{data_table_name} type {type(data_table)} is not supported, must be a'
+                                   f' pandas DataFrame')
+    if len(data_table) != expected_size:
+        raise DeepchecksValueError(f'received metadata with {len(data_table)} rows, expected {expected_size}')
+
+    if column_types is None:  # TODO: Add tests
+        cat_features = infer_categorical_features(data_table)
+        column_types = {data_table.columns[i]: 'categorical' if data_table.columns[i] in cat_features else 'numeric'
+                        for i in range(len(data_table.columns))}
+        get_logger().info('%s types were not provided, auto inferred types are: ', data_table_name)
+        get_logger().info(column_types)
+    elif sorted(list(column_types.keys())) != sorted(list(data_table.columns)):
+        raise DeepchecksValueError(f'{data_table_name} types keys must identical to {data_table_name} table columns')
+
+    return column_types

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -23,7 +23,7 @@ from deepchecks.utils.validation import is_sequence_not_str
 
 def validate_tokenized_text(tokenized_text: Optional[Sequence[Sequence[str]]]):
     """Validate tokenized text format."""
-    error_string = 'tokenized_text must be a Sequence of sequences of strings'
+    error_string = 'tokenized_text must be a Sequence of Sequences of strings'
     if not is_sequence_not_str(tokenized_text):
         raise DeepchecksValueError(error_string)
     if not all(is_sequence_not_str(x) for x in tokenized_text):
@@ -80,7 +80,7 @@ def validate_modify_label(labels: Optional[TTextLabel], task_type: TaskType, exp
                                            f'However, for sample index {idx} received token list of length '
                                            f'{len(tokens)} and label list of length {len(label)}')
             result.append([str(x) for x in label])
-        labels = result
+        labels = np.asarray(result, dtype=object)
 
     return np.asarray(labels)
 

--- a/deepchecks/nlp/task_type.py
+++ b/deepchecks/nlp/task_type.py
@@ -9,9 +9,15 @@
 # ----------------------------------------------------------------------------
 #
 """The task type module containing the TaskType enum."""
+import typing as t
 from enum import Enum
 
-__all__ = ['TaskType']
+__all__ = ['TaskType', 'TTokenLabel', 'TClassLabel', 'TTextLabel']
+
+TSingleLabel = t.Union[int, str]
+TClassLabel = t.Sequence[t.Union[TSingleLabel, t.Tuple[TSingleLabel]]]
+TTokenLabel = t.Sequence[t.Sequence[t.Union[str, int]]]
+TTextLabel = t.Union[TClassLabel, TTokenLabel]
 
 
 class TaskType(Enum):

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -112,11 +112,11 @@ class TextData:
             raise DeepchecksNotSupportedError(f'task_type {task_type} is not supported, must be one of '
                                               f'text_classification, token_classification, other')
 
-        if raw_text is None and tokenized_text is None:
-            raise DeepchecksValueError('Either raw_text or tokenized_text must be provided')
-        elif raw_text is None:
+        if raw_text is None:
+            if tokenized_text is None:
+                raise DeepchecksValueError('Either raw_text or tokenized_text must be provided')
             self._text = np.asarray([' '.join(tokens) for tokens in tokenized_text])  # Revisit this decision
-        else:  # raw_text is not None, tokenized_text can be None
+        else:
             validate_raw_text(raw_text)
             self._text = np.asarray([str(x) for x in raw_text])
             if tokenized_text is not None and len(raw_text) != len(tokenized_text):

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -106,7 +106,7 @@ class TextData:
                 raise DeepchecksValueError('tokenized_text must be provided for token_classification task type')
             validate_tokenized_text(tokenized_text)
             modified = [[str(token) for token in tokens_per_sample] for tokens_per_sample in tokenized_text]
-            self._tokenized_text = np.asarray(modified)
+            self._tokenized_text = np.asarray(modified, dtype=object)
             self._task_type = TaskType.TOKEN_CLASSIFICATION
         else:
             raise DeepchecksNotSupportedError(f'task_type {task_type} is not supported, must be one of '
@@ -301,8 +301,8 @@ class TextData:
     def properties(self) -> pd.DataFrame:
         """Return the properties of the dataset."""
         if self._properties is None:
-            get_logger().info('No properties are set, calculating default properties')
-            self.calculate_default_properties()
+            raise DeepchecksValueError('TextData does not contain properties, add them by using '
+                                       'calculate_default_properties or set_properties functions')
         return self._properties
 
     @property

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -116,7 +116,7 @@ class TextData:
             raise DeepchecksValueError('Either raw_text or tokenized_text must be provided')
         elif raw_text is None:
             self._text = np.asarray([' '.join(tokens) for tokens in tokenized_text])  # Revisit this decision
-        else:
+        else:  # raw_text is not None, tokenized_text can be None
             validate_raw_text(raw_text)
             self._text = np.asarray([str(x) for x in raw_text])
             if tokenized_text is not None and len(raw_text) != len(tokenized_text):

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -15,6 +15,7 @@ from numbers import Number
 
 import numpy as np
 import pandas as pd
+
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError
 from deepchecks.nlp.input_validations import (validate_length_and_calculate_column_types, validate_modify_label,
                                               validate_raw_text, validate_tokenized_text)

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -11,25 +11,21 @@
 """The dataset module containing the tabular Dataset class and its functions."""
 import typing as t
 import warnings
-from operator import itemgetter
+from numbers import Number
 
 import numpy as np
 import pandas as pd
-
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError
-from deepchecks.nlp.task_type import TaskType
+from deepchecks.nlp.input_validations import (validate_length_and_calculate_column_types, validate_modify_label,
+                                              validate_raw_text, validate_tokenized_text)
+from deepchecks.nlp.task_type import TaskType, TTextLabel
 from deepchecks.nlp.utils.text_properties import calculate_default_properties
 from deepchecks.utils.logger import get_logger
-from deepchecks.utils.type_inference import infer_categorical_features
 from deepchecks.utils.validation import is_sequence_not_str
 
-__all__ = ['TextData', 'TTokenLabel', 'TClassLabel', 'TTextLabel']
+__all__ = ['TextData']
 
 TDataset = t.TypeVar('TDataset', bound='TextData')
-TSingleLabel = t.Tuple[int, str]
-TClassLabel = t.Sequence[t.Union[TSingleLabel, t.Tuple[TSingleLabel]]]
-TTokenLabel = t.Sequence[t.Sequence[t.Union[str, int]]]
-TTextLabel = t.Union[TClassLabel, TTokenLabel]
 
 
 class TextData:
@@ -65,10 +61,8 @@ class TextData:
     task_type : str, default: None
         The task type for the text data. Can be either 'text_classification' or 'token_classification'. Must be set if
         label is provided.
-    dataset_name : t.Optional[str] , default: None
+    name : t.Optional[str] , default: None
         The name of the dataset. If None, the dataset name will be defined when running it within a check.
-    index : t.Optional[t.Sequence[int]] , default: None
-        The index of the samples. If None, the index is set to np.arange(len(raw_text)).
     metadata : t.Optional[pd.DataFrame] , default: None
         Metadata for the samples. If None, no metadata is set. If a DataFrame is given, it must contain
         the same number of samples as the raw_text and identical index.
@@ -76,199 +70,107 @@ class TextData:
         The text properties for the samples. If None, no properties are set. If 'auto', the properties are calculated
         using the default properties. If a DataFrame is given, it must contain the properties for each sample as the raw
         text and identical index.
-    device : str, default: None
-        The device to use to calculate the text properties.
     """
 
-    _text: t.Sequence[str]
+    _text: np.ndarray
     _label: TTextLabel
-    index: t.Sequence[t.Any]
-    _task_type: t.Optional[TaskType]
-    _has_label: bool
-    _is_multilabel: bool = False
+    task_type: t.Optional[TaskType]
+    _tokenized_text: t.Optional[t.Sequence[t.Sequence[str]]] = None  # Outer sequence is np array
     name: t.Optional[str] = None
     _metadata: t.Optional[pd.DataFrame] = None
+    _metadata_types: t.Optional[t.Dict[str, str]] = None
     _properties: t.Optional[t.Union[pd.DataFrame, str]] = None
+    _properties_types: t.Optional[t.Dict[str, str]] = None
+    _original_text_index: t.Optional[t.Sequence[int]] = None  # Sequence is np array
 
     def __init__(
             self,
             raw_text: t.Optional[t.Sequence[str]] = None,
             tokenized_text: t.Optional[t.Sequence[t.Sequence[str]]] = None,
             label: t.Optional[TTextLabel] = None,
-            task_type: t.Optional[str] = None,
-            dataset_name: t.Optional[str] = None,
-            index: t.Optional[t.Sequence[t.Any]] = None,
+            task_type: str = 'other',
+            name: t.Optional[str] = None,
             metadata: t.Optional[pd.DataFrame] = None,
-            properties: t.Optional[t.Union[pd.DataFrame, str]] = None,
-            device: t.Optional[str] = None
+            properties: t.Optional[t.Union[pd.DataFrame]] = None,
     ):
         # Require explicitly setting task type if label is provided
         if task_type in [None, 'other']:
             if label is not None:
-                if isinstance(label, t.Sequence):
-                    if pd.notnull(label).any():
-                        raise DeepchecksValueError('task_type must be set when label is provided')
-                else:
-                    raise DeepchecksValueError('task_type must be set when label is provided')
-
+                raise DeepchecksValueError('task_type must be set when label is provided')
             self._task_type = TaskType.OTHER
         elif task_type == 'text_classification':
             self._task_type = TaskType.TEXT_CLASSIFICATION
         elif task_type == 'token_classification':
+            if tokenized_text is None:
+                raise DeepchecksValueError('tokenized_text must be provided for token_classification task type')
+            validate_tokenized_text(tokenized_text)
+            modified = [[str(token) for token in tokens_per_sample] for tokens_per_sample in tokenized_text]
+            self._tokenized_text = np.asarray(modified)
             self._task_type = TaskType.TOKEN_CLASSIFICATION
         else:
             raise DeepchecksNotSupportedError(f'task_type {task_type} is not supported, must be one of '
                                               f'text_classification, token_classification, other')
 
         if raw_text is None and tokenized_text is None:
-            raise DeepchecksValueError('raw_text and tokenized_text cannot both be None')
+            raise DeepchecksValueError('Either raw_text or tokenized_text must be provided')
         elif raw_text is None:
-            self._validate_tokenized_text(tokenized_text)
-            self._tokenized_text = list(tokenized_text)
-            self._text = [' '.join(tokens) for tokens in tokenized_text]
-        elif tokenized_text is None:
-            self._validate_text(raw_text)
-            self._text = list(raw_text)
-            if self._task_type == TaskType.TOKEN_CLASSIFICATION:
-                self._tokenized_text = [sample.split() for sample in self._text]
-            else:
-                self._tokenized_text = None
+            self._text = np.asarray([' '.join(tokens) for tokens in tokenized_text])  # Revisit this decision
         else:
-            self._validate_text(raw_text)
-            self._validate_tokenized_text(tokenized_text)
-            self._text, self._tokenized_text = list(raw_text), list(tokenized_text)
-            if len(raw_text) != len(tokenized_text):
-                raise DeepchecksValueError('raw_text and tokenized_text must have the same length')
+            validate_raw_text(raw_text)
+            self._text = np.asarray([str(x) for x in raw_text])
+            if tokenized_text is not None and len(raw_text) != len(tokenized_text):
+                raise DeepchecksValueError('raw_text and tokenized_text sequences must have the same length')
 
-        if index is None:
-            self.index = list(range(len(raw_text)))
-        elif len(index) != len(raw_text):
-            raise DeepchecksValueError('index must be the same length as raw_text')
-        else:
-            self.index = list(index)
+        self._label = validate_modify_label(label, self._task_type, len(self), tokenized_text)
 
-        self._validate_and_set_label(label)
+        if name is not None and not isinstance(name, str):
+            raise DeepchecksNotSupportedError(f'name must be a string, got {type(name)}')
+        self.name = name
 
-        if dataset_name is not None:
-            if not isinstance(dataset_name, str):
-                raise DeepchecksNotSupportedError(f'dataset_name type {type(dataset_name)} is not supported, must be a'
-                                                  f' str')
-        self.name = dataset_name
+        self.set_metadata(metadata)
+        self.set_properties(properties)
 
-        if metadata is not None:
-            self.set_metadata(metadata)
-        else:
-            self._metadata = None
-            self._metadata_types = None
+        # Used for display purposes
+        self._original_text_index = np.arange(len(self))
 
-        if properties is not None:
-            if isinstance(properties, str) and properties == 'auto':
-                self.calculate_default_properties(device=device)
-            else:
-                self.set_properties(properties)
-        else:
-            self._properties = None
-            self._properties_types = None
+    def is_multi_label_classification(self) -> bool:
+        """Check if the dataset is multi-label."""
+        if self.task_type == TaskType.TEXT_CLASSIFICATION and self._label is not None:
+            return is_sequence_not_str(self._label[0])
+        return False
 
-    @staticmethod
-    def _validate_text(raw_text: t.Sequence[str]):
-        """Validate text format."""
-        error_string = 'raw_text must be a Sequence of strings'
-        if not is_sequence_not_str(raw_text):
-            raise DeepchecksValueError(error_string)
-        if not all(isinstance(x, str) for x in raw_text):
-            raise DeepchecksValueError(error_string)
+    def copy(self: TDataset, rows_to_use: t.Optional[t.Sequence[int]] = None) -> TDataset:
+        """Create a copy of this Dataset with new data.
 
-    @staticmethod
-    def _validate_tokenized_text(tokenized_text: t.Sequence[t.Sequence[str]]):
-        """Validate tokenized text format."""
-        error_string = 'tokenized_text must be a Sequence of sequences of strings'
-        if not is_sequence_not_str(tokenized_text):
-            raise DeepchecksValueError(error_string)
-        if not all(is_sequence_not_str(x) for x in tokenized_text):
-            raise DeepchecksValueError(error_string)
-        if not all(isinstance(x, str) for tokens in tokenized_text for x in tokens):
-            raise DeepchecksValueError(error_string)
-
-    def _validate_and_set_label(self, label: t.Optional[TTextLabel]):
-        """Validate and process label to accepted formats."""
-        # If label is not set, create an empty label of nulls
-        if label is None:
-            self._has_label, self._label = False, [None] * len(self._text)
-            return
-
-        # Check if label is n array of None, if so return
-        if isinstance(label, t.Sequence) and all(x is None for x in label):
-            self._has_label, self._label = False, label
-            return
-
-        self._has_label = True
-        if not is_sequence_not_str(label):
-            raise DeepchecksValueError('label must be a Sequence')
-
-        if not len(label) == len(self._text):
-            raise DeepchecksValueError('label must be the same length as raw_text')
-
-        if self.task_type == TaskType.TEXT_CLASSIFICATION:
-            if all((isinstance(x, t.Sequence) and not isinstance(x, str)) for x in label):
-                self._is_multilabel = True
-                multilabel_error = 'multilabel was identified. It must be a Sequence of Sequences of 0 or 1.'
-                if not all(all(y in (0, 1) for y in x) for x in label):
-                    raise DeepchecksValueError(multilabel_error)
-                if any(len(label[0]) != len(label[i]) for i in range(len(label))):
-                    raise DeepchecksValueError('All multilabel entries must be of the same length, which is the number'
-                                               ' of classes.')
-            elif not all(isinstance(x, (str, int)) for x in label):
-                raise DeepchecksValueError('label must be a Sequence of strings or ints or a Sequence of Sequences'
-                                           'of strings or ints (for multilabel classification)')
-
-        if self.task_type == TaskType.TOKEN_CLASSIFICATION:
-            token_class_error = 'label must be a Sequence of Sequences of either strings or integers'
-            if not all(isinstance(x, t.Sequence) for x in label):
-                raise DeepchecksValueError(token_class_error)
-
-            for i in range(len(label)):  # TODO: Runs on all labels, very costly
-                if not (all(isinstance(x, str) for x in label[i]) or all(isinstance(x, int) for x in label[i])):
-                    raise DeepchecksValueError(token_class_error)
-                if not len(label[i]) == len(self._tokenized_text[i]):
-                    raise DeepchecksValueError(f'label must be the same length as tokenized_text. '
-                                               f'However, for sample index {self.index[i]} of length '
-                                               f'{len(self._tokenized_text[i])} received label of '
-                                               f'length {len(label[i])}')
-        self._label = list(label)
-
-    def reindex(self, index: t.Sequence[t.Any]):
-        """Reindex the TextData with a new index."""
-        if not is_sequence_not_str(index):
-            raise DeepchecksValueError('index must be a Sequence')
-        if not len(index) == len(self.index):
-            raise DeepchecksValueError('new index must be the same length as original index')
-        self.index = list(index)
-        if self._metadata is not None:
-            self._metadata = self._metadata.reindex(index)
-        if self._properties is not None:
-            self._properties = self._properties.reindex(index)
-
-    def copy(self: TDataset, rows_to_use: t.Optional[t.Sequence[t.Any]] = None) -> TDataset:
-        """Create a copy of this Dataset with new data."""
+        Parameters
+        ----------
+        rows_to_use : t.Optional[t.List[int]] , default: None
+            The rows to use in the new copy. If None, the new copy will contain all the rows.
+        """
         cls = type(self)
         logger_state = get_logger().disabled
         get_logger().disabled = True  # Make sure we won't get the warning for setting class in the non multilabel case
         if rows_to_use is None:
             new_copy = cls(raw_text=self._text, tokenized_text=self._tokenized_text, label=self._label,
-                           task_type=self._task_type.value,
-                           dataset_name=self.name, index=self.index, metadata=self.metadata,
-                           properties=self._properties)
+                           task_type=self._task_type.value, name=self.name)
+            metadata, properties = self._metadata, self._properties
+            index_kept = self._original_text_index
         else:
-            new_copy = cls(
-                raw_text=list(itemgetter(*rows_to_use)(self._text)),
-                tokenized_text=list(
-                    itemgetter(*rows_to_use)(self._tokenized_text)) if self._tokenized_text else None,
-                label=list(itemgetter(*rows_to_use)(self._label)) if self._label else None,
-                index=list(itemgetter(*rows_to_use)(self.index)),
-                metadata=self._metadata.iloc[rows_to_use, :] if self._metadata is not None else None,
-                properties=self._properties.iloc[rows_to_use, :] if self._properties is not None else None,
-                task_type=self._task_type.value, dataset_name=self.name)
+            if not isinstance(rows_to_use, t.Sequence) or any(not isinstance(x, Number) for x in rows_to_use):
+                raise DeepchecksValueError('rows_to_use must be a list of integers')
+            rows_to_use = sorted(rows_to_use)
+            new_copy = cls(raw_text=self._text[rows_to_use],
+                           tokenized_text=self._tokenized_text[
+                               rows_to_use] if self._tokenized_text is not None else None,
+                           label=self._label[rows_to_use] if self.has_label() else None,
+                           task_type=self._task_type.value, name=self.name)
+            metadata = self._metadata.iloc[rows_to_use, :] if self._metadata is not None else None
+            properties = self._properties.iloc[rows_to_use, :] if self._properties is not None else None
+            index_kept = self._original_text_index[rows_to_use]
+
+        new_copy.set_metadata(metadata, self._metadata_types)
+        new_copy.set_properties(properties, self._properties_types)
+        new_copy._original_text_index = index_kept  # pylint: disable=protected-access
         get_logger().disabled = logger_state
         return new_copy
 
@@ -292,79 +194,78 @@ class TextData:
         Dataset
             instance of the Dataset with sampled internal dataframe.
         """
-        samples = self.index
+        samples = np.arange(len(self))
         if drop_na_label and self.has_label():
             samples = samples[pd.notnull(self._label)]
         n_samples = min(n_samples, len(samples))
 
         np.random.seed(random_state)
         sample_idx = np.random.choice(range(len(samples)), n_samples, replace=replace)
-        return self.copy(rows_to_use=sample_idx)
+        return self.copy(rows_to_use=sorted(sample_idx))
 
-    def get_raw_sample(self, index: t.Any) -> str:
-        """Get the raw text of a sample.
-
-        Parameters
-        ----------
-        index : int
-            Index of sample to get.
-        Returns
-        -------
-        str
-            Raw text of sample.
-        """
-        return self._text[self.index.index(index)]
-
-    def get_tokenized_sample(self, index: t.Any) -> t.List[str]:
-        """Get the tokenized text of a sample.
-
-        Parameters
-        ----------
-        index : int
-            Index of sample to get.
-        Returns
-        -------
-        List[str]
-            Tokenized text of sample.
-        """
-        if self._tokenized_text is None:
-            raise DeepchecksValueError('TextData does not contain tokenized text')
-        return self._tokenized_text[self.index.index(index)]
+    def __len__(self) -> int:
+        """Return number of samples in the dataset."""
+        return self.n_samples
 
     @property
     def n_samples(self) -> int:
         """Return number of samples in the dataset."""
-        return len(self._text)
+        if self._text is not None:
+            return len(self._text)
+        elif self._label is not None:
+            return len(self._label)
+        else:
+            return 0
 
     @property
     def metadata(self) -> pd.DataFrame:
         """Return the metadata of for the dataset."""
+        if self._metadata is None:
+            raise DeepchecksValueError('Metadata does not exist, please set it first using the set_metadata method')
         return self._metadata
 
     @property
     def metadata_types(self) -> t.Dict[str, str]:
         """Return the metadata types of for the dataset."""
+        if self._metadata_types is None:
+            raise DeepchecksValueError('Metadata does not exist, please set it first using the set_metadata method')
         return self._metadata_types
 
     def set_metadata(self, metadata: pd.DataFrame, metadata_types: t.Optional[t.Dict[str, str]] = None):
-        """Set the metadata of the dataset."""
+        """Set metadata for the dataset.
+
+        Parameters
+        ----------
+        metadata : pd.DataFrame
+            Metadata of the provided textual samples.
+        metadata_types : t.Optional[t.Dict[str, str]] , default : None
+            The types of the metadata columns. Can be either 'numeric' or 'categorical'.
+            If not provided, will be inferred automatically.
+        """
         if self._metadata is not None:
             warnings.warn('Metadata already exist, overwriting it', UserWarning)
 
-        if not isinstance(metadata, pd.DataFrame):
-            raise DeepchecksValueError(f'metadata type {type(metadata)} is not supported, must be a'
-                                       f' pandas DataFrame')
-        if self.index != list(metadata.index):
-            raise DeepchecksValueError('metadata index must be the same as the text data index')
-        self._metadata = metadata
+        self._metadata_types = validate_length_and_calculate_column_types(metadata, 'Metadata',
+                                                                          len(self), metadata_types)
+        self._metadata = metadata.reset_index(drop=True) if isinstance(metadata, pd.DataFrame) else None
 
-        if metadata_types is None:  # TODO: Add tests
-            cat_features = infer_categorical_features(metadata)
-            metadata_types = {metadata.columns[i]: 'categorical' if metadata.columns[i] in cat_features else 'numeric'
-                              for i in range(len(metadata.columns))}
-        elif sorted(list(metadata_types.keys())) != sorted(list(metadata.columns)):
-            raise DeepchecksValueError('metadata_types keys must identical to metadata columns')
-        self._metadata_types = metadata_types
+    def set_properties(self, properties: pd.DataFrame, properties_types: t.Optional[t.Dict[str, str]] = None):
+        """Set properties for the dataset.
+
+        Parameters
+        ----------
+        properties : pd.DataFrame
+            Properties of the provided textual samples.
+        properties_types : t.Optional[t.Dict[str, str]] , default : None
+            The types of the properties columns. Can be either 'numeric' or 'categorical'.
+            If not provided, will be inferred automatically.
+        """
+        if self._properties is not None:
+            warnings.warn('Properties already exist, overwriting it', UserWarning)
+
+        self._properties_types = validate_length_and_calculate_column_types(properties, 'Properties',
+                                                                            len(self), properties_types)
+        self._properties = properties.reset_index(drop=True) if isinstance(properties, pd.DataFrame) else None
 
     def calculate_default_properties(self, include_properties: t.List[str] = None,
                                      ignore_properties: t.List[str] = None,
@@ -392,49 +293,23 @@ class TextData:
         properties, properties_types = calculate_default_properties(
             self.text, include_properties=include_properties, ignore_properties=ignore_properties,
             include_long_calculation_properties=include_long_calculation_properties, device=device)
-        self._properties = pd.DataFrame(properties, index=self.index)
-        self._properties_types = properties_types
-
-    def set_properties(self, properties: pd.DataFrame, properties_types: t.Optional[t.Dict[str, str]] = None):
-        """Set the properties of the dataset."""
-        if self._properties is not None:
-            warnings.warn('Properties already exist, overwriting them', UserWarning)
-
-        if not isinstance(properties, pd.DataFrame):
-            raise DeepchecksValueError(f'properties type {type(properties)} is not supported, must be a'
-                                       f' pandas DataFrame')
-        if list(properties.index) != self.index:
-            raise DeepchecksValueError('properties index must be the same as the text data index')
-        self._properties = properties
-
-        if properties_types is None:
-            # TODO: move infer_categorical_features to core
-            cat_features = infer_categorical_features(properties)
-            properties_types = {
-                properties.columns[i]: 'categorical' if properties.columns[i] in cat_features else 'numeric'
-                for i in range(len(properties.columns))}
-        elif sorted(list(properties_types.keys())) != sorted(list(properties.columns)):
-            raise DeepchecksValueError('properties_types keys must identical to properties columns')
-
+        self._properties = pd.DataFrame(properties, index=self.get_original_text_indexes())
         self._properties_types = properties_types
 
     @property
     def properties(self) -> pd.DataFrame:
         """Return the properties of the dataset."""
         if self._properties is None:
-            raise DeepchecksNotSupportedError(
-                'TextData does not contain properties, add them by using calculate_default_properties or '
-                'set_properties functions')
+            get_logger().info('No properties are set, calculating default properties')
+            self.calculate_default_properties()
         return self._properties
 
     @property
     def properties_types(self) -> t.Dict[str, str]:
         """Return the property types of the dataset."""
+        if self._properties is None:
+            raise DeepchecksValueError('Properties does not exist, please set it first using the set_properties method')
         return self._properties_types
-
-    def __len__(self):
-        """Return number of samples in the dataset."""
-        return self.n_samples
 
     @property
     def task_type(self) -> t.Optional[TaskType]:
@@ -467,6 +342,9 @@ class TextData:
         t.Sequence[t.Sequence[str]]
            Sequence of tokenized text samples.
         """
+        if self._tokenized_text is None:
+            raise DeepchecksValueError('Tokenized text is not set, provide it when initializing the TextData object '
+                                       'to run the requested functionalities')
         return self._tokenized_text
 
     @property
@@ -477,18 +355,10 @@ class TextData:
         -------
         TTextLabel
         """
+        if not self.has_label():
+            raise DeepchecksValueError('Label is not set, provide it when initializing the TextData object '
+                                       'to run the requested functionalities')
         return self._label
-
-    @property
-    def is_multilabel(self) -> bool:
-        """Return True if label is multilabel.
-
-        Returns
-        -------
-        bool
-            True if label is multilabel.
-        """
-        return self._is_multilabel
 
     def has_label(self) -> bool:
         """Return True if label was set.
@@ -498,7 +368,17 @@ class TextData:
         bool
            True if label was set.
         """
-        return self._has_label
+        return self._label is not None
+
+    def get_original_text_indexes(self) -> t.Sequence[int]:
+        """Return the original indexes of the text samples.
+
+        Returns
+        -------
+        t.Sequence[int]
+           Original indexes of the text samples.
+        """
+        return self._original_text_index
 
     @classmethod
     def cast_to_dataset(cls, obj: t.Any) -> 'TextData':
@@ -523,35 +403,37 @@ class TextData:
             raise DeepchecksValueError(f'{obj} is not a {cls.__name__} instance')
         return obj.copy()
 
-    @classmethod
-    def datasets_share_task_type(cls, *datasets: 'TextData') -> bool:
+    def validate_textdata_compatibility(self, other_text_data: 'TextData') -> bool:
         """Verify that all provided datasets share same label name and task types.
 
         Parameters
         ----------
-        datasets : List[TextData]
-            list of TextData to validate
+        other_text_data : TextData
+            The other dataset TextData object to compare with.
 
         Returns
         -------
         bool
-            True if all TextData share same label names and task types, otherwise False
-
-        Raises
-        ------
-        AssertionError
-            'datasets' parameter is not a list;
-            'datasets' contains less than one dataset;
+            True if provided dataset share same label name and task types.
         """
-        assert len(datasets) > 1, "'datasets' must contains at least two items"
-
-        task_type = datasets[0].task_type
-
-        for ds in datasets[1:]:
-            if ds.task_type != task_type:
-                return False
+        assert other_text_data is not None
+        if self.task_type != other_text_data.task_type:
+            return False
 
         return True
+
+    def head(self, n_samples: int = 5) -> pd.DataFrame:
+        """Return a copy of the dataset as a pandas Dataframe with the first n_samples samples."""
+        if n_samples > len(self):
+            n_samples = len(self) - 1
+        result = pd.DataFrame({'text': self.text[:n_samples]}, index=self.get_original_text_indexes()[:n_samples])
+        if self.has_label():
+            result['label'] = self.label[:n_samples]
+        if self._tokenized_text is not None:
+            result['tokenized_text'] = self.tokenized_text[:n_samples]
+        if self._metadata is not None:
+            result = result.join(self.metadata.loc[result.index])
+        return result
 
     def len_when_sampled(self, n_samples: t.Optional[int]):
         """Return number of samples in the sampled dataframe this dataset is sampled with n_samples samples."""
@@ -564,16 +446,3 @@ class TextData:
         if n_samples is None:
             return False
         return self.n_samples > n_samples
-
-    def head(self, n_samples: int = 5) -> pd.DataFrame:
-        """Return a copy of the dataset as a pandas Dataframe with the first n_samples samples."""
-        if n_samples > len(self):
-            n_samples = len(self) - 1
-        result = pd.DataFrame({'text': self.text[:n_samples]}, index=self.index[:n_samples])
-        if self.has_label():
-            result['label'] = self.label[:n_samples]
-        if self._tokenized_text is not None:
-            result['tokenized_text'] = self.tokenized_text[:n_samples]
-        if self._metadata is not None:
-            result = result.join(self.metadata.loc[result.index])
-        return result

--- a/deepchecks/nlp/utils/text_properties.py
+++ b/deepchecks/nlp/utils/text_properties.py
@@ -240,6 +240,7 @@ def calculate_default_properties(raw_text: Sequence[str], include_properties: Op
     if not calculated_properties:
         raise RuntimeError('Failed to calculate any of the properties.')
 
-    properties_types = {prop['name']: prop['output_type'] for prop in default_text_properties}  # TODO: Add tests
+    properties_types = {prop['name']: prop['output_type'] for prop in default_text_properties
+                        if prop['name'] in calculated_properties.keys()}  # TODO: Add tests
 
     return calculated_properties, properties_types

--- a/deepchecks/nlp/utils/text_properties.py
+++ b/deepchecks/nlp/utils/text_properties.py
@@ -154,7 +154,6 @@ DEFAULT_PROPERTIES = [
     {'name': 'Formality', 'method': formality, 'output_type': 'numeric'}
 ]
 
-
 LONG_RUN_PROPERTIES = ['Toxicity', 'Fluency', 'Formality']
 ENGLISH_ONLY_PROPERTIES = ['Sentiment', 'Subjectivity', 'Toxicity', 'Fluency', 'Formality']
 LARGE_SAMPLE_SIZE = 10_000
@@ -222,8 +221,8 @@ def calculate_default_properties(raw_text: Sequence[str], include_properties: Op
     else:  # Check if the run may take a long time and warn
         heavy_properties = [prop for prop in default_text_properties if prop['name'] in LONG_RUN_PROPERTIES]
         if heavy_properties and len(raw_text) > LARGE_SAMPLE_SIZE:
-            h_property_names = [prop['name'] for prop in heavy_properties]
-            warning_message = f'Calculating the properties {h_property_names} on a large dataset may take a long time.'\
+            h_prop_names = [prop['name'] for prop in heavy_properties]
+            warning_message = f'Calculating the properties {h_prop_names} on a large dataset may take a long time.' \
                               f' Consider using a smaller sample size or running this code on better hardware.'
             if device is None or device == 'cpu':
                 warning_message += ' Consider using a GPU or a similar device to run these properties.'
@@ -241,6 +240,6 @@ def calculate_default_properties(raw_text: Sequence[str], include_properties: Op
         raise RuntimeError('Failed to calculate any of the properties.')
 
     properties_types = {prop['name']: prop['output_type'] for prop in default_text_properties
-                        if prop['name'] in calculated_properties.keys()}  # TODO: Add tests
+                        if prop['name'] in calculated_properties}  # TODO: Add tests
 
     return calculated_properties, properties_types

--- a/deepchecks/utils/validation.py
+++ b/deepchecks/utils/validation.py
@@ -10,8 +10,6 @@
 #
 """Objects validation utilities."""
 
-# TODO: move tabular functionality to the tabular sub-package
-
 import typing as t
 
 import numpy as np
@@ -22,18 +20,17 @@ from deepchecks.utils.typing import Hashable
 
 __all__ = [
     'ensure_hashable_or_mutable_sequence',
-    'is_sequence_not_str'
+    'is_sequence_not_str',
 ]
-
 
 T = t.TypeVar('T', bound=Hashable)
 
 
 def ensure_hashable_or_mutable_sequence(
-    value: t.Union[T, t.MutableSequence[T]],
-    message: str = (
-        'Provided value is neither hashable nor mutable '
-        'sequence of hashable items. Got {type}')
+        value: t.Union[T, t.MutableSequence[T]],
+        message: str = (
+                'Provided value is neither hashable nor mutable '
+                'sequence of hashable items. Got {type}')
 ) -> t.List[T]:
     """Validate that provided value is either hashable or mutable sequence of hashable values."""
     if isinstance(value, Hashable):

--- a/tests/nlp/checks/data_integrity/property_label_correlation_test.py
+++ b/tests/nlp/checks/data_integrity/property_label_correlation_test.py
@@ -17,13 +17,12 @@ from deepchecks.nlp.datasets.classification import tweet_emotion
 from tests.base.utils import equal_condition_result
 
 
-def test_tweet_emotion_properties(tweet_emotion_train_test_textdata):
+def test_tweet_emotion_properties(tweet_emotion_train_test_textdata, tweet_emotion_train_test_probabilities):
     # Arrange
     _, test = tweet_emotion_train_test_textdata
-    test_probas = tweet_emotion.load_precalculated_predictions(pred_format='probabilities')[test.index]
     check = PropertyLabelCorrelation().add_condition_property_pps_less_than(0.1)
     # Act
-    result = check.run(test, probabilities=test_probas)
+    result = check.run(test, probabilities=tweet_emotion_train_test_probabilities[1])
     condition_result = check.conditions_decision(result)
 
     # Assert

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -20,10 +20,10 @@ def test_defaults(text_classification_dataset_mock):
 
     # Act
     result = check.run(text_classification_dataset_mock,
-                       predictions=[0, 1, 1])
+                       predictions=['0', '1', '1'])
 
     # Assert
-    assert_that(text_classification_dataset_mock.label, equal_to([0, 0, 1]))
+    assert_that(list(text_classification_dataset_mock.label), equal_to(['0', '0', '1']))
     assert_that(result.value[0][0], close_to(1, 0.001))
     assert_that(result.value.shape[0], close_to(2, 0.001))
 
@@ -37,7 +37,7 @@ def test_run_default_scorer_string_class(text_classification_string_class_datase
                        predictions=['wise', 'wise', 'meh'])
 
     # Assert
-    assert_that(text_classification_string_class_dataset_mock.label, equal_to(['wise', 'meh', 'meh']))
+    assert_that(list(text_classification_string_class_dataset_mock.label), equal_to(['wise', 'meh', 'meh']))
     assert_that(result.value[0][0], close_to(1, 0.001))
     assert_that(result.value.shape[0], close_to(2, 0.001))
 
@@ -51,7 +51,7 @@ def test_run_default_scorer_string_class_new_cats_in_model_classes(text_classifi
                        predictions=['wise', 'new', 'meh'])
 
     # Assert
-    assert_that(text_classification_string_class_dataset_mock.label, equal_to(['wise', 'meh', 'meh']))
+    assert_that(list(text_classification_string_class_dataset_mock.label), equal_to(['wise', 'meh', 'meh']))
     assert_that(result.value[0][0], close_to(1, 0.001))
     assert_that(result.value.shape[0], close_to(3, 0.001))
 

--- a/tests/nlp/checks/model_evaluation/prediction_drift_test.py
+++ b/tests/nlp/checks/model_evaluation/prediction_drift_test.py
@@ -60,7 +60,7 @@ def test_tweet_emotion_no_drift_no_label(tweet_emotion_train_test_textdata, twee
     # Arrange
     train, _ = tweet_emotion_train_test_textdata
     train = TextData(train.text, task_type='text_classification', metadata=train.metadata,
-                     properties=train.properties, index=train.index)
+                     properties=train.properties)
     train_preds, _ = tweet_emotion_train_test_predictions
     check = PredictionDrift().add_condition_drift_score_less_than()
     # Act

--- a/tests/nlp/checks/model_evaluation/single_dataset_performance_test.py
+++ b/tests/nlp/checks/model_evaluation/single_dataset_performance_test.py
@@ -10,10 +10,9 @@
 #
 """Test for the nlp SingleDatasetPerformance check"""
 
-from hamcrest import assert_that, close_to, calling, raises, equal_to, has_items
-
 from deepchecks.core.errors import DeepchecksValueError, ValidationError
 from deepchecks.nlp.checks.model_evaluation.single_dataset_performance import SingleDatasetPerformance
+from hamcrest import assert_that, close_to, calling, raises, equal_to, has_items
 from tests.base.utils import equal_condition_result
 
 
@@ -133,6 +132,7 @@ def test_run_with_scorer_multilabel_class_names(text_multilabel_classification_d
     assert_that(result.value.values[0][-1], close_to(1.0, 0.001))
     assert_that(result.value.values[0][0], equal_to('a'))
 
+
 def test_wikiann_data(wikiann):
     """Temp to test wikiann dataset loads correctly"""
     dataset = wikiann
@@ -141,14 +141,15 @@ def test_wikiann_data(wikiann):
 
     assert_that(result.value.values[0][-1], equal_to(1))
 
+
 def test_run_with_scorer_token(text_token_classification_dataset_mock):
     # Arrange
     check = SingleDatasetPerformance(scorers=['token_f1_macro'])
 
     correct_predictions = [['B-PER', 'O', 'O', 'O', 'O'], ['B-PER', 'O', 'O', 'B-GEO', 'O', 'B-GEO'],
-                     ['O', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]
-    almost_correct_predictions = [['B-PER', 'O', 'O', 'O', 'O'], ['B-PER', 'O', 'O', 'O', 'O', 'B-GEO'],
                            ['O', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]
+    almost_correct_predictions = [['B-PER', 'O', 'O', 'O', 'O'], ['B-PER', 'O', 'O', 'O', 'O', 'B-GEO'],
+                                  ['O', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]
 
     # Act
     result = check.run(text_token_classification_dataset_mock,
@@ -168,7 +169,6 @@ def test_run_with_scorer_token(text_token_classification_dataset_mock):
 
 
 def test_run_with_scorer_token_per_class(text_token_classification_dataset_mock):
-
     # Arrange
     check = SingleDatasetPerformance(scorers=['token_recall_per_class'])
 
@@ -187,6 +187,7 @@ def test_run_with_scorer_token_per_class(text_token_classification_dataset_mock)
     assert_that(result.value.values[1][0], equal_to('B-GEO'))
     assert_that(result.value.values[2][-1], close_to(1., 0.001))
     assert_that(result.value.values[2][0], equal_to('B-PER'))
+
 
 def test_ignore_O_label_in_model_classes(text_token_classification_dataset_mock):
     # Arrange

--- a/tests/nlp/conftest.py
+++ b/tests/nlp/conftest.py
@@ -37,22 +37,16 @@ def tweet_emotion_train_test_textdata():
 
 
 @pytest.fixture(scope='session')
-def tweet_emotion_train_test_predictions(tweet_emotion_train_test_textdata):
+def tweet_emotion_train_test_predictions():
     """Tweet emotion text classification dataset predictions"""
-    train_data, test_data = tweet_emotion_train_test_textdata
-    train_preds = tweet_emotion.load_precalculated_predictions(pred_format='predictions')[train_data.index]
-    test_preds = tweet_emotion.load_precalculated_predictions(pred_format='predictions')[test_data.index]
-
-    return train_preds, test_preds
+    return tweet_emotion.load_precalculated_predictions(pred_format='predictions', as_train_test=True)
 
 
 @pytest.fixture(scope='session')
-def tweet_emotion_train_test_probabilities(tweet_emotion_train_test_textdata):
+def tweet_emotion_train_test_probabilities():
     """Tweet emotion text classification dataset probabilities"""
-    train_data, test_data = tweet_emotion_train_test_textdata
-    train_probas = tweet_emotion.load_precalculated_predictions(pred_format='probabilities')[train_data.index]
-    test_probas = tweet_emotion.load_precalculated_predictions(pred_format='probabilities')[test_data.index]
-    return train_probas, test_probas
+    return tweet_emotion.load_precalculated_predictions(pred_format='probabilities', as_train_test=True)
+
 
 
 @pytest.fixture(scope='session')
@@ -95,7 +89,7 @@ def movie_reviews_data_positive():
     download_nltk_resources()
     random.seed(42)
     pos_sentences = [' '.join(x) for x in movie_reviews.sents(categories='pos')]
-    pos_data = TextData(random.choices(pos_sentences, k=1000), dataset_name='Positive')
+    pos_data = TextData(random.choices(pos_sentences, k=1000), name='Positive')
     return pos_data
 
 
@@ -105,15 +99,18 @@ def movie_reviews_data_negative():
     download_nltk_resources()
     random.seed(42)
     neg_sentences = [' '.join(x) for x in movie_reviews.sents(categories='neg')]
-    neg_data = TextData(random.choices(neg_sentences, k=1000), dataset_name='Negative')
+    neg_data = TextData(random.choices(neg_sentences, k=1000), name='Negative')
     return neg_data
 
+def _tokenize_raw_text(raw_text):
+    """Tokenize raw text"""
+    return [x.split() for x in raw_text]
 
 @pytest.fixture(scope='session')
 def text_token_classification_dataset_mock():
     """Mock for a token classification dataset"""
-    return TextData(raw_text=['Mary had a little lamb', 'Mary lives in London and Paris',
-                              'How much wood can a wood chuck chuck?'],
+    return TextData(tokenized_text=_tokenize_raw_text(['Mary had a little lamb', 'Mary lives in London and Paris',
+                              'How much wood can a wood chuck chuck?']),
                     label=[['B-PER', 'O', 'O', 'O', 'O'], ['B-PER', 'O', 'O', 'B-GEO', 'O', 'B-GEO'],
                            ['O', 'O', 'O', 'O', 'O', 'O', 'O', 'O']],
                     task_type='token_classification')
@@ -129,4 +126,4 @@ def wikiann():
     ner_to_iob_dict = {0: 'O', 1: 'B-PER', 2: 'I-PER', 3: 'B-ORG', 4: 'I-ORG', 5: 'B-LOC', 6: 'I-LOC'}
     ner_tags_translated = [[ner_to_iob_dict[ner_tag] for ner_tag in ner_tag_list.as_py()] for ner_tag_list in ner_tags]
 
-    return TextData(raw_text=data, label=ner_tags_translated, task_type='token_classification')
+    return TextData(tokenized_text=_tokenize_raw_text(data), label=ner_tags_translated, task_type='token_classification')

--- a/tests/nlp/test_text_data.py
+++ b/tests/nlp/test_text_data.py
@@ -43,7 +43,7 @@ def test_init_mismatched_task_type():
     # Act & Assert
     assert_that(
         calling(TextData).with_args(raw_text=text, label=label, task_type='token_classification'),
-        raises(DeepchecksValueError, r'label must be a Sequence of Sequences of either strings or integers')
+        raises(DeepchecksValueError, r'tokenized_text must be provided for token_classification task type')
     )
 
     # Arrange
@@ -59,7 +59,7 @@ def test_init_mismatched_task_type():
 
 def test_wrong_token_label_format():
     # Arrange
-    text = ['a', 'b b b', 'c c c c']
+    tokenized_text = [['a'] ,['b', 'b' ,'b'], ['c', 'c', 'c', 'c']]
 
     label_structure_error = r'label must be a Sequence of Sequences of either strings or integers'
 
@@ -68,28 +68,28 @@ def test_wrong_token_label_format():
     label = [['B-PER'],
              ['B-PER', 'B-GEO', 'B-GEO'],
              ['B-PER', 'B-GEO', 'B-GEO', 'B-GEO']]
-    _ = TextData(raw_text=text, label=label, task_type='token_classification')  # Should pass
+    _ = TextData(tokenized_text=tokenized_text, label=label, task_type='token_classification')  # Should pass
 
     # Not a list:
     label = 'PER'
     assert_that(
-        calling(TextData).with_args(raw_text=text, label=label, task_type='token_classification'),
+        calling(TextData).with_args(tokenized_text=tokenized_text, label=label, task_type='token_classification'),
         raises(DeepchecksValueError, 'label must be a Sequence')
     )
 
     # Not a list of lists:
     label = [3, 3, 3]
     assert_that(
-        calling(TextData).with_args(raw_text=text, label=label, task_type='token_classification'),
+        calling(TextData).with_args(tokenized_text=tokenized_text, label=label, task_type='token_classification'),
         raises(DeepchecksValueError, label_structure_error)
     )
 
     # Mixed strings and integers:
     label = [['B-PER'],
-             ['B-PER', 1, 'B-GEO'],
+             1,
              ['B-PER', 'B-GEO', 'B-GEO', 'B-GEO']]
     assert_that(
-        calling(TextData).with_args(raw_text=text, label=label, task_type='token_classification'),
+        calling(TextData).with_args(tokenized_text=tokenized_text, label=label, task_type='token_classification'),
         raises(DeepchecksValueError, label_structure_error)
     )
 
@@ -98,9 +98,9 @@ def test_wrong_token_label_format():
              ['B-PER', 'B-GEO', 'B-GEO'],
              ['B-PER', 'B-GEO', 'B-GEO']]
     assert_that(
-        calling(TextData).with_args(raw_text=text, label=label, task_type='token_classification'),
-        raises(DeepchecksValueError, r'label must be the same length as tokenized_text. '
-                                     r'However, for sample index 2 of length 4 received label of length 3')
+        calling(TextData).with_args(tokenized_text=tokenized_text, label=label, task_type='token_classification'),
+        raises(DeepchecksValueError, r'label must be the same length as tokenized_text. However, for sample '
+                                     r'index 2 received token list of length 4 and label list of length 3')
     )
 
 
@@ -115,7 +115,7 @@ def test_metadata_format():
     assert_that(
         calling(TextData).with_args(raw_text=text, metadata=metadata, task_type='text_classification'),
         raises(DeepchecksValueError,
-               r"metadata type <class 'dict'> is not supported, must be a pandas DataFrame")
+               r"Metadata type <class 'dict'> is not supported, must be a pandas DataFrame")
     )
 
 
@@ -178,7 +178,7 @@ def test_set_metadata(text_classification_dataset_mock):
     dataset._metadata_types = None  # pylint: disable=protected-access
 
     assert_that(calling(dataset.set_metadata).with_args(metadata, metadata_types={'first': 'numeric'}),
-                raises(DeepchecksValueError, 'metadata_types keys must identical to metadata columns'))
+                raises(DeepchecksValueError, 'Metadata types keys must identical to Metadata table columns'))
 
 
 def test_set_properties(text_classification_dataset_mock):
@@ -204,4 +204,4 @@ def test_set_properties(text_classification_dataset_mock):
     dataset._properties_types = None  # pylint: disable=protected-access
 
     assert_that(calling(dataset.set_properties).with_args(properties, properties_types={'text_length': 'numeric'}),
-                raises(DeepchecksValueError, 'properties_types keys must identical to properties columns'))
+                raises(DeepchecksValueError, 'Properties types keys must identical to Properties table columns'))


### PR DESCRIPTION
Part of effort to robust the nlp base package

Main changes:
Input validation and convert to uniform standard (np arrays)
No outside usage of index (only used internally to support sampling mechanism + display)
Labels and predictions which are not multilabel are converted to str
For token classification - you must supply tokenized text