### PR TITLE
fix hide index

### DIFF
--- a/deepchecks/core/serialization/common.py
+++ b/deepchecks/core/serialization/common.py
@@ -185,7 +185,10 @@ def aggregate_conditions(
 
     with warnings.catch_warnings():
         warnings.simplefilter(action='ignore', category=FutureWarning)
-        return df.style.hide_index()
+        # style.hide_index() was deprecated in the latest versions and new method was added
+        styler = df.style
+        styler = styler.hide(axis='index') if hasattr(styler, 'hide') else styler.hide_index()
+        return styler
 
 
 def create_results_dataframe(

--- a/deepchecks/core/serialization/suite_result/html.py
+++ b/deepchecks/core/serialization/suite_result/html.py
@@ -348,5 +348,8 @@ class SuiteResultSerializer(HtmlSerializer['suite.SuiteResult']):
 
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=FutureWarning)
-            table = DataFrameHtmlSerializer(df.style.hide_index()).serialize()
+            # style.hide_index() was deprecated in the latest versions and new method was added
+            styler = df.style
+            styler = styler.hide(axis='index') if hasattr(styler, 'hide') else styler.hide_index()
+            table = DataFrameHtmlSerializer(styler).serialize()
             return f'<h2>Other Checks That Weren\'t Displayed</h2>\n{table}'

--- a/deepchecks/core/serialization/suite_result/widget.py
+++ b/deepchecks/core/serialization/suite_result/widget.py
@@ -305,7 +305,10 @@ class SuiteResultSerializer(WidgetSerializer['suite.SuiteResult']):
                 output_id=output_id,
                 is_for_iframe_with_srcdoc=is_for_iframe_with_srcdoc
             )
-            return DataFrameSerializer(df.style.hide_index()).serialize()
+            # style.hide_index() was deprecated in the latest versions and new method was added
+            styler = df.style
+            styler = styler.hide(axis='index') if hasattr(styler, 'hide') else styler.hide_index()
+            return DataFrameSerializer(styler).serialize()
 
 
 def select_serializer(result):

--- a/deepchecks/tabular/checks/model_evaluation/model_info.py
+++ b/deepchecks/tabular/checks/model_evaluation/model_info.py
@@ -53,7 +53,10 @@ class ModelInfo(ModelOnlyCheck):
                 return n * ['']
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=FutureWarning)
-            model_param_df = model_param_df.style.apply(highlight_not_default, axis=1).hide_index()
+            model_param_df = model_param_df.style.apply(highlight_not_default, axis=1)
+            # style.hide_index() was deprecated in the latest versions and new method was added
+            model_param_df = model_param_df.hide(axis='index') if hasattr(model_param_df, 'hide') \
+                else model_param_df.hide_index()
 
         value = {'type': model_type, 'params': model_params}
         footnote = '<p style="font-size:0.7em"><i>Colored rows are parameters with non-default values</i></p>'


### PR DESCRIPTION
`styler.hide_index()` was removed in pandas 1.4.0
An alternative solution is to change the requirements to `pandas>=1.4.0`