### PR TITLE
Feat/Add Misclassified samples lower than condition to Confusion Matrix Report

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -406,6 +406,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "hjain5164",
+      "name": "Harsh Jain",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20479605?v=4",
+      "profile": "https://github.com/hjain5164",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "projectName": "deepchecks",

--- a/.gitignore
+++ b/.gitignore
@@ -100,25 +100,30 @@ __MACOSX
 *wolves_vs_dogs_mini*
 *hymenoptera_data*
 *tomato-detection*
+tweet_emotion_*.csv
 
 # docs build files
 docs/source/_build
 
 # build folders of sphinx gallery
-docs/source/user-guide/general/customizations/examples/
-docs/source/user-guide/general/exporting_results/examples/
-docs/source/checks_gallery/tabular/
-docs/source/checks_gallery/vision/
+docs/source/general/usage/customizations/auto_examples/
+docs/source/general/usage/exporting_results/auto_examples/
 
-docs/source/user-guide/tabular/auto_tutorials
-docs/source/user-guide/vision/auto_tutorials
+docs/source/tabular/auto_checks
+docs/source/nlp/auto_checks
+docs/source/vision/auto_checks
+
+docs/source/tabular/auto_tutorials
+docs/source/nlp/auto_tutorials
+docs/source/vision/auto_tutorials
 
 docs/source/user-guide/tabular/auto_quickstarts
 docs/source/user-guide/vision/auto_quickstarts
 
-# build artifacts from running docs (vision and wandb export)
-docs/source/user-guide/vision/quickstarts/*.html
-docs/source/user-guide/vision/tutorials/*.html
+# build artificats from running docs (vision, nlp, wandb export)
+docs/source/vision/tutorials/quickstarts/*.html
+
+# (old, update paths for relevant) build artifacts from running docs (vision and wandb export)
 docs/source/tutorials/vision/deepchecks_formatted_image*.jpg
 docs/source/user-guide/general/exporting_results/wandb
 deepchecks/vision/datasets/classification/models/

--- a/LICENSE
+++ b/LICENSE
@@ -19,7 +19,8 @@ also found at <https://www.gnu.org/licenses/>.
 Additional permission under GNU AGPL version 3 section 7
 
   If you modify this Program, or any covered work, by linking or combining it 
-with the sub-library in the Deepchecks Monitoring “**/ee/” sub-directory (or 
+with the sub-library in the Deepchecks Monitoring
+(https://github.com/deepchecks/monitoring) “**/ee/” sub-directory (or 
 a modified version of that library), covered by the Terms & Conditions of the 
 Deepchecks Monitoring sub-library in the “**/ee/” sub-directory, found at 
 https://deepchecks.com/terms-and-conditions (the "Commercial License"), 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ stars](https://img.shields.io/github/stars/deepchecks/deepchecks.svg?style=socia
 [![Coverage
 Status](https://coveralls.io/repos/github/deepchecks/deepchecks/badge.svg?branch=main)](https://coveralls.io/github/deepchecks/deepchecks?branch=main)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-40-orange.svg?style=flat-round)](#https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst)
+[![All Contributors](https://img.shields.io/badge/all_contributors-41-orange.svg?style=flat-round)](#https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst)
 <!-- ALL-CONTRIBUTORS-BADGE:END --> 
 
 
@@ -385,6 +385,7 @@ key](https://allcontributors.org/docs/en/emoji-key)):
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/MichaelMarien"><img src="https://avatars.githubusercontent.com/u/13829139?v=4?s=100" width="100px;" alt="Michael Marien"/><br /><sub><b>Michael Marien</b></sub></a><br /><a href="#doc-MichaelMarien" title="Documentation">📖</a> <a href="#bug-MichaelMarien" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mglowacki100"><img src="https://avatars.githubusercontent.com/u/6077538?v=4?s=100" width="100px;" alt="OrdoAbChao"/><br /><sub><b>OrdoAbChao</b></sub></a><br /><a href="#code-mglowacki100" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/thewchan"><img src="https://avatars.githubusercontent.com/u/49702524?v=4?s=100" width="100px;" alt="Matt Chan"/><br /><sub><b>Matt Chan</b></sub></a><br /><a href="#code-thewchan" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/hjain5164"><img src="https://avatars.githubusercontent.com/u/20479605?v=4?s=100" width="100px;" alt="Harsh Jain"/><br /><sub><b>Harsh Jain</b></sub></a><br /><a href="#code-hjain5164" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/deepchecks/core/serialization/suite_result/html.py
+++ b/deepchecks/core/serialization/suite_result/html.py
@@ -196,7 +196,8 @@ class SuiteResultSerializer(HtmlSerializer['suite.SuiteResult']):
         extra_info = self.prepare_extra_info()
 
         suite_creation_example_link = (
-            'https://docs.deepchecks.com/en/stable/examples/guides/create_a_custom_suite.html'
+            'https://docs.deepchecks.com/stable/general/usage/customizations/'
+            'auto_examples/plot_create_a_custom_suite.html'
             '?utm_source=display_output&utm_medium=referral&utm_campaign=suite_link'
         )
         icons = textwrap.dedent("""

--- a/deepchecks/nlp/base_checks.py
+++ b/deepchecks/nlp/base_checks.py
@@ -54,7 +54,7 @@ class SingleDatasetCheck(SingleDatasetBaseCheck):
             predictions on dataset
         probabilities: Union[TTextProba, None] , default: None
             probabilities on dataset
-        model_classes: Optional[List, List[List], default: None
+        model_classes: Optional[List], default: None
             For classification: list of classes known to the model
         random_state : int, default 42
             A seed to set for pseudo-random functions, primarily sampling.
@@ -99,6 +99,7 @@ class TrainTestCheck(TrainTestBaseCheck):
             test_predictions: Optional[TTextPred] = None,
             train_probabilities: Optional[TTextProba] = None,
             test_probabilities: Optional[TTextProba] = None,
+            model_classes: Optional[List] = None,
             random_state: int = 42,
     ) -> CheckResult:
         """Run check.
@@ -121,6 +122,8 @@ class TrainTestCheck(TrainTestBaseCheck):
             probabilities on train dataset
         test_probabilities: Union[TTextProba, None] , default: None
             probabilities on test_dataset dataset
+        model_classes: Optional[List], default: None
+            For classification: list of classes known to the model
         random_state : int, default 42
             A seed to set for pseudo-random functions, primarily sampling.
 
@@ -134,6 +137,7 @@ class TrainTestCheck(TrainTestBaseCheck):
             test_pred=test_predictions,
             train_proba=train_probabilities,
             test_proba=test_probabilities,
+            model_classes=model_classes,
             random_state=random_state,
             with_display=with_display,
         )

--- a/deepchecks/nlp/checks/__init__.py
+++ b/deepchecks/nlp/checks/__init__.py
@@ -11,7 +11,7 @@
 """Module importing all nlp checks."""
 
 from deepchecks.nlp.checks.data_integrity import (ConflictingLabels, PropertyLabelCorrelation, SpecialCharacters,
-                                                  TextDuplicates, TextPropertyOutliers)
+                                                  TextDuplicates, TextPropertyOutliers, UnknownTokens)
 from deepchecks.nlp.checks.model_evaluation import (ConfusionMatrixReport, MetadataSegmentsPerformance, PredictionDrift,
                                                     PropertySegmentsPerformance, SingleDatasetPerformance,
                                                     TrainTestPerformance)
@@ -24,6 +24,7 @@ __all__ = [
     'TextDuplicates',
     'ConflictingLabels',
     'SpecialCharacters',
+    'UnknownTokens',
 
     # Model Evaluation
     'SingleDatasetPerformance',

--- a/deepchecks/nlp/checks/data_integrity/__init__.py
+++ b/deepchecks/nlp/checks/data_integrity/__init__.py
@@ -15,11 +15,13 @@ from .property_label_correlation import PropertyLabelCorrelation
 from .special_characters import SpecialCharacters
 from .text_duplicates import TextDuplicates
 from .text_property_outliers import TextPropertyOutliers
+from .unknown_tokens import UnknownTokens
 
 __all__ = [
     'PropertyLabelCorrelation',
     'TextPropertyOutliers',
     'TextDuplicates',
     'ConflictingLabels',
-    'SpecialCharacters'
+    'SpecialCharacters',
+    'UnknownTokens',
 ]

--- a/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
+++ b/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
@@ -131,7 +131,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
             'conflicting_samples': result_df,
         }
 
-        if context.with_display is False:
+        if context.with_display is False or num_of_ambiguous_samples == 0:
             return CheckResult(value=result_value)
 
         ambiguous_samples['Text'] = ambiguous_samples['Text'].apply(self._truncate_text)

--- a/deepchecks/nlp/checks/data_integrity/property_label_correlation.py
+++ b/deepchecks/nlp/checks/data_integrity/property_label_correlation.py
@@ -27,7 +27,7 @@ __all__ = ['PropertyLabelCorrelation']
 
 PLC = t.TypeVar('PLC', bound='PropertyLabelCorrelation')
 
-pps_url = 'https://docs.deepchecks.com/en/stable/checks_gallery/tabular/' \
+pps_url = 'https://docs.deepchecks.com/stable/tabular/auto_checks/' \
           'train_test_validation/plot_feature_label_correlation_change.html'
 pps_html = f'<a href={pps_url} target="_blank">Predictive Power Score</a>'
 

--- a/deepchecks/nlp/checks/data_integrity/special_characters.py
+++ b/deepchecks/nlp/checks/data_integrity/special_characters.py
@@ -45,8 +45,7 @@ class SpecialCharacters(SingleDatasetCheck):
     ----------
     special_characters_whitelist: Union[str, Sequence[str]] , default ' ' + string.punctuation
         set of special characters to ignore. Punctuation (string.punctuation) is whitelisted by default.
-    {text_normalization_params:1*indent}
-    n_most_common : int , default: 2
+    n_most_common : int , default: 10
         Number of most common special-only samples to show in results
     n_samples: int, default: 10_000_000
         number of samples to use for this check.
@@ -61,11 +60,6 @@ class SpecialCharacters(SingleDatasetCheck):
     def __init__(
         self,
         special_characters_whitelist: t.Union[str, t.Sequence[str], None] = None,
-        ignore_case: bool = True,
-        remove_punctuation: bool = True,
-        normalize_unicode: bool = True,
-        remove_stopwords: bool = True,
-        ignore_whitespace: bool = False,
         n_most_common: int = 10,
         n_samples: int = 10_000_000,
         random_state: int = 42,
@@ -81,25 +75,10 @@ class SpecialCharacters(SingleDatasetCheck):
         self.special_characters = self.SPECIAL_CHARACTERS.difference(
             self.special_characters_whitelist
         )
-        self.ignore_case = ignore_case
-        self.remove_punctuation = remove_punctuation
-        self.normalize_unicode = normalize_unicode
-        self.remove_stopwords = remove_stopwords
-        self.ignore_whitespace = ignore_whitespace
         self.n_most_common = n_most_common
         self.n_samples = n_samples
         self.random_state = random_state
         self.max_text_length_for_display = max_text_length_for_display
-
-    @property
-    def _text_normalization_kwargs(self):
-        return {
-            'ignore_case': self.ignore_case,
-            'ignore_whitespace': self.ignore_whitespace,
-            'normalize_uni': self.normalize_unicode,
-            'remove_punct': self.remove_punctuation,
-            'remove_stops': self.remove_stopwords,
-        }
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
         """Run check."""

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -10,6 +10,7 @@
 #
 """Module contains the Unknown Tokens check."""
 import typing as t
+import warnings
 from collections import Counter
 
 import nltk
@@ -113,9 +114,11 @@ class UnknownTokens(SingleDatasetCheck):
     def find_unknown_words(self, samples, indices):
         """Find words with unknown tokens in samples."""
         # Choose tokenizer based on availability of nltk
-        if nltk.download('punkt'):
+        if nltk.download('punkt', quiet=True):
             tokenize = nltk.word_tokenize
         else:
+            warnings.warn('nltk punkt is not available, using str.split instead to identify individual words. '
+                          'Please check your internet connection.')
             tokenize = str.split
 
         # Tokenize samples and count unknown words

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -64,10 +64,11 @@ class UnknownTokens(SingleDatasetCheck):
         if tokenizer is None:
             try:
                 from transformers import BertTokenizer  # pylint: disable=W0611,C0415 # noqa
-            except ImportError:
-                DeepchecksProcessError(
-                    'Tokenizer was not provided. In order to use checks default tokenizer (BertTokenizer),'
-                    'please pip install transformers>=4.27.4. ')
+            except ImportError as e:
+                raise DeepchecksProcessError(
+                    'Tokenizer was not provided. In order to use checks default '
+                    'tokenizer (BertTokenizer), please run:\n>> pip install transformers>=4.27.4.'
+                ) from e
             self.tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         else:
             self._validate_tokenizer()

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -1,0 +1,190 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Module contains the Unknown Tokens check."""
+import typing as t
+from collections import Counter
+
+import nltk
+import plotly.graph_objects as go
+from transformers import BertTokenizer
+
+from deepchecks.core import CheckResult, ConditionCategory, ConditionResult
+from deepchecks.core.errors import DeepchecksValueError
+from deepchecks.nlp import Context, SingleDatasetCheck
+from deepchecks.nlp._shared_docs import docstrings
+from deepchecks.nlp.text_data import TextData
+from deepchecks.utils.strings import format_list, format_percent
+from deepchecks.utils.strings import get_ellipsis as truncate_string
+
+__all__ = ['UnknownTokens']
+
+OTHER_CAT_NAME = 'Other Unknown Words'
+
+
+@docstrings
+class UnknownTokens(SingleDatasetCheck):
+    """Find samples that contain tokens unsupported by your tokenizer.
+
+    Parameters
+    ----------
+    tokenizer: t.Any , default: None
+        Tokenizer from the HuggingFace transformers library to use for tokenization. If None,
+        BertTokenizer.from_pretrained('bert-base-uncased') will be used.
+    group_singleton_words: bool, default: False
+        If True, group all words that appear only once in the data into the "Other" category in the display.
+    n_most_common : int , default: 5
+        Number of most common words with unknown tokens to show in the display.
+    n_samples: int, default: 1_000_000
+        number of samples to use for this check.
+    random_state : int, default: 42
+        random seed for all check internals.
+    {max_text_length_for_display_param:1*indent}
+    """
+
+    def __init__(
+        self,
+        tokenizer: t.Any = None,
+        group_singleton_words: bool = False,
+        n_most_common: int = 5,
+        n_samples: int = 1_000_000,
+        random_state: int = 42,
+        max_text_length_for_display: int = 30,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.tokenizer = tokenizer
+        if self.tokenizer is None:
+            self.tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+        if not hasattr(self.tokenizer, 'tokenize'):
+            raise DeepchecksValueError('tokenizer must have a "tokenize" method')
+        if not hasattr(self.tokenizer, 'unk_token_id'):
+            raise DeepchecksValueError('tokenizer must have an "unk_token_id" attribute')
+        if not hasattr(self.tokenizer, 'convert_tokens_to_ids'):
+            raise DeepchecksValueError('tokenizer must have an "convert_tokens_to_ids" method')
+        self.group_singleton_words = group_singleton_words
+        self.n_most_common = n_most_common
+        self.n_samples = n_samples
+        self.random_state = random_state
+        self.max_text_length_for_display = max_text_length_for_display
+
+    def run_logic(self, context: Context, dataset_kind) -> CheckResult:
+        """Run check."""
+        dataset = context.get_data_by_kind(dataset_kind).sample(self.n_samples, random_state=self.random_state)
+        dataset = t.cast(TextData, dataset)
+        samples = dataset.text
+        if len(samples) == 0:
+            raise DeepchecksValueError('Dataset cannot be empty')
+
+        indices = dataset.get_original_text_indexes()
+
+        all_unknown_words_counter, total_words, unknown_word_indexes = self.find_unknown_words(samples, indices)
+        if len(all_unknown_words_counter) == 0:
+            display = None
+            value = {'unknown_word_ratio': 0,
+                     'unknown_word_details': {}}
+        else:
+            fig = self.create_pie_chart(all_unknown_words_counter, total_words)
+            percent_explanation = (
+                '<p style="font-size:0.9em;line-height:1;"><i>'
+                'Percents shown above are the percent of each word (or group of words) out of all words in the data.'
+            )
+            display = [fig, percent_explanation]
+
+            # The value contains two fields - unknown_word_percent and unknown_word_details.
+            # The latter contains a dict, in which for each word we have its ratio of the data and the list of indexes
+            # of the samples that contain it.
+            unknown_word_details = {}
+            for word, indexes in unknown_word_indexes.items():
+                unknown_word_details[word] = {'ratio': all_unknown_words_counter[word] / total_words,
+                                              'indexes': indexes}
+            value = {'unknown_word_ratio': sum(all_unknown_words_counter.values()) / total_words,
+                     'unknown_word_details': unknown_word_details}
+
+        return CheckResult(value, display=display)
+
+    def find_unknown_words(self, samples, indices):
+        """Find words with unknown tokens in samples."""
+        # Choose tokenizer based on availability of nltk
+        if nltk.download('punkt'):
+            tokenize = nltk.word_tokenize
+        else:
+            tokenize = str.split
+
+        # Tokenize samples and count unknown words
+        words_array = [tokenize(sample) for sample in samples]
+        all_unknown_words = []
+        unknown_word_indexes = {}
+        total_words = 0
+        for idx, words in zip(indices, words_array):
+            total_words += len(words)
+            for word in words:
+                tokens = self.tokenizer.tokenize(word)
+                if any(self.tokenizer.convert_tokens_to_ids(token) == self.tokenizer.unk_token_id for token in tokens):
+                    all_unknown_words.append(word)
+                    unknown_word_indexes.setdefault(word, []).append(idx)
+
+        return Counter(all_unknown_words), total_words, unknown_word_indexes
+
+    def create_pie_chart(self, all_unknown_words_counter, total_words):
+        """Create pie chart with most common unknown words."""
+        most_common_unknown_words = [x[0] for x in all_unknown_words_counter.most_common(self.n_most_common) if
+                                     ((x[1] > 1) or (not self.group_singleton_words))]
+        other_words = [x for x in all_unknown_words_counter if x not in most_common_unknown_words]
+
+        # Calculate percentages for each category
+        other_words_count = sum(all_unknown_words_counter[word] for word in other_words)
+        other_words_percentage = (other_words_count * 1. / total_words) * 100.
+        labels = most_common_unknown_words
+        percentages = [all_unknown_words_counter[word] * 1. / total_words * 100. for word in most_common_unknown_words]
+
+        # Add "Other Unknown Words" and "Known Words" categories
+        if other_words_percentage > 0:
+            labels.append(OTHER_CAT_NAME)
+            percentages.append(other_words_percentage)
+
+        # Truncate labels for display
+        labels = [truncate_string(label, self.max_text_length_for_display) for label in labels]
+
+        # Create pie chart with hover text and custom hover template
+        fig = go.Figure(data=[go.Pie(
+            labels=labels, values=percentages, texttemplate='%{label}<br>%{value}%',
+            hovertext=[format_list(other_words, max_string_length=self.max_text_length_for_display)
+                       if label == OTHER_CAT_NAME else label for label in labels],
+            hovertemplate=['<b>Unknown Word</b>: %{hovertext}<br><b>Percent of All Words</b>: %{value}%<extra></extra>'
+                           if label != OTHER_CAT_NAME else
+                           '<b>Other Unknown Words</b>: %{hovertext}<br>'
+                           '<b>Percent of All Words</b>: %{value}%<extra></extra>'
+                           for label in labels],
+            pull=[0.1 if label == OTHER_CAT_NAME else 0 for label in labels]
+        )])
+
+        # Customize chart appearance
+        fig.update_layout(title=f'Words containing Unknown Tokens - {self.tokenizer.name_or_path} Tokenizer',
+                          legend_title='Words with Unknown Tokens')
+
+        return fig
+
+    def add_condition_ratio_of_unknown_words_less_or_equal(self, ratio: float = 0):
+        """Add condition that checks if the ratio of unknown words is less than a given ratio.
+
+        Parameters
+        ----------
+        ratio : float
+            Maximal allowed ratio of unknown words.
+        """
+        def condition(result):
+            passed = result['unknown_word_ratio'] <= ratio
+            condition_result = ConditionCategory.FAIL if not passed else ConditionCategory.PASS
+            details = f'Ratio was {format_percent(result["unknown_word_ratio"])}'
+            return ConditionResult(condition_result, details)
+
+        return self.add_condition(f'Ratio of unknown words is less than {format_percent(ratio)}',
+                                  condition)

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -166,6 +166,8 @@ class UnknownTokens(SingleDatasetCheck):
 
         # Truncate labels for display
         labels = [truncate_string(label, self.max_text_length_for_display) for label in labels]
+        # round percentages to 2 decimal places after the percent
+        percentages = [round(percent, 2) for percent in percentages]
 
         # Create pie chart with hover text and custom hover template
         fig = go.Figure(data=[go.Pie(
@@ -181,7 +183,9 @@ class UnknownTokens(SingleDatasetCheck):
         )])
 
         # Customize chart appearance
-        fig.update_layout(title=f'Words containing Unknown Tokens - {self.tokenizer.name_or_path} Tokenizer',
+        fig.update_layout(title=f'Words containing Unknown Tokens - {self.tokenizer.name_or_path} Tokenizer<br>'
+                                f'({format_percent(sum(percentages) / 100.)} of all words)',
+                          title_x=0.5,
                           legend_title='Words with Unknown Tokens')
 
         return fig

--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -13,7 +13,9 @@ import numpy as np
 
 from deepchecks.core import CheckResult
 from deepchecks.nlp import Context, SingleDatasetCheck
-from deepchecks.utils.abstracts.confusion_matrix_abstract import run_confusion_matrix_check
+from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
+                                                                  run_confusion_matrix_check)
+from deepchecks.utils.strings import format_number
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -63,3 +65,21 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_pred = np.array(context.model.predict(dataset)).reshape(len(y_true), )
 
         return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+
+    def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
+        """Add condition - Misclassified samples lower than threshold.
+
+        Condition validates if the misclassified cell size/samples are lower than the threshold based on the
+        `misclassified_samples_threshold` parameter.
+
+        Parameters
+        ----------
+        misclassified_samples_threshold: float, default: 0.20
+            Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
+        """
+        return self.add_condition(
+            f'Misclassified cell size lower than {format_number(misclassified_samples_threshold * 100)}% '
+            'of the total samples',
+            misclassified_samples_lower_than_condition,
+            misclassified_samples_threshold=misclassified_samples_threshold
+        )

--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -78,7 +78,8 @@ class ConfusionMatrixReport(SingleDatasetCheck):
             Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
         """
         return self.add_condition(
-            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} of the total samples',
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} '
+            'of the total samples',
             misclassified_samples_lower_than_condition,
             misclassified_samples_threshold=misclassified_samples_threshold
         )

--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -15,7 +15,7 @@ from deepchecks.core import CheckResult
 from deepchecks.nlp import Context, SingleDatasetCheck
 from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
                                                                   run_confusion_matrix_check)
-from deepchecks.utils.strings import format_number
+from deepchecks.utils.strings import format_percent
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -78,8 +78,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
             Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
         """
         return self.add_condition(
-            f'Misclassified cell size lower than {format_number(misclassified_samples_threshold * 100)}% '
-            'of the total samples',
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} of the total samples',
             misclassified_samples_lower_than_condition,
             misclassified_samples_threshold=misclassified_samples_threshold
         )

--- a/deepchecks/nlp/checks/model_evaluation/single_dataset_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/single_dataset_performance.py
@@ -31,16 +31,20 @@ class SingleDatasetPerformance(SingleDatasetCheck, BaseSingleDatasetPerformance)
     scorers : Union[List[str], Dict[str, Union[str, Callable]]], default: None
         List of scorers to use. If None, use default scorers.
         Scorers can be supplied as a list of scorer names or as a dictionary of names and functions.
+    max_rows_to_display : int, default: 15
+        Maximum number of rows to display in the check result.
     n_samples : int , default: 10_000
         Maximum number of samples to use for this check.
     """
 
     def __init__(self,
                  scorers: Union[List[str], Dict[str, Union[str, Callable]]] = None,
+                 max_rows_to_display: int = 15,
                  n_samples: int = 10_000,
                  **kwargs):
         super().__init__(**kwargs)
         self.scorers = scorers
+        self.max_rows_to_display = max_rows_to_display
         self.n_samples = n_samples
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
@@ -62,7 +66,12 @@ class SingleDatasetPerformance(SingleDatasetCheck, BaseSingleDatasetPerformance)
         results_df = pd.DataFrame(results, columns=['Class', 'Metric', 'Value'])
 
         if context.with_display:
-            display = [results_df]
+            if len(results_df) > self.max_rows_to_display:
+                display = [results_df.iloc[:self.max_rows_to_display, :],
+                           '<p style="font-size:0.9em;line-height:1;"><i>'
+                           f'* Only showing first {self.max_rows_to_display} rows.']
+            else:
+                display = [results_df]
         else:
             display = []
 

--- a/deepchecks/nlp/checks/model_evaluation/train_test_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/train_test_performance.py
@@ -102,7 +102,7 @@ class TrainTestPerformance(TrainTestPerformanceAbstract, TrainTestCheck):
         for dataset_name, dataset in datasets.items():
 
             if context.task_type is TaskType.TEXT_CLASSIFICATION and dataset.is_multi_label_classification():
-                n_samples_per_class = dict(enumerate(np.array(dataset.label).sum(axis=0)))
+                n_samples_per_class = dict(zip(context.model_classes, np.array(dataset.label).sum(axis=0)))
                 n_of_labels = sum(n_samples_per_class.values())
 
             elif context.task_type is TaskType.TEXT_CLASSIFICATION:

--- a/deepchecks/nlp/context.py
+++ b/deepchecks/nlp/context.py
@@ -471,23 +471,6 @@ class Context(BaseContext):
             )
         return True
 
-    @staticmethod
-    def assert_metadata(text_data):
-        """Assert that metadata exists."""
-        if text_data.metadata is None:
-            raise DeepchecksNotSupportedError(
-                'Check requires metadata, but the the TextData object had none. To use this check, use the '
-                'set_metadata method to set your own metadata with a pandas.DataFrame.')
-
-    @staticmethod
-    def assert_properties(text_data):
-        """Assert that properties exists."""
-        if text_data.properties is None:
-            raise DeepchecksNotSupportedError(
-                'Check requires properties, but the the TextData object had none. To use this check, use the'
-                'set_properties method to set your own properties with a pandas.DataFrame or use '
-                'TextData.calculate_default_properties to add the default deepchecks properties.')
-
     def raise_if_token_classification_task(self, check=None):
         """Raise an exception if it is a token classification task."""
         check_name = type(check).__name__ if check else 'Check'

--- a/deepchecks/nlp/context.py
+++ b/deepchecks/nlp/context.py
@@ -191,7 +191,7 @@ class _DummyModel(BasicModel):
     @staticmethod
     def _validate_classification_prediction(dataset: TextData, prediction: TTextPred, n_classes: int):
         """Validate prediction for given text classification dataset."""
-        classification_format_error = f'Check requires classification for {dataset.name} to be ' \
+        classification_format_error = f'Check requires classification predictions for {dataset.name} to be ' \
                                       f'either a sequence that can be cast to a 1D numpy array of shape' \
                                       f' (n_samples,), or a sequence of sequences that can be cast to a 2D ' \
                                       f'numpy array of shape (n_samples, n_classes) for the multilabel case.'

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -61,11 +61,11 @@ def validate_modify_label(labels: Optional[TTextLabel], task_type: TaskType, exp
                 raise DeepchecksValueError('All multilabel entries must be of the same length, which is the number'
                                            ' of possible classes.')
             labels = [[int(x) for x in label_per_sample] for label_per_sample in labels]
-        elif not all(isinstance(x, (str, int)) for x in labels):  # Classic classification
+        elif not all(isinstance(x, (str, int)) or pd.isna(x) for x in labels):  # Classic classification
             raise DeepchecksValueError('label must be a Sequence of strings or ints (multiclass classification) '
                                        'or a Sequence of Sequences of strings or ints (multilabel classification)')
         else:
-            labels = [str(x) for x in labels]
+            labels = [None if pd.isna(x) else str(x) for x in labels]
     elif task_type == TaskType.TOKEN_CLASSIFICATION:
         token_class_error = 'label must be a Sequence of Sequences of either strings or integers.'
         if not is_sequence_not_str(labels):
@@ -73,7 +73,7 @@ def validate_modify_label(labels: Optional[TTextLabel], task_type: TaskType, exp
 
         result = []
         for idx, (tokens, label) in enumerate(zip(tokenized_text, labels)):  # TODO: Runs on all labels, very costly
-            if not is_sequence_not_str(label):
+            if not is_sequence_not_str(label) and not pd.isna(label):
                 raise DeepchecksValueError(token_class_error + f' label at {idx} was of type {type(label)}')
             if not len(tokens) == len(label):
                 raise DeepchecksValueError(f'label must be the same length as tokenized_text. '

--- a/deepchecks/nlp/suite.py
+++ b/deepchecks/nlp/suite.py
@@ -8,9 +8,9 @@
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
 #
-"""Module for base tabular abstractions."""
+"""Module for base nlp suite."""
 # pylint: disable=broad-except
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from deepchecks.core import DatasetKind
 from deepchecks.core.check_result import CheckFailure
@@ -42,6 +42,7 @@ class Suite(BaseSuite):
         test_predictions: Optional[TTextPred] = None,
         train_probabilities: Optional[TTextProba] = None,
         test_probabilities: Optional[TTextProba] = None,
+        model_classes: Optional[List] = None,
         random_state: int = 42,
     ) -> SuiteResult:
         """Run all checks.
@@ -62,6 +63,8 @@ class Suite(BaseSuite):
             probabilities on train dataset
         test_probabilities: Union[TTextProba, None] , default: None
             probabilities on test_dataset dataset
+        model_classes: Optional[List], default: None
+            For classification: list of classes known to the model
         random_state : int, default 42
             A seed to set for pseudo-random functions, primarily sampling.
 
@@ -79,6 +82,7 @@ class Suite(BaseSuite):
             test_pred=test_predictions,
             train_proba=train_probabilities,
             test_proba=test_probabilities,
+            model_classes=model_classes,
             with_display=with_display,
             random_state=random_state
         )

--- a/deepchecks/nlp/suites/default_suites.py
+++ b/deepchecks/nlp/suites/default_suites.py
@@ -18,7 +18,8 @@ It is possible to customize these suites by editing the checks and conditions in
 from deepchecks.nlp import Suite
 from deepchecks.nlp.checks import (ConflictingLabels, LabelDrift, MetadataSegmentsPerformance, PredictionDrift,
                                    PropertyLabelCorrelation, PropertySegmentsPerformance, SingleDatasetPerformance,
-                                   SpecialCharacters, TextDuplicates, TextPropertyOutliers, TrainTestSamplesMix)
+                                   SpecialCharacters, TextDuplicates, TextPropertyOutliers, TrainTestSamplesMix,
+                                   UnknownTokens)
 
 __all__ = ['data_integrity', 'train_test_validation',
            'model_evaluation', 'full_suite']
@@ -61,7 +62,8 @@ def data_integrity(n_samples: int = None,
         TextPropertyOutliers(),
         TextDuplicates().add_condition_ratio_less_or_equal(),
         ConflictingLabels().add_condition_ratio_of_conflicting_labels_less_or_equal(),
-        SpecialCharacters().add_condition_ratio_of_samples_with_special_characters_less_or_equal()
+        SpecialCharacters().add_condition_ratio_of_samples_with_special_characters_less_or_equal(),
+        UnknownTokens().add_condition_ratio_of_unknown_words_less_or_equal()
     )
 
 

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -269,20 +269,16 @@ class TextData:
     def metadata(self) -> pd.DataFrame:
         """Return the metadata of for the dataset."""
         if self._metadata is None:
-            raise ValueError(
-                'TextData does not contain metadata, add it by using '
-                '"set_metadata" function'
+            raise DeepchecksValueError(
+                'Functionality requires metadata, but the the TextData object had none. '
+                'To use this functionality, use the '
+                'set_metadata method to set your own metadata with a pandas.DataFrame.'
             )
         return self._metadata
 
     @property
     def categorical_metadata_columns(self) -> t.List[str]:
         """Return categorical metadata column names."""
-        if self._cat_metadata is None:
-            raise ValueError(
-                'TextData does not contain metadata, add it by using '
-                '"set_metadata" function'
-            )
         return self._cat_metadata
 
     def set_metadata(
@@ -387,19 +383,15 @@ class TextData:
         """Return the properties of the dataset."""
         if self._properties is None:
             raise DeepchecksNotSupportedError(
-                'TextData does not contain properties, add them by using '
-                '"calculate_default_properties" or "set_properties" functions'
+                'Functionality requires properties, but the the TextData object had none. To use this functionality, '
+                'use the set_properties method to set your own properties with a pandas.DataFrame or use '
+                'TextData.calculate_default_properties to add the default deepchecks properties.'
             )
         return self._properties
 
     @property
     def categorical_properties(self) -> t.List[str]:
         """Return categorical properties names."""
-        if self._cat_properties is None:
-            raise ValueError(
-                'TextData does not contain properties, add them by using '
-                '"calculate_default_properties" or "set_properties" functions'
-            )
         return self._cat_properties
 
     @property

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -72,7 +72,7 @@ class TextData:
         The number of rows in the metadata DataFrame must be equal to the number of samples in the dataset, and the
         order of the rows must be the same as the order of the samples in the dataset.
         For more on metadata, see the `NLP Metadata Guide
-        <https://docs.deepchecks.com/en/latest/nlp/nlp-metadata.html>`_.
+        <https://docs.deepchecks.com/stable/nlp/usage_guides/nlp_metadata.html>`_.
     categorical_metadata : t.Optional[t.List[str]] , default: None
         The names of the categorical metadata columns. If None, categorical metadata columns are automatically inferred.
         Only relevant if metadata is not None.
@@ -85,7 +85,7 @@ class TextData:
         In order to calculate the default properties, use the `TextData.calculate_default_properties` function after
         the creation of the TextData object.
         For more on properties, see the `NLP Properties Guide
-        <https://docs.deepchecks.com/en/latest/nlp/nlp-properties.html>`_.
+        <https://docs.deepchecks.com/stable/nlp/usage_guides/nlp_properties.html>`_.
     categorical_properties : t.Optional[t.List[str]] , default: None
         The names of the categorical properties columns. If None, categorical properties columns are automatically
         inferred. Only relevant if properties is not None.

--- a/deepchecks/nlp/utils/text.py
+++ b/deepchecks/nlp/utils/text.py
@@ -12,6 +12,7 @@
 import string
 import typing as t
 import unicodedata
+import warnings
 
 import nltk
 from nltk.corpus import stopwords
@@ -62,10 +63,6 @@ def break_to_lines_and_trim(s, max_lines: int = 10, min_line_length: int = 50, m
     return '<br>'.join(lines)
 
 
-nltk.download('stopwords')
-nltk.download('punkt')
-
-
 def remove_punctuation(text: str) -> str:
     """Remove punctuation characters from a string."""
     return text.translate(str.maketrans('', '', string.punctuation))
@@ -78,8 +75,17 @@ def normalize_unicode(text: str) -> str:
 
 def remove_stopwords(text: str) -> str:
     """Remove stop words from a string."""
-    stop_words = set(stopwords.words('english'))
-    words = word_tokenize(text)
+    if nltk.download('stopwords', quiet=True):
+        stop_words = set(stopwords.words('english'))
+    else:
+        warnings.warn('nltk stopwords not found, stopwords won\'t be ignored when considering text duplicates.'
+                      ' Please check your internet connection.')
+        return text
+    if nltk.download('punkt', quiet=True):
+        tokenize = word_tokenize
+    else:
+        tokenize = str.split
+    words = tokenize(text)
     return ' '.join([word for word in words if word.lower() not in stop_words])
 
 

--- a/deepchecks/nlp/utils/weak_segments.py
+++ b/deepchecks/nlp/utils/weak_segments.py
@@ -1,0 +1,62 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Utils module for auto-detecting interesting segments in text."""
+
+import warnings
+from typing import Hashable, List, Optional, Union
+
+import pandas as pd
+
+from deepchecks.core.errors import DeepchecksProcessError
+from deepchecks.nlp import TextData
+from deepchecks.utils.dataframes import select_from_dataframe
+
+
+def get_relevant_data_table(text_data: TextData, data_type: str, columns: Union[Hashable, List[Hashable], None],
+                            ignore_columns: Union[Hashable, List[Hashable], None], n_top_features: Optional[int],
+                            add_label: bool = True):
+    """Get relevant data table from the database."""
+    if data_type == 'metadata':
+        features = select_from_dataframe(text_data.metadata, columns, ignore_columns)
+        cat_features = [col for col in features.columns if col in text_data.categorical_metadata_columns]
+
+    elif data_type == 'properties':
+        features = select_from_dataframe(text_data.properties, columns, ignore_columns)
+        cat_features = [col for col in features.columns if col in text_data.categorical_properties]
+    else:
+        raise DeepchecksProcessError(f'Unknown segment_by value: {data_type}')
+
+    if n_top_features is not None and n_top_features < features.shape[1]:
+        _warn_n_top_columns(data_type, n_top_features)
+
+    if add_label:  # most commonly used for target encoding
+        features['label'] = pd.Series(text_data.label, index=features.index)
+
+    return features, cat_features
+
+
+def _warn_n_top_columns(data_type: str, n_top_features: int):
+    """Warn if n_top_columns is smaller than the number of segmenting features (metadata or properties)."""
+    if data_type == 'metadata':
+        features_name = 'metadata columns'
+        n_top_columns_parameter = 'n_top_columns'
+        columns_parameter = 'columns'
+    else:
+        features_name = 'properties'
+        n_top_columns_parameter = 'n_top_properties'
+        columns_parameter = 'properties'
+
+    warnings.warn(
+        f'Parameter {n_top_columns_parameter} is set to {n_top_features} to avoid long computation time. '
+        f'This means that the check will run on the first {n_top_features} {features_name}. '
+        f'If you want to run on all {features_name}, set {n_top_columns_parameter} to None. '
+        f'Alternatively, you can set parameter {columns_parameter} to a list of the specific {features_name} '
+        f'you want to run on.', UserWarning)

--- a/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/feature_label_correlation.py
@@ -26,7 +26,7 @@ __all__ = ['FeatureLabelCorrelation']
 FLC = t.TypeVar('FLC', bound='FeatureLabelCorrelation')
 
 
-pps_url = 'https://docs.deepchecks.com/en/stable/checks_gallery/tabular/' \
+pps_url = 'https://docs.deepchecks.com/stable/tabular/auto_checks/' \
           'train_test_validation/plot_feature_label_correlation_change.html'
 pps_html = f'<a href={pps_url} target="_blank">Predictive Power Score</a>'
 

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -75,7 +75,8 @@ class ConfusionMatrixReport(SingleDatasetCheck):
             Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
         """
         return self.add_condition(
-            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} of the total samples',
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} '
+            'of the total samples',
             misclassified_samples_lower_than_condition,
             misclassified_samples_threshold=misclassified_samples_threshold
         )

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -13,7 +13,9 @@ import numpy as np
 
 from deepchecks.core import CheckResult
 from deepchecks.tabular import Context, SingleDatasetCheck
-from deepchecks.utils.abstracts.confusion_matrix_abstract import run_confusion_matrix_check
+from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
+                                                                  run_confusion_matrix_check)
+from deepchecks.utils.strings import format_number
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -60,3 +62,21 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_pred = np.array(context.model.predict(dataset.features_columns)).reshape(len(y_true), )
 
         return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+
+    def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
+        """Add condition - Misclassified samples lower than threshold.
+
+        Condition validates if the misclassified cell size/samples are lower than the threshold based on the
+        `misclassified_samples_threshold` parameter.
+
+        Parameters
+        ----------
+        misclassified_samples_threshold: float, default: 0.20
+            Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
+        """
+        return self.add_condition(
+            f'Misclassified cell size lower than {format_number(misclassified_samples_threshold * 100)}% '
+            'of the total samples',
+            misclassified_samples_lower_than_condition,
+            misclassified_samples_threshold=misclassified_samples_threshold
+        )

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -15,7 +15,7 @@ from deepchecks.core import CheckResult
 from deepchecks.tabular import Context, SingleDatasetCheck
 from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
                                                                   run_confusion_matrix_check)
-from deepchecks.utils.strings import format_number
+from deepchecks.utils.strings import format_percent
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -75,8 +75,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
             Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
         """
         return self.add_condition(
-            f'Misclassified cell size lower than {format_number(misclassified_samples_threshold * 100)}% '
-            'of the total samples',
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} of the total samples',
             misclassified_samples_lower_than_condition,
             misclassified_samples_threshold=misclassified_samples_threshold
         )

--- a/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
+++ b/deepchecks/tabular/checks/train_test_validation/feature_label_correlation_change.py
@@ -27,7 +27,7 @@ __all__ = ['FeatureLabelCorrelationChange']
 
 FLC = t.TypeVar('FLC', bound='FeatureLabelCorrelationChange')
 
-pps_url = 'https://docs.deepchecks.com/en/stable/checks_gallery/tabular/' \
+pps_url = 'https://docs.deepchecks.com/stable/tabular/auto_checks/' \
           'train_test_validation/plot_feature_label_correlation_change.html'
 pps_html = f'<a href={pps_url} target="_blank">Predictive Power Score</a>'
 

--- a/deepchecks/tabular/suites/default_suites.py
+++ b/deepchecks/tabular/suites/default_suites.py
@@ -51,29 +51,29 @@ def data_integrity(columns: Union[Hashable, List[Hashable]] = None,
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_tabular_is_single_value`
+           * - :ref:`tabular__is_single_value`
              - :class:`~deepchecks.tabular.checks.data_integrity.IsSingleValue`
-           * - :ref:`plot_tabular_special_chars`
+           * - :ref:`tabular__special_chars`
              - :class:`~deepchecks.tabular.checks.data_integrity.SpecialCharacters`
-           * - :ref:`plot_tabular_mixed_nulls`
+           * - :ref:`tabular__mixed_nulls`
              - :class:`~deepchecks.tabular.checks.data_integrity.MixedNulls`
-           * - :ref:`plot_tabular_mixed_data_types`
+           * - :ref:`tabular__mixed_data_types`
              - :class:`~deepchecks.tabular.checks.data_integrity.MixedDataTypes`
-           * - :ref:`plot_tabular_string_mismatch`
+           * - :ref:`tabular__string_mismatch`
              - :class:`~deepchecks.tabular.checks.data_integrity.StringMismatch`
-           * - :ref:`plot_tabular_data_duplicates`
+           * - :ref:`tabular__data_duplicates`
              - :class:`~deepchecks.tabular.checks.data_integrity.DataDuplicates`
-           * - :ref:`plot_tabular_string_length_out_of_bounds`
+           * - :ref:`tabular__string_length_out_of_bounds`
              - :class:`~deepchecks.tabular.checks.data_integrity.StringLengthOutOfBounds`
-           * - :ref:`plot_tabular_conflicting_labels`
+           * - :ref:`tabular__conflicting_labels`
              - :class:`~deepchecks.tabular.checks.data_integrity.ConflictingLabels`
-           * - :ref:`plot_tabular_outlier_sample_detection`
+           * - :ref:`tabular__outlier_sample_detection`
              - :class:`~deepchecks.tabular.checks.data_integrity.OutlierSampleDetection`
-           * - :ref:`plot_tabular_feature_label_correlation`
+           * - :ref:`tabular__feature_label_correlation`
              - :class:`~deepchecks.tabular.checks.data_integrity.FeatureLabelCorrelation`
-           * - :ref:`plot_tabular_identifier_label_correlation`
+           * - :ref:`tabular__identifier_label_correlation`
              - :class:`~deepchecks.tabular.checks.data_integrity.IdentifierLabelCorrelation`
-           * - :ref:`plot_tabular_feature_feature_correlation`
+           * - :ref:`tabular__feature_feature_correlation`
              - :class:`~deepchecks.tabular.checks.data_integrity.FeatureFeatureCorrelation`
 
     Parameters
@@ -148,29 +148,29 @@ def train_test_validation(columns: Union[Hashable, List[Hashable]] = None,
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_tabular_datasets_size_comparison`
+           * - :ref:`tabular__datasets_size_comparison`
              - :class:`~deepchecks.tabular.checks.train_test_validation.DatasetsSizeComparison`
-           * - :ref:`plot_tabular_new_label`
+           * - :ref:`tabular__new_label`
              - :class:`~deepchecks.tabular.checks.train_test_validation.NewLabelTrainTest`
-           * - :ref:`plot_tabular_new_category`
+           * - :ref:`tabular__new_category`
              - :class:`~deepchecks.tabular.checks.train_test_validation.CategoryMismatchTrainTest`
-           * - :ref:`plot_tabular_string_mismatch_comparison`
+           * - :ref:`tabular__string_mismatch_comparison`
              - :class:`~deepchecks.tabular.checks.train_test_validation.StringMismatchComparison`
-           * - :ref:`plot_tabular_date_train_test_validation_leakage_duplicates`
+           * - :ref:`tabular__date_train_test_validation_leakage_duplicates`
              - :class:`~deepchecks.tabular.checks.train_test_validation.DateTrainTestLeakageDuplicates`
-           * - :ref:`plot_tabular_date_train_test_validation_leakage_overlap`
+           * - :ref:`tabular__date_train_test_validation_leakage_overlap`
              - :class:`~deepchecks.tabular.checks.train_test_validation.DateTrainTestLeakageOverlap`
-           * - :ref:`plot_tabular_index_leakage`
+           * - :ref:`tabular__index_leakage`
              - :class:`~deepchecks.tabular.checks.train_test_validation.IndexTrainTestLeakage`
-           * - :ref:`plot_tabular_train_test_samples_mix`
+           * - :ref:`tabular__train_test_samples_mix`
              - :class:`~deepchecks.tabular.checks.train_test_validation.TrainTestSamplesMix`
-           * - :ref:`plot_tabular_feature_label_correlation_change`
+           * - :ref:`tabular__feature_label_correlation_change`
              - :class:`~deepchecks.tabular.checks.train_test_validation.FeatureLabelCorrelationChange`
-           * - :ref:`plot_tabular_feature_drift`
+           * - :ref:`tabular__feature_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.FeatureDrift`
-           * - :ref:`plot_tabular_label_drift`
+           * - :ref:`tabular__label_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.LabelDrift`
-           * - :ref:`plot_tabular_multivariate_drift`
+           * - :ref:`tabular__multivariate_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.MultivariateDrift`
 
     Parameters
@@ -247,29 +247,29 @@ def model_evaluation(alternative_scorers: Dict[str, Callable] = None,
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_tabular_roc_report`
+           * - :ref:`tabular__roc_report`
              - :class:`~deepchecks.tabular.checks.model_evaluation.RocReport`
-           * - :ref:`plot_tabular_confusion_matrix_report`
+           * - :ref:`tabular__confusion_matrix_report`
              - :class:`~deepchecks.tabular.checks.model_evaluation.ConfusionMatrixReport`
-           * - :ref:`plot_tabular_weak_segment_performance`
+           * - :ref:`tabular__weak_segment_performance`
              - :class:`~deepchecks.tabular.checks.model_evaluation.WeakSegmentPerformance`
-           * - :ref:`plot_tabular_prediction_drift`
+           * - :ref:`tabular__prediction_drift`
              - :class:`~deepchecks.tabular.checks.model_evaluation.PredictionDrift`
-           * - :ref:`plot_tabular_simple_model_comparison`
+           * - :ref:`tabular__simple_model_comparison`
              - :class:`~deepchecks.tabular.checks.model_evaluation.SimpleModelComparison`
-           * - :ref:`plot_tabular_calibration_score`
+           * - :ref:`tabular__calibration_score`
              - :class:`~deepchecks.tabular.checks.model_evaluation.CalibrationScore`
-           * - :ref:`plot_tabular_regression_systematic_error`
+           * - :ref:`tabular__regression_systematic_error`
              - :class:`~deepchecks.tabular.checks.model_evaluation.RegressionSystematicError`
-           * - :ref:`plot_tabular_regression_error_distribution`
+           * - :ref:`tabular__regression_error_distribution`
              - :class:`~deepchecks.tabular.checks.model_evaluation.RegressionErrorDistribution`
-           * - :ref:`plot_tabular_unused_features`
+           * - :ref:`tabular__unused_features`
              - :class:`~deepchecks.tabular.checks.model_evaluation.UnusedFeatures`
-           * - :ref:`plot_tabular_boosting_overfit`
+           * - :ref:`tabular__boosting_overfit`
              - :class:`~deepchecks.tabular.checks.model_evaluation.BoostingOverfit`
-           * - :ref:`plot_tabular_model_inference_time`
+           * - :ref:`tabular__model_inference_time`
              - :class:`~deepchecks.tabular.checks.model_evaluation.ModelInferenceTime`
-           * - :ref:`plot_tabular_prediction_drift`
+           * - :ref:`tabular__prediction_drift`
              - :class:`~deepchecks.tabular.checks.model_evaluation.PredictionDrift`
 
     Parameters
@@ -352,35 +352,35 @@ def production_suite(task_type: str = None,
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_tabular_roc_report`
+           * - :ref:`tabular__roc_report`
              - :class:`~deepchecks.tabular.checks.model_evaluation.RocReport`
-           * - :ref:`plot_tabular_confusion_matrix_report`
+           * - :ref:`tabular__confusion_matrix_report`
              - :class:`~deepchecks.tabular.checks.model_evaluation.ConfusionMatrixReport`
-           * - :ref:`plot_tabular_weak_segment_performance`
+           * - :ref:`tabular__weak_segment_performance`
              - :class:`~deepchecks.tabular.checks.model_evaluation.WeakSegmentPerformance`
-           * - :ref:`plot_tabular_regression_error_distribution`
+           * - :ref:`tabular__regression_error_distribution`
              - :class:`~deepchecks.tabular.checks.model_evaluation.RegressionErrorDistribution`
-           * - :ref:`plot_tabular_string_mismatch_comparison`
+           * - :ref:`tabular__string_mismatch_comparison`
              - :class:`~deepchecks.tabular.checks.train_test_validation.StringMismatchComparison`
-           * - :ref:`plot_tabular_feature_label_correlation_change`
+           * - :ref:`tabular__feature_label_correlation_change`
              - :class:`~deepchecks.tabular.checks.train_test_validation.FeatureLabelCorrelationChange`
-           * - :ref:`plot_tabular_feature_drift`
+           * - :ref:`tabular__feature_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.FeatureDrift`
-           * - :ref:`plot_tabular_label_drift`
+           * - :ref:`tabular__label_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.LabelDrift`
-           * - :ref:`plot_tabular_multivariate_drift`
+           * - :ref:`tabular__multivariate_drift`
              - :class:`~deepchecks.tabular.checks.train_test_validation.MultivariateDrift`
-           * - :ref:`plot_tabular_prediction_drift`
+           * - :ref:`tabular__prediction_drift`
              - :class:`~deepchecks.tabular.checks.model_evaluation.PredictionDrift`
-           * - :ref:`plot_tabular_prediction_drift`
+           * - :ref:`tabular__prediction_drift`
              - :class:`~deepchecks.tabular.checks.model_evaluation.PredictionDrift`
-           * - :ref:`plot_tabular_string_mismatch`
+           * - :ref:`tabular__string_mismatch`
              - :class:`~deepchecks.tabular.checks.data_integrity.StringMismatch`
-           * - :ref:`plot_tabular_feature_label_correlation`
+           * - :ref:`tabular__feature_label_correlation`
              - :class:`~deepchecks.tabular.checks.data_integrity.FeatureLabelCorrelation`
-           * - :ref:`plot_tabular_feature_feature_correlation`
+           * - :ref:`tabular__feature_feature_correlation`
              - :class:`~deepchecks.tabular.checks.data_integrity.FeatureFeatureCorrelation`
-           * - :ref:`plot_tabular_single_dataset_performance`
+           * - :ref:`tabular__single_dataset_performance`
              - :class:`~deepchecks.tabular.checks.model_evaluation.SingleDatasetPerformance`
 
     Parameters

--- a/deepchecks/tabular/utils/validation.py
+++ b/deepchecks/tabular/utils/validation.py
@@ -26,7 +26,7 @@ __all__ = [
     'ensure_predictions_proba',
 ]
 
-supported_models_link = ('https://docs.deepchecks.com/en/stable/user-guide/supported_models.html'
+supported_models_link = ('https://docs.deepchecks.com/stable/tabular/usage_guides/supported_models.html'
                          '?utm_source=display_output&utm_medium=referral&utm_campaign=exception_link')
 supported_models_html = f'<a href="{supported_models_link}" target="_blank">supported model types</a>'
 

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -137,7 +137,7 @@ def misclassified_samples_lower_than_condition(value: np.ndarray,
 
                     if n_samples > max_samples_in_cell_above_thresh:
                         max_samples_in_cell_above_thresh = n_samples
-    
+
     # There are misclassified cells in the confusion matrix with samples more than 'thresh_samples'
     if n_cells_above_thresh > 0:
         details = f'The confusion matrix has {n_cells_above_thresh} cells with samples ' \

--- a/deepchecks/utils/abstracts/weak_segment_abstract.py
+++ b/deepchecks/utils/abstracts/weak_segment_abstract.py
@@ -9,9 +9,9 @@
 # ----------------------------------------------------------------------------
 #
 """Module contains common methods for weak segment performance checks."""
-
+import abc
 from collections import defaultdict
-from typing import Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -24,67 +24,76 @@ from sklearn.tree import DecisionTreeRegressor
 
 from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.tabular import Dataset
+from deepchecks.tabular.context import _DummyModel
 from deepchecks.tabular.metric_utils.scorers import DeepcheckScorer
 from deepchecks.utils.dataframes import default_fill_na_per_column_type
-from deepchecks.utils.performance.partition import (convert_tree_leaves_into_filters,
+from deepchecks.utils.performance.partition import (DeepchecksFilter, convert_tree_leaves_into_filters,
                                                     partition_numeric_feature_around_segment)
 from deepchecks.utils.strings import format_number, format_percent
 
 
-class WeakSegmentAbstract:
+class WeakSegmentAbstract(abc.ABC):
     """Abstract class with common methods to be inherited by WeakSegmentsPerformance checks, both vision and tabular."""
 
-    def __init__(self,
-                 n_top_features: int = 5,
-                 n_to_show: int = 3,
-                 categorical_aggregation_threshold: float = 0.05,
-                 segment_minimum_size_ratio: float = 0.05,
-                 ):
-        self.n_top_features = n_top_features
-        self.n_to_show = n_to_show
-        self.categorical_aggregation_threshold = categorical_aggregation_threshold
-        self.segment_minimum_size_ratio = segment_minimum_size_ratio
+    n_top_features: int = 5
+    n_to_show: int = 3
+    categorical_aggregation_threshold: float = 0.05
+    min_category_size_ratio: float = 0.01
+    segment_minimum_size_ratio: float = 0.05
+    random_state: int = 42
+    add_condition: Callable[..., Any]
 
-    def _target_encode_categorical_features_fill_na(self, dataset: Dataset,
-                                                    possible_classes: Optional[List] = None) -> Dataset:
+    def _target_encode_categorical_features_fill_na(self, data: pd.DataFrame, label_name: str,
+                                                    cat_features: List[str]) -> Dataset:
         values_mapping = defaultdict(list)  # mapping of per feature of original values to their encoded value
-        df_aggregated = default_fill_na_per_column_type(dataset.features_columns.copy(), dataset.cat_features)
-        for col in dataset.cat_features:
+        df_aggregated = default_fill_na_per_column_type(data.drop(columns=label_name), cat_features)
+        # Merging small categories into Other
+        for col in cat_features:
             categories_to_mask = [k for k, v in df_aggregated[col].value_counts().items() if
-                                  v / dataset.n_samples < self.categorical_aggregation_threshold]
+                                  v / data.shape[0] < self.categorical_aggregation_threshold]
             df_aggregated.loc[np.isin(df_aggregated[col], categories_to_mask), col] = 'Other'
 
-        if len(dataset.cat_features) > 0:
-            t_encoder = TargetEncoder(cols=dataset.cat_features)
-            encoded_label = dataset.label_col.map(possible_classes.index) if \
-                possible_classes is not None else dataset.label_col
-            # label is either encoded by possible_classes or already ints if called from the vision check
-            df_encoded = t_encoder.fit_transform(df_aggregated, encoded_label.astype('float'))
-            for col in dataset.cat_features:
+        # Target encoding of categorical features based on label col (when unavailable we use loss_per_sample)
+        if len(cat_features) > 0:
+            t_encoder = TargetEncoder(cols=cat_features)
+            label_as_int = pd.Categorical(data[label_name], categories=sorted(data[label_name].unique())).codes
+            df_encoded = t_encoder.fit_transform(df_aggregated, pd.Series(label_as_int, dtype=int, index=data.index))
+            for col in cat_features:
                 values_mapping[col] = pd.concat([df_encoded[col], df_aggregated[col]], axis=1).drop_duplicates()
         else:
             df_encoded = df_aggregated
         self.encoder_mapping = values_mapping
-        return Dataset(df_encoded, cat_features=dataset.cat_features, label=dataset.label_col)
+        return Dataset(df_encoded, cat_features=cat_features, label=data[label_name])
 
-    def _create_heatmap_display(self, dummy_model, encoded_dataset, weak_segments, avg_score, scorer):
+    def _create_heatmap_display(self, data: pd.DataFrame,
+                                weak_segments: pd.DataFrame, avg_score: float,
+                                loss_per_sample: Optional[pd.Series] = None,
+                                label_col: Optional[pd.Series] = None,
+                                dummy_model: Optional[_DummyModel] = None,
+                                scorer: Optional[DeepcheckScorer] = None, scorer_name: Optional[str] = None):
         display_tabs = {}
-        data = encoded_dataset.data
+        scorer_name = scorer_name if scorer_name is not None else 'Average Loss' if scorer is None else scorer.name
+        temp_col = 'temp_label_column'
+        if label_col is not None:  # add label col to data for filtering purposes
+            data[temp_col] = label_col
+
         idx = -1
         while len(display_tabs.keys()) < self.n_to_show and idx + 1 < len(weak_segments):
             idx += 1
             segment = weak_segments.iloc[idx, :]
             feature1 = data[segment['Feature1']]
 
+            # Bin the rest of the data into data segments based on the features used to create the weak segment
             if segment['Feature2'] != '':
                 feature2 = data[segment['Feature2']]
-                segments_f1 = partition_numeric_feature_around_segment(feature1, segment['Feature1 range'])
-                segments_f2 = partition_numeric_feature_around_segment(feature2, segment['Feature2 range'])
-            else:
+                segments_f1 = partition_numeric_feature_around_segment(feature1, segment['Feature1 Range'])
+                segments_f2 = partition_numeric_feature_around_segment(feature2, segment['Feature2 Range'])
+            else:  # if only one feature is used to create the weak segment
                 feature2 = pd.Series(np.ones(len(feature1)))
-                segments_f1 = partition_numeric_feature_around_segment(feature1, segment['Feature1 range'], 7)
+                segments_f1 = partition_numeric_feature_around_segment(feature1, segment['Feature1 Range'], 7)
                 segments_f2 = [0, 2]
 
+            # Calculate the score for each of the bins defined above
             scores = np.empty((len(segments_f2) - 1, len(segments_f1) - 1), dtype=float)
             counts = np.empty((len(segments_f2) - 1, len(segments_f1) - 1), dtype=int)
             for f1_idx in range(len(segments_f1) - 1):
@@ -96,8 +105,12 @@ class WeakSegmentAbstract:
                         scores[f2_idx, f1_idx] = np.NaN
                         counts[f2_idx, f1_idx] = 0
                     else:
-                        scores[f2_idx, f1_idx] = scorer.run_on_data_and_label(dummy_model, segment_data,
-                                                                              segment_data[encoded_dataset.label_name])
+                        if scorer is not None and dummy_model is not None and label_col is not None:
+                            scores[f2_idx, f1_idx] = scorer.run_on_data_and_label(dummy_model,
+                                                                                  segment_data.drop(columns=temp_col),
+                                                                                  segment_data[temp_col])
+                        else:
+                            scores[f2_idx, f1_idx] = loss_per_sample[list(segment_data.index)].mean()
                         counts[f2_idx, f1_idx] = len(segment_data)
 
             f1_labels = self._format_partition_vec_for_display(segments_f1, segment['Feature1'])
@@ -119,14 +132,14 @@ class WeakSegmentAbstract:
             scores = scores.astype(object)
             scores[np.isnan(scores.astype(float))] = None
 
-            labels = dict(x=segment['Feature1'], y=segment['Feature2'], color=f'{scorer.name} score')
+            labels = dict(x=segment['Feature1'], y=segment['Feature2'], color=f'{scorer_name} score')
             fig = px.imshow(scores, x=f1_labels, y=f2_labels, labels=labels, color_continuous_scale='rdylgn')
             fig.update_traces(text=scores_text, texttemplate='%{text}')
             if segment['Feature2']:
-                title = f'{scorer.name} score (percent of data) {segment["Feature1"]} vs {segment["Feature2"]}'
+                title = f'{scorer_name} score (percent of data) {segment["Feature1"]} vs {segment["Feature2"]}'
                 tab_name = f'{segment["Feature1"]} vs {segment["Feature2"]}'
             else:
-                title = f'{scorer.name} score (percent of data) {segment["Feature1"]}'
+                title = f'{scorer_name} score (percent of data) {segment["Feature1"]}'
                 tab_name = f'{segment["Feature1"]}'
             fig.update_layout(
                 title=title,
@@ -135,25 +148,34 @@ class WeakSegmentAbstract:
                 yaxis_showgrid=False
             )
 
-            msg = f'Check ran on {encoded_dataset.n_samples} data samples. Average {scorer.name} ' \
+            msg = f'Check ran on {data.shape[0]} data samples. Average {scorer_name} ' \
                   f'score is {format_number(avg_score)}.'
             display_tabs[tab_name] = [fig, msg]
 
         return display_tabs
 
-    def _weak_segments_search(self, dummy_model, encoded_dataset, feature_rank_for_search, loss_per_sample, scorer):
+    def _weak_segments_search(self, data: pd.DataFrame, loss_per_sample: pd.Series,
+                              label_col: Optional[pd.Series] = None,
+                              feature_rank_for_search: Optional[np.ndarray] = None,
+                              dummy_model: Optional[_DummyModel] = None,
+                              scorer: Optional[DeepcheckScorer] = None, scorer_name: Optional[str] = None) \
+            -> pd.DataFrame:
         """Search for weak segments based on scorer."""
+        scorer_name = scorer_name if scorer_name is not None else 'Average Loss' if scorer is None else scorer.name
+        if feature_rank_for_search is None:
+            feature_rank_for_search = np.asarray(data.columns)
+
         weak_segments = pd.DataFrame(
-            columns=[f'{scorer.name} score', 'Feature1', 'Feature1 range', 'Feature2', 'Feature2 range', '% of data'])
+            columns=[f'{scorer_name} Score', 'Feature1', 'Feature1 Range', 'Feature2', 'Feature2 Range', '% of Data'])
         for i in range(min(len(feature_rank_for_search), self.n_top_features)):
             for j in range(i + 1, min(len(feature_rank_for_search), self.n_top_features)):
                 feature1, feature2 = feature_rank_for_search[[i, j]]
-                weak_segment_score, weak_segment_filter = self._find_weak_segment(dummy_model, encoded_dataset,
-                                                                                  [feature1, feature2], scorer,
-                                                                                  loss_per_sample)
+                weak_segment_score, weak_segment_filter = self._find_weak_segment(data, [feature1, feature2],
+                                                                                  loss_per_sample, label_col,
+                                                                                  dummy_model, scorer)
                 if weak_segment_score is None or len(weak_segment_filter.filters) == 0:
                     continue
-                data_size = 100 * weak_segment_filter.filter(encoded_dataset.data).shape[0] / encoded_dataset.n_samples
+                data_size = 100 * weak_segment_filter.filter(data).shape[0] / data.shape[0]
                 filters = weak_segment_filter.filters
                 if len(filters.keys()) == 1:
                     weak_segments.loc[len(weak_segments)] = [weak_segment_score, list(filters.keys())[0],
@@ -164,10 +186,22 @@ class WeakSegmentAbstract:
                                                              tuple(filters[feature1]), feature2,
                                                              tuple(filters[feature2]), data_size]
 
-        return weak_segments.drop_duplicates().sort_values(f'{scorer.name} score').reset_index(drop=True)
+        return weak_segments.drop_duplicates().sort_values(f'{scorer_name} Score').reset_index(drop=True)
 
-    def _find_weak_segment(self, dummy_model, dataset, features_for_segment, scorer: DeepcheckScorer, loss_per_sample):
-        """Find weak segment based on scorer for specified features."""
+    def _find_weak_segment(self, data: pd.DataFrame, features_for_segment: List[str], loss_per_sample: pd.Series,
+                           label_col: Optional[pd.Series] = None, dummy_model: Optional[_DummyModel] = None,
+                           scorer: Optional[DeepcheckScorer] = None) -> \
+            Tuple[Optional[float], Optional[DeepchecksFilter]]:
+        """Find weak segment based on scorer for specified features.
+
+        In each iteration build a decision tree with a set of parameters with the goal of grouping samples with
+        similar loss_per_sample values together. Then, the generated tree is values based only on the quality of
+        the worst leaf in the tree (the rest are ignored). The worst leaf score is calculated by the scorer
+        if provided, otherwise by the average loss_per_sample value of the leaf.
+
+        After all the iterations are done, the tree with the best score (the one with the worst leaf) is selected, and
+        the worst leaf of it is extracted and returned as a deepchecks filter.
+        """
         if version.parse(sklearn.__version__) < version.parse('1.0.0'):
             criterion = ['mse', 'mae']
         else:
@@ -179,13 +213,17 @@ class WeakSegmentAbstract:
             'criterion': criterion
         }
 
+        # In a given tree finds the leaf with the worst score (the rest are ignored)
         def get_worst_leaf_filter(tree):
             leaves_filters = convert_tree_leaves_into_filters(tree, features_for_segment)
             min_score, min_score_leaf_filter = np.inf, None
             for leaf_filter in leaves_filters:
-                leaf_data = leaf_filter.filter(dataset.data)
-                leaf_score = scorer.run_on_data_and_label(dummy_model, leaf_data.drop(columns=[dataset.label_name]),
-                                                          leaf_data[dataset.label_name])
+                if scorer is not None and dummy_model is not None and label_col is not None:
+                    leaf_data, leaf_labels = leaf_filter.filter(data, label_col)
+                    leaf_score = scorer.run_on_data_and_label(dummy_model, leaf_data, leaf_labels)
+                else:  # if no scorer is provided, use the average loss_per_sample of samples in the leaf as the score
+                    leaf_score = loss_per_sample[list(leaf_filter.filter(data).index)].mean()
+
                 if leaf_score < min_score:
                     min_score, min_score_leaf_filter = leaf_score, leaf_filter
             return min_score, min_score_leaf_filter
@@ -202,7 +240,8 @@ class WeakSegmentAbstract:
         grid_searcher = GridSearchCV(DecisionTreeRegressor(random_state=random_state),
                                      scoring=neg_worst_segment_score, param_grid=search_space, n_jobs=-1, cv=3)
         try:
-            grid_searcher.fit(dataset.features_columns[features_for_segment], loss_per_sample)
+            grid_searcher.fit(data[features_for_segment], loss_per_sample)
+            # Get the worst leaf filter out of the selected tree
             segment_score, segment_filter = get_worst_leaf_filter(grid_searcher.best_estimator_.tree_)
         except ValueError:
             return None, None
@@ -234,6 +273,15 @@ class WeakSegmentAbstract:
                 result.append(f'({format_number(lower)}, {format_number(upper)}]')
             result[0] = '[' + result[0][1:]
 
+        return result
+
+    def _generate_check_value_display(self, weak_segments_df, cat_features: List[str]):
+        result = weak_segments_df
+        for idx, segment in result.copy().iterrows():
+            for feature in ['Feature1', 'Feature2']:
+                if segment[feature] in cat_features:
+                    result[f'{feature} Range'][idx] = \
+                        self._format_partition_vec_for_display(segment[f'{feature} Range'], segment[feature], None)[0]
         return result
 
     def add_condition_segments_relative_performance_greater_than(self, max_ratio_change: float = 0.20):

--- a/deepchecks/utils/dataframes.py
+++ b/deepchecks/utils/dataframes.py
@@ -20,20 +20,26 @@ from deepchecks.utils.typing import Hashable
 from deepchecks.utils.validation import ensure_hashable_or_mutable_sequence
 
 __all__ = ['validate_columns_exist', 'select_from_dataframe', 'un_numpy', 'generalized_corrwith',
-           'floatify_dataframe', 'floatify_series', 'default_fill_na_per_column_type', 'is_float_column',
+           'floatify_dataframe', 'floatify_series', 'default_fill_na_per_column_type',
+           'is_float_column', 'default_fill_na_series',
            'cast_categorical_to_object_dtype']
 
 
 def default_fill_na_per_column_type(df: pd.DataFrame, cat_features: t.Union[pd.Series, t.List]) -> pd.DataFrame:
     """Fill NaN values per column type."""
     for col_name in df.columns:
-        if col_name in cat_features:
-            df[col_name] = df[col_name].astype('object').fillna('None')
-        elif is_numeric_dtype(df[col_name]):
-            df[col_name] = df[col_name].astype('float64').fillna(df[col_name].mean())
-        else:
-            df[col_name].fillna(df[col_name].mode(), inplace=True)
+        df[col_name] = default_fill_na_series(df[col_name], col_name in cat_features)
     return df
+
+
+def default_fill_na_series(col: pd.Series, is_categorical: t.Optional[bool] = None) -> pd.Series:
+    """Fill NaN values based on column type."""
+    if is_categorical:
+        return col.astype('object').fillna('None')
+    elif is_numeric_dtype(col):
+        return col.astype('float64').fillna(col.mean())
+    else:
+        return col.fillna(col.mode(), inplace=True)
 
 
 def floatify_dataframe(df: pd.DataFrame):
@@ -96,9 +102,9 @@ def un_numpy(val):
 
 
 def validate_columns_exist(
-    df: pd.DataFrame,
-    columns: t.Union[Hashable, t.List[Hashable]],
-    raise_error: bool = True
+        df: pd.DataFrame,
+        columns: t.Union[Hashable, t.List[Hashable]],
+        raise_error: bool = True
 ) -> bool:
     """Validate given columns exist in dataframe.
 
@@ -139,9 +145,9 @@ def validate_columns_exist(
 
 
 def select_from_dataframe(
-    df: pd.DataFrame,
-    columns: t.Union[Hashable, t.List[Hashable], None] = None,
-    ignore_columns: t.Union[Hashable, t.List[Hashable], None] = None
+        df: pd.DataFrame,
+        columns: t.Union[Hashable, t.List[Hashable], None] = None,
+        ignore_columns: t.Union[Hashable, t.List[Hashable], None] = None
 ) -> pd.DataFrame:
     """Filter DataFrame columns by given params.
 

--- a/deepchecks/utils/docref.py
+++ b/deepchecks/utils/docref.py
@@ -18,9 +18,9 @@ __all__ = ['doclink']
 # TODO:
 links = {
     'default': {
-        'supported-metrics-by-string': 'https://docs.deepchecks.com/en/stable/user-guide/general/metrics_guide.html#list-of-supported-strings', # pylint: disable=line-too-long  # noqa
-        'supported-prediction-format': 'https://docs.deepchecks.com/en/stable/user-guide/tabular/supported_models.html#supported-tasks-and-predictions-format', # pylint: disable=line-too-long  # noqa
-        'supported-predictions-format-nlp': 'https://docs.deepchecks.com/en/stable/user-guide/nlp/supported_tasks.html#supported-labels-and-predictions-format', # pylint: disable=line-too-long  # noqa
+        'supported-metrics-by-string': 'https://docs.deepchecks.com/stable/general/guides/metrics_guide.html#list-of-supported-strings', # pylint: disable=line-too-long  # noqa
+        'supported-prediction-format': 'https://docs.deepchecks.com/stable/tabular/usage_guides/supported_models.html#supported-tasks-and-predictions-format', # pylint: disable=line-too-long  # noqa
+        'supported-predictions-format-nlp': 'https://docs.deepchecks.com/stable/nlp/usage_guides/supported_tasks.html#supported-labels-and-predictions-format', # pylint: disable=line-too-long  # noqa
     },
     # '0.0.1': {},  # noqa
     # '0.0.2': {},  # noqa

--- a/deepchecks/utils/performance/partition.py
+++ b/deepchecks/utils/performance/partition.py
@@ -11,7 +11,7 @@
 """Module of functions to partition columns into segments."""
 from collections import defaultdict
 from copy import deepcopy
-from typing import Callable, List
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -46,11 +46,18 @@ class DeepchecksFilter:
             self.filter_functions = filter_functions
         self.label = label
 
-    def filter(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+    def filter(self, dataframe: pd.DataFrame, label_col: Optional[pd.Series] = None) -> \
+            Union[Tuple[pd.DataFrame, pd.Series], pd.DataFrame]:
         """Run the filter on given dataframe. Return rows in data frame satisfying the filter properties."""
+        if label_col is not None:
+            dataframe['temp_label_col'] = label_col
         for func in self.filter_functions:
             dataframe = dataframe.loc[func(dataframe)]
-        return dataframe
+
+        if label_col is not None:
+            return dataframe.drop(columns=['temp_label_col']), dataframe['temp_label_col']
+        else:
+            return dataframe
 
 
 class DeepchecksBaseFilter(DeepchecksFilter):

--- a/deepchecks/utils/single_sample_metrics.py
+++ b/deepchecks/utils/single_sample_metrics.py
@@ -9,84 +9,41 @@
 # ----------------------------------------------------------------------------
 #
 """Common metrics to calculate performance on single samples."""
-from typing import Union
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
-from sklearn import metrics
-from sklearn.preprocessing import LabelBinarizer
 
-from deepchecks.tabular import Dataset
-from deepchecks.tabular.utils.task_type import TaskType
+from deepchecks.core.errors import DeepchecksValueError
 
 
-def calculate_per_sample_loss(model, task_type: TaskType, dataset: Dataset,
-                              classes_index_order: Union[np.array, pd.Series]) -> pd.Series:
-    """Calculate error per sample for a given model and a dataset."""
-    if task_type == TaskType.REGRESSION:
-        return pd.Series([metrics.mean_squared_error([y], [y_pred]) for y, y_pred in
-                          zip(model.predict(dataset.features_columns), dataset.label_col)], index=dataset.data.index)
-    else:
-        proba = model.predict_proba(dataset.features_columns)
-        return pd.Series([metrics.log_loss([y], [y_proba], labels=classes_index_order) for
-                          y_proba, y in zip(proba, dataset.label_col)], index=dataset.data.index)
+def calculate_neg_mse_per_sample(labels, predictions, index=None) -> pd.Series:
+    """Calculate negative mean squared error per sample."""
+    if index is None and isinstance(labels, pd.Series):
+        index = labels.index
+    return pd.Series([-(y - y_pred) ** 2 for y, y_pred in zip(labels, predictions)], index=index)
 
 
-def per_sample_cross_entropy(y_true: np.array, y_pred: np.array, eps=1e-15):
-    """Calculate cross entropy on a single sample.
+def calculate_neg_cross_entropy_per_sample(labels, probas: np.ndarray, model_classes: Optional[List] = None,
+                                           index=None, eps=1e-15) -> pd.Series:
+    """Calculate negative cross entropy per sample."""
+    if index is None and isinstance(labels, pd.Series):
+        index = labels.index
 
-    This code is based on the code for sklearn log_loss metric, without the averaging over all samples. Licence below:
-    BSD 3-Clause License
+    # transform categorical labels into integers
+    if model_classes is not None:
+        if any(x not in model_classes for x in labels):
+            raise DeepchecksValueError(
+                f'Label observed values {sorted(labels.unique())} contain values '
+                f'that are not found in the model classes: {model_classes}.')
+        if probas.shape[1] != len(model_classes):
+            raise DeepchecksValueError(
+                f'Predicted probabilities shape {probas.shape} does not match the number of classes found in'
+                f' the labels: {model_classes}.')
+        labels = pd.Series(labels).apply(list(model_classes).index)
 
-    Copyright (c) 2007-2021 The scikit-learn developers.
-    All rights reserved.
+    num_samples, num_classes = probas.shape
+    one_hot_labels = np.zeros((num_samples, num_classes))
+    one_hot_labels[list(np.arange(num_samples)), list(labels)] = 1
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    """
-    y_true, y_pred = np.array(y_true), np.array(y_pred)
-
-    # Make y_true into one-hot
-    # We assume that the integers in y_true correspond to the columns in y_pred, such that if y_true[i] = k, then
-    # the corresponding predicted probability would be y_pred[i, k]
-    lb = LabelBinarizer()
-    lb.fit(list(range(y_pred.shape[1])))
-    transformed_labels = lb.transform(y_true)
-
-    if transformed_labels.shape[1] == 1:
-        transformed_labels = np.append(
-            1 - transformed_labels, transformed_labels, axis=1
-        )
-
-    # clip and renormalization y_pred
-    y_pred = y_pred.astype('float').clip(eps, 1 - eps)
-    y_pred /= y_pred.sum(axis=1)[:, np.newaxis]
-
-    return -(transformed_labels * np.log(y_pred)).sum(axis=1)
-
-
-def per_sample_mse(y_true, y_pred):
-    """Calculate mean square error on a single value."""
-    return (y_true - y_pred) ** 2
+    return pd.Series(np.sum(one_hot_labels * np.log(probas + eps), axis=1), index=index)

--- a/deepchecks/vision/README.rst
+++ b/deepchecks/vision/README.rst
@@ -93,13 +93,13 @@ Using conda
 
 Check out the following tutorials for a quick start with deepchecks for CV:
 
-- `Image Data Validation in 5 Minutes (for data without model) <https://docs.deepchecks.com/stable/user-guide/vision/auto_tutorials/plot_simple_classification_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
+- `Image Data Validation in 5 Minutes (for data without model) <https://docs.deepchecks.com/stable/vision/auto_tutorials/quickstarts/plot_simple_classification_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
 
-- `Deepchecks for Object Detection Tutorial <https://docs.deepchecks.com/stable/user-guide/vision/auto_tutorials/plot_detection_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
+- `Deepchecks for Object Detection Tutorial <https://docs.deepchecks.com/stable/vision/auto_tutorials/quickstarts/plot_detection_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
 
-- `Deepchecks for Classification Tutorial <https://docs.deepchecks.com/stable/user-guide/vision/auto_tutorials/plot_classification_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
+- `Deepchecks for Classification Tutorial <https://docs.deepchecks.com/stable/vision/auto_tutorials/quickstarts/plot_classification_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
 
-- `Deepchecks for Segmentation Tutorial <https://docs.deepchecks.com/stable/user-guide/vision/auto_tutorials/plot_segmentation_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
+- `Deepchecks for Segmentation Tutorial <https://docs.deepchecks.com/stable/vision/auto_tutorials/quickstarts/plot_segmentation_tutorial.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=try_it_out>`_
 
 
 📊 Check Examples
@@ -111,7 +111,7 @@ details about the existing checks and the parameters they can receive
 can be found in our `API Reference`_.
 
 .. _API Reference:
-   https://docs.deepchecks.com/en/stable/
+   https://docs.deepchecks.com/stable/
    api/index.html?
    utm_source=github.com&utm_medium=referral&
    utm_campaign=readme&utm_content=running_a_check
@@ -120,7 +120,7 @@ Model Evaluation Checks
 ------------------------
 
 Evaluation checks help you to validate your model's performance.
-See all evaluation checks `here <https://docs.deepchecks.com/en/stable/api/generated/deepchecks.vision.checks.model_evaluation.html
+See all evaluation checks `here <https://docs.deepchecks.com/stable/api/generated/deepchecks.vision.checks.model_evaluation.html
 ?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation>`_.
 Example for a model evaluation check calculating mAP:
 
@@ -143,7 +143,7 @@ Example for a model evaluation check calculating mAP:
       <h4>Mean Average Precision Report</h4>
       <p>Summarize mean average precision metrics on a dataset
       and model per IoU and area range.</p>
-      <a href="https://docs.deepchecks.com/en/stable/checks_gallery/vision/model_evaluation/plot_mean_average_precision_report.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation" target="_blank">
+      <a href="https://docs.deepchecks.com/stable/vision/auto_checks/model_evaluation/plot_mean_average_precision_report.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation" target="_blank">
       Read More...</a>
       <h5>Additional Outputs</h5>
       <table id="T_908a2_">
@@ -197,7 +197,7 @@ Property Distribution Checks
 
 Image Properties are one-dimension values that are extracted from either the images, labels or predictions. For example, an
 image property is **brightness**, and a label property is **bounding box area** (for detection tasks).
-Deepchecks includes `built-in properties <https://docs.deepchecks.com/en/stable/user-guide/vision/vision_properties.html#deepchecks-built-in-properties \
+Deepchecks includes `built-in properties <https://docs.deepchecks.com/stable/vision/usage_guides/vision_properties.html#deepchecks-built-in-properties \
 ?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation>`_ and supports implementing your own
 properties.
 
@@ -220,7 +220,7 @@ Example of a property distribution check and its output:
       <h4>Image Property Outliers</h4>
          <p>
             Find outliers images with respect to the given properties.
-            <a href="https://docs.deepchecks.com/en/stable/checks_gallery/vision/data_integrity/plot_image_property_outliers.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation" target="_blank">Read More...</a>
+            <a href="https://docs.deepchecks.com/stable/vision/auto_checks/data_integrity/plot_image_property_outliers.html?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=documentation" target="_blank">Read More...</a>
          </p>
          <h5>Additional Outputs</h5>
       <h3><b>Property "Brightness"</b></h3>

--- a/deepchecks/vision/checks/data_integrity/property_label_correlation.py
+++ b/deepchecks/vision/checks/data_integrity/property_label_correlation.py
@@ -28,7 +28,7 @@ from deepchecks.vision.vision_data.batch_wrapper import BatchWrapper
 
 __all__ = ['PropertyLabelCorrelation']
 
-pps_url = 'https://docs.deepchecks.com/en/stable/checks_gallery/vision/' \
+pps_url = 'https://docs.deepchecks.com/stable/vision/auto_checks/' \
           'data_integrity/plot_property_label_correlation.html'
 pps_html = f'<a href={pps_url} target="_blank">Predictive Power Score</a>'
 

--- a/deepchecks/vision/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/vision/checks/model_evaluation/weak_segments_performance.py
@@ -10,15 +10,16 @@
 #
 """Module of weak segments performance check."""
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+import numpy as np
 import pandas as pd
 
 from deepchecks.core import CheckResult, DatasetKind
 from deepchecks.core.check_result import DisplayMap
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksProcessError, DeepchecksValueError
 from deepchecks.utils.abstracts.weak_segment_abstract import WeakSegmentAbstract
-from deepchecks.utils.single_sample_metrics import per_sample_cross_entropy
+from deepchecks.utils.single_sample_metrics import calculate_neg_cross_entropy_per_sample
 from deepchecks.vision._shared_docs import docstrings
 from deepchecks.vision.base_checks import SingleDatasetCheck
 from deepchecks.vision.context import Context
@@ -46,11 +47,6 @@ class WeakSegmentsPerformance(SingleDatasetCheck, WeakSegmentAbstract):
 
     Parameters
     ----------
-    scorer: Optional[Callable], default: None
-        a scorer (metric) to override the default scorer, callable that accepts (predictions, labels) and returns the
-        score per sample.
-    scorer_name: Optional[str], default: None
-        The scorer name to display in the plots.
     image_properties : List[Dict[str, Any]], default: None
         List of properties. Replaces the default deepchecks properties.
         Each property is a dictionary with keys ``'name'`` (str), ``method`` (Callable) and ``'output_type'`` (str),
@@ -60,32 +56,26 @@ class WeakSegmentsPerformance(SingleDatasetCheck, WeakSegmentAbstract):
         - ``'categorical'`` - for discrete, non-ordinal outputs. These can still be numbers,
           but these numbers do not have inherent value.
 
-        For more on image properties, see the guide about :ref:`vision_properties_guide`.
-    number_of_bins: int, default : 5
-        Maximum number of bins to segment a single property into.
-    number_of_samples_to_infer_bins : int, default : 1000
-        Minimum number of samples to use to infer the bounds of the segments' bins
-    n_top_properties: int , default: 10
-        Number of features to use for segment search. Top columns are selected based on feature importance.
-    n_to_show: int , default: 3
-        number of segments with the weakest performance to show.
+        For more on image properties, see the guide about :ref:`vision__properties_guide`.
     segment_minimum_size_ratio: float , default: 0.05
         Minimum size ratio for segments. Will only search for segments of
         size >= segment_minimum_size_ratio * data_size.
+    n_samples : Optional[int] , default: 10_000
+        number of samples to use for this check.
+    n_to_show : int , default: 3
+        number of segments with the weakest performance to show.
+    categorical_aggregation_threshold : float , default: 0.05
+        For each categorical property, categories with frequency below threshold will be merged into "Other" category.
     {additional_check_init_params:2*indent}
     """
 
     def __init__(
             self,
-            scorer: Optional[Callable] = None,
-            scorer_name: Optional[str] = None,
             image_properties: List[Dict[str, Any]] = None,
-            number_of_bins: int = 5,
-            number_of_samples_to_infer_bins: int = 1000,
-            n_top_properties: int = 10,
             n_to_show: int = 3,
             segment_minimum_size_ratio: float = 0.05,
             n_samples: Optional[int] = 10000,
+            categorical_aggregation_threshold: float = 0.05,
             **kwargs
     ):
         super().__init__(**kwargs)
@@ -93,34 +83,25 @@ class WeakSegmentsPerformance(SingleDatasetCheck, WeakSegmentAbstract):
             raise DeepchecksNotSupportedError('Check requires at least two image properties in order to run.')
         self.image_properties = image_properties
         self.n_samples = n_samples
-        self.n_top_features = n_top_properties
-        self.scorer = scorer
-        self.scorer_name = scorer_name
-        self.number_of_bins = number_of_bins
-        self.number_of_samples_to_infer_bins = number_of_samples_to_infer_bins
         self.n_to_show = n_to_show
         self.segment_minimum_size_ratio = segment_minimum_size_ratio
+        self.categorical_aggregation_threshold = categorical_aggregation_threshold
         self._properties_results = None
         self._sample_scores = None
+        self._scorer_name = None
 
     def initialize_run(self, context: Context, dataset_kind: DatasetKind):
         """Initialize the properties and sample scores states."""
         task_type = context.get_data_by_kind(dataset_kind).task_type
-        if self.scorer is None:
-            if task_type == TaskType.CLASSIFICATION:
-                def scoring_func(predictions, labels):
-                    return per_sample_cross_entropy(labels, predictions)
+        if task_type == TaskType.CLASSIFICATION:
+            self._scorer_name = 'Cross Entropy'
+        elif task_type == TaskType.OBJECT_DETECTION:
+            self._scorer_name = 'Mean IoU'
+        elif task_type == TaskType.SEMANTIC_SEGMENTATION:
+            self._scorer_name = 'Dice'
+        else:
+            raise DeepchecksValueError(f'Default scorer is not defined for task type {task_type}.')
 
-                self.scorer = scoring_func
-                self.scorer_name = 'cross entropy'
-            elif task_type == TaskType.OBJECT_DETECTION:
-                self.scorer = per_sample_mean_iou
-                self.scorer_name = 'mean IoU'
-            elif task_type == TaskType.SEMANTIC_SEGMENTATION:
-                self.scorer = per_sample_dice
-                self.scorer_name = 'Dice score'
-            else:
-                raise DeepchecksValueError(f'Default scorer is not defined for task type {task_type}.')
         self._properties_results = defaultdict(list)
         self._sample_scores = []
 
@@ -130,40 +111,46 @@ class WeakSegmentsPerformance(SingleDatasetCheck, WeakSegmentAbstract):
         for prop_name, prop_value in properties_results.items():
             self._properties_results[prop_name].extend(prop_value)
 
-        self._sample_scores.extend(self.scorer(batch.numpy_predictions, batch.numpy_labels))
+        if self._scorer_name == 'Cross Entropy':
+            batch_per_sample_score = calculate_neg_cross_entropy_per_sample(np.asarray(batch.numpy_labels),
+                                                                            np.asarray(batch.numpy_predictions))
+        elif self._scorer_name == 'Mean IoU':
+            batch_per_sample_score = per_sample_mean_iou(batch.numpy_predictions, batch.numpy_labels)
+        elif self._scorer_name == 'Dice':
+            batch_per_sample_score = per_sample_dice(batch.numpy_predictions, batch.numpy_labels)
+
+        self._sample_scores.extend(list(batch_per_sample_score))
 
     def compute(self, context: Context, dataset_kind: DatasetKind) -> CheckResult:
         """Find the segments with the worst performance."""
-        results_dict = self._properties_results
-        loss_per_sample_col = 'score'
-        results_dict[loss_per_sample_col] = self._sample_scores
-        results_df = pd.DataFrame(results_dict)
+        results_df = pd.DataFrame(self._properties_results)
+        score_per_sample_col = pd.Series(self._sample_scores, index=results_df.index)
         properties_used = self.image_properties or default_image_properties
         cat_features = [p['name'] for p in properties_used if p['output_type'] == 'categorical']
 
-        #  encoding categorical features based on the loss per sample (not smart but a way to gets the job done)
+        # Encoding categorical properties based on the loss per sample (not smart but a way to gets the job done)
         encoded_dataset = self._target_encode_categorical_features_fill_na(results_df,
-                                                                           loss_per_sample_col, cat_features)
+                                                                           score_per_sample_col,
+                                                                           cat_features,
+                                                                           is_cat_label=False)
 
         weak_segments = self._weak_segments_search(data=encoded_dataset.features_columns,
-                                                   loss_per_sample=encoded_dataset.label_col,
-                                                   scorer_name=self.scorer_name)
+                                                   score_per_sample=score_per_sample_col,
+                                                   scorer_name=self._scorer_name)
         if len(weak_segments) == 0:
             raise DeepchecksProcessError('WeakSegmentsPerformance was unable to train an error model to find weak '
                                          'segments. Try increasing n_samples or supply additional properties.')
-
-        avg_score = round(results_df[loss_per_sample_col].mean(), 3)
+        avg_score = round(score_per_sample_col.mean(), 3)
 
         if context.with_display:
             display = self._create_heatmap_display(data=encoded_dataset.features_columns, weak_segments=weak_segments,
-                                                   avg_score=avg_score, loss_per_sample=encoded_dataset.label_col,
-                                                   scorer_name=self.scorer_name)
+                                                   avg_score=avg_score, score_per_sample=score_per_sample_col,
+                                                   scorer_name=self._scorer_name)
         else:
             display = []
 
-        weak_segments = self._generate_check_value_display(weak_segments, cat_features)
+        check_result_value = self._generate_check_result_value(weak_segments, cat_features, avg_score)
         display_msg = 'Showcasing intersections of properties with weakest detected segments.<br> The full list of ' \
                       'weak segments can be observed in the check result value. '
-        return CheckResult(
-            {'weak_segments_list': weak_segments, 'avg_score': avg_score, 'scorer_name': self.scorer_name},
-            display=[display_msg, DisplayMap(display)])
+        return CheckResult(value=check_result_value,
+                           display=[display_msg, DisplayMap(display)])

--- a/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
+++ b/deepchecks/vision/checks/train_test_validation/property_label_correlation_change.py
@@ -30,7 +30,7 @@ from deepchecks.vision.vision_data.batch_wrapper import BatchWrapper
 
 __all__ = ['PropertyLabelCorrelationChange']
 
-pps_url = 'https://docs.deepchecks.com/en/stable/checks_gallery/vision/' \
+pps_url = 'https://docs.deepchecks.com/stable/vision/auto_checks/' \
           'train_test_validation/plot_feature_label_correlation_change.html'
 pps_html = f'<a href={pps_url} target="_blank">Predictive Power Score</a>'
 

--- a/deepchecks/vision/metrics_utils/iou_utils.py
+++ b/deepchecks/vision/metrics_utils/iou_utils.py
@@ -10,6 +10,7 @@
 #
 """Module for computing Intersection over Unions."""
 from collections import defaultdict
+from typing import List
 
 import numpy as np
 
@@ -77,7 +78,7 @@ def compute_bounding_box_class_ious(detected: np.ndarray, ground_truth: np.ndarr
             for class_id, info in bb_info.items()}
 
 
-def per_sample_mean_iou(predictions: np.ndarray, labels: np.ndarray):
+def per_sample_mean_iou(predictions: np.ndarray, labels: np.ndarray) -> List[float]:
     """Calculate mean iou for a single sample."""
     mean_ious = []
     for detected, ground_truth in zip(predictions, labels):

--- a/deepchecks/vision/suites/default_suites.py
+++ b/deepchecks/vision/suites/default_suites.py
@@ -38,17 +38,17 @@ def train_test_validation(label_properties: List[Dict[str, Any]] = None, image_p
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_vision_new_labels`
+           * - :ref:`vision__new_labels`
              - :class:`~deepchecks.vision.checks.train_test_validation.NewLabels`
-           * - :ref:`plot_vision_heatmap_comparison`
+           * - :ref:`vision__heatmap_comparison`
              - :class:`~deepchecks.vision.checks.train_test_validation.HeatmapComparison`
-           * - :ref:`plot_vision_label_drift`
+           * - :ref:`vision__label_drift`
              - :class:`~deepchecks.vision.checks.train_test_validation.LabelDrift`
-           * - :ref:`plot_vision_image_property_drift`
+           * - :ref:`vision__image_property_drift`
              - :class:`~deepchecks.vision.checks.train_test_validation.ImagePropertyDrift`
-           * - :ref:`plot_vision_image_dataset_drift`
+           * - :ref:`vision__image_dataset_drift`
              - :class:`~deepchecks.vision.checks.train_test_validation.ImageDatasetDrift`
-           * - :ref:`_nlp__property_label_correlation `
+           * - :ref:`vision__property_label_correlation `
              - :class:`~deepchecks.vision.checks.train_test_validation.PropertyLabelCorrelationChange`
 
     Parameters
@@ -95,8 +95,9 @@ def train_test_validation(label_properties: List[Dict[str, Any]] = None, image_p
 
     See Also
     --------
-    :ref:`vision_classification_tutorial`
-    :ref:`vision_detection_tutorial`
+    :ref:`vision__classification_tutorial`
+    :ref:`vision__detection_tutorial`
+    :ref:`vision__segmentation_tutorial`
     """
     args = locals()
     args.pop('kwargs')
@@ -123,17 +124,17 @@ def model_evaluation(scorers: Union[Dict[str, Union[Callable, str]], List[Any]] 
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_vision_class_performance`
+           * - :ref:`vision__class_performance`
              - :class:`~deepchecks.vision.checks.model_evaluation.ClassPerformance`
-           * - :ref:`plot_vision_mean_average_precision_report`
+           * - :ref:`vision__mean_average_precision_report`
              - :class:`~deepchecks.vision.checks.model_evaluation.MeanAveragePrecisionReport`
-           * - :ref:`plot_vision_mean_average_recall_report`
+           * - :ref:`vision__mean_average_recall_report`
              - :class:`~deepchecks.vision.checks.model_evaluation.MeanAverageRecallReport`
-           * - :ref:`plot_vision_prediction_drift`
+           * - :ref:`vision__prediction_drift`
              - :class:`~deepchecks.vision.checks.model_evaluation.PredictionDrift`
-           * - :ref:`plot_vision_simple_model_comparison`
+           * - :ref:`vision__simple_model_comparison`
              - :class:`~deepchecks.vision.checks.model_evaluation.SimpleModelComparison`
-           * - :ref:`plot_weak_segment_performance`
+           * - :ref:`vision__weak_segment_performance`
              - :class:`~deepchecks.vision.checks.model_evaluation.WeakSegmentPerformance`
 
     Parameters
@@ -183,8 +184,9 @@ def model_evaluation(scorers: Union[Dict[str, Union[Callable, str]], List[Any]] 
 
     See Also
     --------
-    :ref:`vision_classification_tutorial`
-    :ref:`vision_detection_tutorial`
+    :ref:`vision__classification_tutorial`
+    :ref:`vision__detection_tutorial`
+    :ref:`vision__segmentation_tutorial`
     """
     args = locals()
     args.pop('kwargs')
@@ -212,9 +214,9 @@ def data_integrity(image_properties: List[Dict[str, Any]] = None, label_properti
 
            * - Check Example
              - API Reference
-           * - :ref:`plot_vision_image_property_outliers`
+           * - :ref:`vision__image_property_outliers`
              - :class:`~deepchecks.vision.checks.data_integrity.ImagePropertyOutliers`
-           * - :ref:`plot_vision_label_property_outliers`
+           * - :ref:`vision__label_property_outliers`
              - :class:`~deepchecks.vision.checks.model_evaluation.LabelPropertyOutliers`
 
     Parameters
@@ -259,8 +261,9 @@ def data_integrity(image_properties: List[Dict[str, Any]] = None, label_properti
 
     See Also
     --------
-    :ref:`vision_classification_tutorial`
-    :ref:`vision_detection_tutorial`
+    :ref:`vision__classification_tutorial`
+    :ref:`vision__detection_tutorial`
+    :ref:`vision__segmentation_tutorial`
     """
     args = locals()
     args.pop('kwargs')

--- a/docs/source/checks/nlp/model_evaluation/plot_confusion_matrix_report.py
+++ b/docs/source/checks/nlp/model_evaluation/plot_confusion_matrix_report.py
@@ -45,3 +45,18 @@ result = check.run(tweets_dataset, predictions=predictions)
 result.show()
 
 #%%
+# Define a condition
+# ==================
+# We can define our check a condition that will validate if all the misclassified
+# cells/samples in the confusion matrix is below a certain threshold. Using the 
+# ``misclassified_samples_threshold`` argument, we can specify what percentage of the total samples
+# our condition should use to validate the misclassified cells.
+
+# Let's add a condition and re-run the check:
+
+check = ConfusionMatrixReport()
+check.add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1)
+result = check.run(tweets_dataset, predictions=predictions)
+result.show()
+
+#%%

--- a/docs/source/checks/nlp/model_evaluation/plot_prediction_drift.py
+++ b/docs/source/checks/nlp/model_evaluation/plot_prediction_drift.py
@@ -3,7 +3,7 @@
 .. _nlp__prediction_drift:
 
 Prediction Drift
-***************************
+****************
 
 This notebook provides an overview for using and understanding the NLP prediction drift check.
 
@@ -40,6 +40,7 @@ on the prediction output.
 #%%
 # Get Data and Predictions
 # ========================
+#
 # For this example, we'll use the tweet emotion dataset, which is a dataset of tweets labeled by one of four emotions:
 # happiness, anger, sadness and optimism.
 #%%
@@ -73,6 +74,7 @@ train_preds = train_preds[indices_to_keep]
 #%%
 # Run Check
 # =========
+#
 
 check = PredictionDrift()
 result = check.run(train_dataset=train_ds, test_dataset=test_ds,
@@ -84,9 +86,9 @@ result
 # We can see that we found drift in the distribution of the predictions, and that the drift is mainly in the "anger"
 # class. This makes sense, as we dropped 50% of the "anger" tweets from the train dataset, and so the model is now
 # predicting less "anger" tweets in the test dataset.
-
-#%%
-# The prediction drift check can also calculate drift on the probability of each class separately rather than the final predicted class.
+#
+# The prediction drift check can also calculate drift on the probability of each class separately
+# rather than the final predicted class.
 # To force this behavior, set the ``drift_mode`` parameter to ``proba``.
 
 # First let's get the probabilities for our data, instead of the predictions:
@@ -98,6 +100,7 @@ result = check.run(train_dataset=train_ds, test_dataset=test_ds,
                    train_probabilities=train_probas, test_probabilities=test_probas)
 
 result
+
 #%%
 # This time, we can see there's small drift in each class. The "anger" class drift is actually probably caused by low
 # sample size, and not by drift in the data itself, as we did not change the data within the class, but only changed

--- a/docs/source/checks/tabular/model_evaluation/plot_confusion_matrix_report.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_confusion_matrix_report.py
@@ -53,3 +53,18 @@ result = check.run(ds, clf)
 result.show()
 
 #%%
+# Define a condition
+# ==================
+# We can define our check a condition that will validate if all the misclassified
+# cells/samples in the confusion matrix is below a certain threshold. Using the 
+# ``misclassified_samples_threshold`` argument, we can specify what percentage of the total samples
+# our condition should use to validate the misclassified cells.
+
+# Let's add a condition and re-run the check:
+
+check = ConfusionMatrixReport()
+check.add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.2)
+result = check.run(ds, clf)
+result.show()
+
+#%%

--- a/docs/source/general/guides/metrics_guide.rst
+++ b/docs/source/general/guides/metrics_guide.rst
@@ -310,6 +310,7 @@ that calculates a metric by accumulating information about the labels and predic
 finalizes the metric computation once all batches have been processed. The metric must
 inherit from :class:`deepchecks.vision.metrics_utils.CustomMetric` and implement the following methods:
 ``reset``, ``update`` and ``compute``:
+
     * ``reset`` - Resets the metric to its initial state, resets any internal variables. Called by deepchecks before
       first call to the ``update`` method.
     * ``update`` - Called once for each batch in the data, this method updates the metric's internal state based on the

--- a/docs/source/general/index.rst
+++ b/docs/source/general/index.rst
@@ -1,4 +1,4 @@
-.. _general_index:
+.. _general__index:
 
 =======
 General

--- a/docs/source/general/integrations/hugging_face.rst
+++ b/docs/source/general/integrations/hugging_face.rst
@@ -113,5 +113,5 @@ for the larger objects, with objects of sizes of up to 32^2 squared pixels impro
 0.21 to 0.26.
 
 Of course, now that the VisionData object has been implemented you can use any of the other deepchecks check and suites.
-You can check them out in our :ref:`vision__checks_gallery`, and learn more about
+You can check them out in our :ref:`Check Gallery <vision__checks_gallery>`, and learn more about
 :ref:`when you should use <when_should_you_use_deepchecks>` each of our built-in suites.

--- a/docs/source/general/usage/customizations/plot_create_a_custom_suite.py
+++ b/docs/source/general/usage/customizations/plot_create_a_custom_suite.py
@@ -55,8 +55,8 @@ new_custom_suite = Suite('Simple Suite For Model Performance',
                                                ).add_condition_gain_greater_than(0.3)
                          )
 
-# The scorers parameter can also be passed to the suite in order to override the scorers of all the checks in the suite.
-# Find more about scorers at https://docs.deepchecks.com/stable/user-guide/general/metrics_guide.html.
+# The scorers' parameter can also be passed to the suite in order to override the scorers of all the checks
+# in the suite. See :ref:`metrics_user_guide` for further details.
 
 #%%
 # Let's see the suite:

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -63,13 +63,33 @@ Simply run the following command in a notebook cell
     !{sys.executable} -m pip install deepchecks --quiet --upgrade # --user
 
 
+Deepchecks For NLP
+==================
+
+.. note:: 
+   Deepchecks' NLP subpackage is in **beta** release, and is available from PyPI,
+   use at your own discretion. `Github Issues <https://github.com/deepchecks/deepchecks/issues>`__ are
+   highly encouraged for feature requests and bug reports.
+
+Installation of deepchecks for NLP should be stated explicitly and it includes
+both the installation of the tabular version and of the nlp subpackage.
+Example commands from above should be altered to install `deepchecks[nlp]`.
+
+
+Using Pip
+---------
+
+.. code-block:: bash
+
+    pip install "deepchecks[nlp]" --upgrade
+
 
 Deepchecks For Computer Vision
 ===============================
 
-.. note:: 
-   Deepchecks' Computer Vision subpackage is in **beta** release, and is available from PyPi, 
-   use at your own discretion. `Github Issues <https://github.com/deepchecks/deepchecks/issues>`_ are
+.. note::
+   Deepchecks' Computer Vision subpackage is in **beta** release, and is available from PyPI,
+   use at your own discretion. `Github Issues <https://github.com/deepchecks/deepchecks/issues>`__ are
    highly encouraged for feature requests and bug reports.
 
 Installation of deepchecks for CV should be stated explicitly and it includes
@@ -83,8 +103,6 @@ Using Pip
 .. code-block:: bash
 
     pip install "deepchecks[vision]" --upgrade
-
-
 
 Start Working with the Package
 =================================

--- a/docs/source/getting-started/welcome.rst
+++ b/docs/source/getting-started/welcome.rst
@@ -183,8 +183,8 @@ Get Help & Give Us Feedback
    - Post an issue or start a discussion on `Github Issues <https://github.com/deepchecks/deepchecks/issues>`__.
    - To contribute to the package, check out the 
      `Contribution Guidelines <https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst>`__ and join the 
-      `contributors-q-and-a Slack channel <https://deepcheckscommunity.slack.com/archives/C030REPARGR>`, 
+     `contributors-q-and-a Slack channel <https://deepcheckscommunity.slack.com/archives/C030REPARGR>`__, 
       or communicate with us via github issues.
 
-   To support us, please give us a star ⭐️ on `Github <https://github.com/deepchecks/deepchecks>`__, it really means a lot for open source projects!
-
+   To support us, please give us a star on ⭐️ `Github <https://github.com/deepchecks/deepchecks>`__ ⭐️, 
+   it really means a lot for open source projects!

--- a/docs/source/getting-started/welcome.rst
+++ b/docs/source/getting-started/welcome.rst
@@ -1,46 +1,86 @@
 .. image:: /_static/images/general/deepchecks-logo-with-white-wide-back.png
-   :target: https://deepchecks.com/?utm_source=docs.deepchecks.com&utm_medium=referral&utm_campaign=welcome
+   :target: https://deepchecks.com/?utm_source=docs.deepchecks.com/stable&utm_medium=referral&utm_campaign=welcome
    :alt: Deepchecks Logo
    :align: center
+   :width: 80%
 
-========================
+=========================
 Welcome to Deepchecks!
-========================
+=========================
 
-Deepchecks is the leading tool for testing, validating and 
-:doc:`monitoring <deepchecks-mon:getting-started/welcome>` your machine learning models
-and data, and it enables doing so with minimal effort. Deepchecks accompanies you through
-various validation and testing needs such as verifying your data's integrity, inspecting its distributions,
-validating data splits, evaluating your model and comparing between different models.
+Deepchecks is a holistic tool for testing, validating and monitoring your machine learning models
+and data, throughout the model's lifecycle. It enables you to identify probelems with your
+data quality, distributions, and model's performance with minimal effort.
 
-.. image:: /_static/images/general/checks-and-conditions.png
-   :alt: Deepchecks Suite of Checks
-   :width: 75%
-   :align: center
+See more info in the :ref:`Deepchecks Components for Continuous Validation <welcome__deepchecks_components>`
+section, along with the direct links to the documentation of each component.
 
-|
 
 .. _welcome__start_working:
 
-Start Working with Deepchecks Testing
-==========================================
+Get Started with Deepchecks Testing
+========================================
+
+.. image:: /_static/images/general/checks-and-conditions.png
+   :alt: Deepchecks Testing Suite of Checks
+   :width: 65%
+   :align: center
+
 
 .. grid:: 1
     :gutter: 3
    
-    .. grid-item-card:: 🤓 Concepts & Guides 🤓
-        :link-type: doc
-        :link: /general/index
+    .. grid-item-card:: 🏃‍♀️ Quickstarts 🏃‍♀️
+        :link-type: ref
+        :link: welcome__quickstarts
          
-        A comprehensive view of deepchecks concepts,
-        customizations, and core use cases.
-   
+        Downloadable end-to-end guides, demonstrating how to start testing your data & model
+        in just a few minutes.
+
+    .. grid-item-card:: 💁‍♂️ Get Help & Give Us Feedback 💁
+        :link-type: ref
+        :link: welcome__get_help
+
+        Links for how to interact with us via our `Slack Community  <https://www.deepchecks.com/slack>`__
+        or by opening `an issue on Github <https://github.com/deepchecks/deepchecks/issues>`__.
+
+
     .. grid-item-card:: 💻  Install 💻 
         :link-type: doc
         :link: /getting-started/installation
 
         Full installation guide (quick one can be found in quickstarts)
 
+    .. grid-item-card:: 🤓 General: Concepts & Guides 🤓
+        :link-type: ref
+        :link: general__index
+         
+        A comprehensive view of deepchecks concepts,
+        customizations, and core use cases.
+
+    .. grid-item-card:: 🔢 Tabular 🔢
+        :link-type: ref
+        :link: tabular__index
+
+        Quickstarts, main concepts, checks gallery and end-to-end guides demonstrating 
+        how to start working Deepchecks with tabular data and models.
+
+    .. grid-item-card:: 🎦‍ Computer Vision (Note: in Beta Release) 🎦‍
+        :link-type: ref
+        :link: vision__index
+         
+        Quickstarts, main concepts, checks gallery and end-to-end guides demonstrating 
+        how to start working Deepchecks with CV data and models.
+        Built-in support for PyTorch, TensorFlow, and custom frameworks.
+
+    .. grid-item-card:: 🔤️ NLP (Note: in Alpha Release) 🔤️
+        :link-type: ref
+        :link: nlp__index
+
+        Quickstarts, main concepts, checks gallery and end-to-end guides demonstrating 
+        how to start working Deepchecks with textual data.
+        Future releases to come!
+    
     .. grid-item-card:: 🚀 Interactive Checks Demo 🚀
         :link-type: url
         :link: https://checks-demo.deepchecks.com/?check=No+check+selected
@@ -50,39 +90,84 @@ Start Working with Deepchecks Testing
         Play with some of the existing tabular checks
         and see how they work on various datasets with custom corruptions injected.
 
-    .. grid-item-card:: 📋 Tabular 📋‍
-        :link-type: doc
-        :link: /tabular/index
-
-        Main concepts, check gallery and end-to-end guides demonstrating how to start working Deepchecks
-        with tabular data and models.
-
-    .. grid-item-card:: 🎦‍ Computer Vision (Note: in Beta Release) 🎦‍
-        :link-type: doc
-        :link: /vision/index
-         
-        Main concepts, check gallery and end-to-end guides demonstrating how to start working Deepchecks
-        with CV data and models. Build-in support for PyTorch, TensorFlow, and custom frameworks.
-
-    .. grid-item-card:: 🔤️ NLP (Note: in Alpha Release) 🔤️
-        :link-type: doc
-        :link: /nlp/index
-
-        Main concepts, check gallery and end-to-end guides demonstrating how to start working Deepchecks
-        with NLP data.
-
-    .. grid-item-card:: 💁‍♂️ Get Help & Give Us Feedback 💁
-        :link-type: ref
-        :link: welcome__get_help
-
-        Links for how to interact with us via our `Slack Community  <https://www.deepchecks.com/slack>`__
-        or by opening `an issue on Github <https://github.com/deepchecks/deepchecks/issues>`__.
-
     .. grid-item-card:: 🤖 API Reference 🤖
         :link-type: doc
         :link: /api/index
 
-        Reference and links to source code for Deepchecks' components
+        Reference and links to source code for Deepchecks Testing's components.
+
+
+.. _welcome__quickstarts:
+
+🏃‍♀️ Testing Quickstarts 🏃‍♀️
+==========================
+
+.. grid:: 1
+    :gutter: 3
+
+    .. grid-item-card:: 🔢 Tabular 🔢 
+        :link-type: doc
+        :link: /tabular/auto_tutorials/quickstarts/index
+        :columns: 4
+    
+    .. grid-item-card:: 🎦‍ Vision 🎦‍ (in Beta)
+        :link-type: doc
+        :link: /vision/auto_tutorials/quickstarts/index
+        :columns: 4
+
+    .. grid-item-card:: 🔤️ NLP 🔤️ (in Alpha)
+        :link-type: doc
+        :link: /nlp/auto_tutorials/quickstarts/plot_text_classification
+        :columns: 4
+
+
+
+.. _welcome__deepchecks_components:
+
+Deepchecks' Components
+=======================
+
+.. grid:: 1
+    :gutter: 3
+
+    .. grid-item-card:: Testing Docs (Here)
+        :link-type: ref
+        :link: welcome__start_working
+        :img-top: /_static/images/welcome/research_title.png
+        :columns: 4
+
+        Tests during research and model development
+    
+    .. grid-item-card:: CI Docs
+        :link-type: doc
+        :link: /general/usage/ci_cd
+        :img-top: /_static/images/welcome/ci_cd_title.png
+        :columns: 4
+        
+        Tests before deploying the model to production
+
+    .. grid-item-card:: Monitoring Docs
+        :link-type: ref
+        :link: deepchecks-mon:welcome__start_with_deepchecks_monitoring
+        :img-top: /_static/images/welcome/monitoring_title.png
+        :columns: 4
+
+        Tests and continuous monitoring during production
+
+Deepchecks accompanies you through various testing needs such as verifying your data's integrity, 
+inspecting its distributions, validating data splits, evaluating your model and comparing between different models,
+throughout the model's lifecycle.
+
+.. image:: /_static/images/welcome/testing_phases_in_pipeline.png
+   :alt: Phases for Continuous Validation of ML Models and Data
+   :align: center
+
+|
+
+Deechecks' continuous validation approach is based on testing the ML models and data throughout the different phases 
+using the exact same checks, enabling a simple, elaborate and seamless experience for configuring and consuming the results.
+Each phase has its relevant interfaces (e.g. visual outputs, output results to json, alert configuration, push notifications, RCA, etc.) for
+interacting with the test results.
 
 .. _welcome__get_help:
 
@@ -94,50 +179,12 @@ Get Help & Give Us Feedback
 
    In addition to perusing the documentation, feel free to:
 
-   - Ask questions on our `Slack Community <https://www.deepchecks.com/slack>`__,
+   - Ask questions on the `Slack Community <https://www.deepchecks.com/slack>`__,
    - Post an issue or start a discussion on `Github Issues <https://github.com/deepchecks/deepchecks/issues>`__.
+   - To contribute to the package, check out the 
+     `Contribution Guidelines <https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst>`__ and join the 
+      `contributors-q-and-a Slack channel <https://deepcheckscommunity.slack.com/archives/C030REPARGR>`, 
+      or communicate with us via github issues.
 
    To support us, please give us a star ⭐️ on `Github <https://github.com/deepchecks/deepchecks>`__, it really means a lot for open source projects!
-
-Deepchecks' Components
-=======================
-
-Continuous validation of ML models and data includes testing throughout the model's lifecycle:
-
-.. image:: /_static/images/welcome/testing_phases_in_pipeline.png
-   :alt: Phases for Continuous Validation of ML Models and Data
-   :align: center
-
-|
-
-Head over to the relevant documentation for more info:
-
-.. grid:: 1
-    :gutter: 3
-
-    .. grid-item-card:: Testing Package (Here)
-        :link-type: ref
-        :link: welcome__start_working
-        :img-top: /_static/images/welcome/research_title.png
-        :columns: 4
-
-        Tests during research and model development
-    
-    .. grid-item-card:: Testing Package CI/CD Usage
-        :link-type: doc
-        :link: /general/usage/ci_cd
-        :img-top: /_static/images/welcome/ci_cd_title.png
-        :columns: 4
-        
-        Tests before deploying the model to production
-
-    .. grid-item-card:: Monitoring
-        :link-type: ref
-        :link: deepchecks-mon:welcome__start_with_deepchecks_monitoring
-        :img-top: /_static/images/welcome/monitoring_title.png
-        :columns: 4
-
-        Tests and continuous monitoring during production
-
-
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,13 +31,13 @@ get up and running with deepchecks in 5 minutes.
     :maxdepth: 3
     :hidden:
 
-    vision/index
+    nlp/index
 
 .. toctree::
     :maxdepth: 3
     :hidden:
 
-    nlp/index
+    vision/index
 
 .. toctree::
     :maxdepth: 3

--- a/docs/source/nlp/index.rst
+++ b/docs/source/nlp/index.rst
@@ -5,14 +5,15 @@ NLP
 ===
 
 Deepchecks for NLP is currently in alpha stage.
-Visit the :ref:`installation_guide` page to set up your environment and than head over to the
-:ref:`nlp__index_tutorials` section.
+Visit the :ref:`installation_guide` page to set up your environment and then head over to the
+Tutorials section.
 
 This is an alpha release and you can help us develop it further! You can provide feedback and suggestions as issues on
 `GitHub <https://github.com/deepchecks/deepchecks/issues>`__, or by joining our
 `Community Slack <https://www.deepchecks.com/slack>`__.
 
 .. _nlp__index_tutorials:
+
 Tutorials
 ---------
 
@@ -35,8 +36,11 @@ This section contain in-depth guides on different aspects and components of the 
     :caption: Usage Guides
 
     usage_guides/supported_tasks
+    usage_guides/nlp_properties
+    usage_guides/nlp_metadata
 
 .. _nlp__checks_gallery:
+
 Checks Gallery
 --------------
 

--- a/docs/source/nlp/index.rst
+++ b/docs/source/nlp/index.rst
@@ -35,6 +35,7 @@ This section contain in-depth guides on different aspects and components of the 
     :maxdepth: 0
     :caption: Usage Guides
 
+    usage_guides/text_data_object
     usage_guides/supported_tasks
     usage_guides/nlp_properties
     usage_guides/nlp_metadata

--- a/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
+++ b/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
@@ -175,12 +175,13 @@ result.show()
 #
 # .. note::
 #
-#    Some of the default properties require additional packages to be installed. If you want to use them, you can
+#    Some default properties require additional packages to be installed. If you want to use them, you can
 #    install them by running ``pip install deepchecks[nlp-properties]``.
 #    Additionally, some properties that use the ``transformers`` package are computationally expensive, and may take
 #    a long time to calculate. If you have a GPU or a similar device you can use it by installing the appropriate
 #    package versions and passing a ``device`` argument to the ``TextData`` constructor or to the
 #    ``calculate_default_properties`` method.
+#
 #
 
 # Calculate properties

--- a/docs/source/nlp/usage_guides/nlp_metadata.rst
+++ b/docs/source/nlp/usage_guides/nlp_metadata.rst
@@ -9,7 +9,7 @@ behavior. In contrast to unstructured text, metadata is structured, and is expec
 Metadata can be anything - from the source of the data, the timestamp of its creation, to the age of the author, and
 any other information that is given about the text.
 
-Not to be confused with :ref:`text properties <nlp_properties_guide>`, which are features extracted from the text
+Not to be confused with :ref:`text properties <nlp__properties_guide>`, which are features extracted from the text
 itself, such as text length or sentiment.
 
 What Is Metadata Used For?

--- a/docs/source/nlp/usage_guides/nlp_properties.rst
+++ b/docs/source/nlp/usage_guides/nlp_properties.rst
@@ -57,6 +57,8 @@ Subjectivity                    Subjectivity of the text. Uses the textblob libr
 Toxicity*                       Toxicity of the text. Uses the unitary/toxic-bert model
 Fluency*                        Fluency of the text. Uses the prithivida/parrot_fluency_model model
 Formality*                      Formality of the text. Uses the s-nlp/roberta-base-formality-ranker model
+Lexical Density                 Percentage of unique words in the text, rounded up to 2 decimal digits
+Unique Noun Count*              Number of unique noun words in the text
 ==============================  ==========
 
 *These properties are not calculated by default, as they may take a long time to calculate. To use them, pass

--- a/docs/source/nlp/usage_guides/nlp_properties.rst
+++ b/docs/source/nlp/usage_guides/nlp_properties.rst
@@ -9,7 +9,7 @@ or **sentiment**.
 Deepchecks includes :ref:`built-in properties <Deepchecks' Built-in Properties>` and supports :ref:`using your own
 properties <Using Your Own Properties>`.
 
-Not to be confused with :ref:`metadata <nlp_metadata_guide>`, which is additional data that comes with it organically,
+Not to be confused with :ref:`metadata <nlp__metadata_guide>`, which is additional data that comes with it organically,
 such as the text's author or date of creation.
 
 

--- a/docs/source/nlp/usage_guides/text_data_object.rst
+++ b/docs/source/nlp/usage_guides/text_data_object.rst
@@ -1,0 +1,110 @@
+.. _nlp__textdata_object:
+
+===================
+The TextData Object
+===================
+
+The :class:`TextData <deepchecks.nlp.text_data.TextData>` is a container for your textual data, labels, and relevant
+metadata for NLP tasks and is a basic building block in the ``deepchecks.nlp`` subpackage.
+In order to use any functionality of the ``deepchecks.nlp`` subpackage, you need to first create a ``TextData`` object.
+The ``TextData`` object enables easy access to metadata, embeddings and properties relevant for training and validating ML
+models.
+
+Class Properties
+==================
+
+The main properties are:
+
+- **raw_text** - The raw text data, a list of strings representing the raw text of each sample. Each sample can be a
+  sentence, paragraph, or a document, depending on the task.
+- **label** - The labels for the text data samples.
+- **task_type** - The task type, see the :ref:`Supported Tasks Guide <nlp__supported_tasks>` for more information.
+
+TextData API Reference
+-------------------------
+
+.. currentmodule:: deepchecks.nlp.text_data
+
+.. autosummary::
+
+    TextData
+
+
+Creating a TextData
+=======================
+
+The default ``TextData`` constructor expects to get a sequence of raw text strings or tokenized text.
+The rest of the arguments are optional, but if you have labels for your data you would want to define them in the constructor,
+as many checks require the dataset labels in order to run.
+
+.. admonition:: Defining task_type
+   :class: attention
+
+   If you define labels, you must also define the ``task_type`` so deepchecks will know how to parse the labels.
+
+
+>>> raw_text = ["This is an example.", "Another example here."]
+>>> labels = ["positive", "negative"]
+>>> task_type = "text_classification"
+>>> text_data = TextData(raw_text=raw_text, label=labels, task_type=task_type)
+
+Tokenized Text
+----------------
+
+If you have tokenized text, you can also create a TextData object from it rather than using the ``raw_text`` argument:
+
+>>> # A tokenized example with named entities and locations
+>>> tokenized_text = [["Dan", "lives", "in", "New", "York", "."], ["He", "works", "at", "Google", "."]]
+>>> labels = [["B-PER", "O", "O", "B-LOC", "I-LOC", "O"], ["O", "O", "O", "B-ORG", "O"]]
+>>> text_data = TextData(tokenized_text=tokenized_text, label=labels, task_type=task_type)
+
+If you're running deepchecks on a token classification task it is recommended to use that argument instead of the
+``raw_text`` argument. If you did pass ``raw_text`` to the constructor,
+deepchecks will break the text into tokens for you, using the default python ``str.split()`` method to split the text
+into tokens.
+
+Useful Functions
+===================
+
+Calculate Default Properties
+-----------------------------
+
+You can calculate the default text properties for the TextData object:
+
+>>> text_data.calculate_default_properties()
+
+To learn more about how deepchecks uses properties and how you can calculate or set them yourself, see
+the :ref:`Text Properties Guide <nlp__properties_guide>`.
+
+Add Metadata
+-------------
+
+You can add metadata to the TextData object:
+
+>>> text_data.set_metadata(metadata_df, categorical_metadata_columns)
+
+To learn more about how deepchecks uses metadata, see the :ref:`Text Metadata Guide <nlp__metadata_guide>`.
+
+Sample
+------
+
+You can sample a subset of the TextData object:
+
+>>> text_data.sample(10000)
+
+Working with Class Parameters
+---------------------------------
+
+You can work directly with the ``TextData`` object, to inspect its defined raw text, tokenized text, and label:
+
+>>> text_data.raw_text
+["This is an example.", "Another example here."]
+>>> text_data.tokenized_text
+[["This", "is", "an", "example."], ["Another", "example", "here."]]
+>>> text_data.label
+["positive", "negative"]
+
+Get its internal metadata and properties DataFrames:
+
+>>> text_data.metadata
+>>> text_data.properties

--- a/docs/source/nlp/usage_guides/text_data_object.rst
+++ b/docs/source/nlp/usage_guides/text_data_object.rst
@@ -4,7 +4,7 @@
 The TextData Object
 ===================
 
-The :class:`TextData <deepchecks.nlp.text_data.TextData>` is a container for your textual data, labels, and relevant
+The :class:`TextData <deepchecks.nlp.TextData>` is a container for your textual data, labels, and relevant
 metadata for NLP tasks and is a basic building block in the ``deepchecks.nlp`` subpackage.
 In order to use any functionality of the ``deepchecks.nlp`` subpackage, you need to first create a ``TextData`` object.
 The ``TextData`` object enables easy access to metadata, embeddings and properties relevant for training and validating ML

--- a/docs/source/tabular/index.rst
+++ b/docs/source/tabular/index.rst
@@ -5,8 +5,8 @@ Tabular
 =======
 
 Deepchecks tabular sub package contain a large variety of checks and suites for different use cases.
-Visit the :ref:`installation_guide` page to set up your environment and than head over to the
-:ref:`tabular__index_tutorials` section.
+Visit the :ref:`installation_guide` page to set up your environment and then head over to the
+Tutorials section.
 
 .. _tabular__index_tutorials:
 

--- a/docs/source/tabular/index.rst
+++ b/docs/source/tabular/index.rst
@@ -9,6 +9,7 @@ Visit the :ref:`installation_guide` page to set up your environment and than hea
 :ref:`tabular__index_tutorials` section.
 
 .. _tabular__index_tutorials:
+
 Tutorials
 ---------
 
@@ -40,6 +41,7 @@ This section contain in-depth guides on different aspects and components of the 
 
 
 .. _tabular__checks_gallery:
+
 Checks Gallery
 --------------
 

--- a/docs/source/tabular/tutorials/quickstarts/plot_quickstart_in_5_minutes.py
+++ b/docs/source/tabular/tutorials/quickstarts/plot_quickstart_in_5_minutes.py
@@ -100,8 +100,8 @@ integ_suite.run(ds_train)
 # ======================
 # If you want to run a specific check, you can just import it and run it directly.
 #
-# Check out the :ref:`tabular__checks_gallery` in
-# the examples or the :doc:`API Reference </api/index>` for more info about the
+# Check out the :ref:`Check Gallery <tabular__checks_gallery>` or the
+# :doc:`API Reference </api/index>` for more info about the
 # existing checks and their parameters.
 
 from deepchecks.tabular.checks import LabelDrift

--- a/docs/source/vision/index.rst
+++ b/docs/source/vision/index.rst
@@ -6,12 +6,14 @@ Vision
 
 Deepchecks vision sub package contain a large variety of checks and suites for different use cases.
 It provides build-in support for PyTorch, TensorFlow, and custom frameworks.
-Visit the :ref:`installation_guide` page to set up your environment and than head over to the
-:ref:`vision__index_tutorials` section.
+Visit the :ref:`installation_guide` page to set up your environment and then head over to the
+Tutorials section.
 
 .. _vision__index_tutorials:
+
 Tutorials
 ---------
+
 This section contain tutorials for different use cases, and how to use deepchecks in your workflow.
 
 .. toctree::
@@ -38,6 +40,7 @@ This section contain in-depth guides on different aspects and components of the 
     usage_guides/vision_properties
 
 .. _vision__checks_gallery:
+
 Checks Gallery
 --------------
 

--- a/docs/source/vision/usage_guides/supported_tasks_and_formats.rst
+++ b/docs/source/vision/usage_guides/supported_tasks_and_formats.rst
@@ -119,6 +119,7 @@ Object Detection
 
 Label Format
 ------------
+
 Object detection label per sample should be an iterable of bounding boxes. Each bounding box should be an iterable
 of 5 elements in the following order: ``(class_id, x_min, y_min, w, h)``.
 
@@ -137,6 +138,7 @@ sample has 2 bounding boxes, should be provided as follows:
 
 Prediction Format
 -----------------
+
 Object detection prediction per sample should be an iterable of predicted bounding boxes and their corresponding
 confidence scores provided by the model. Each bounding box should be an iterable of 6 elements in the following order:
 ``(x_min, y_min, w, h, confidence, class_id)``.
@@ -161,6 +163,7 @@ Semantic Segmentation
 
 Label Format
 ------------
+
 Semantic segmentation label per sample should be an array of shape ``[H, W]`` where ``H`` and ``W`` are the
 height and width of the corresponding image, and its values are the true class_ids of
 the corresponding pixels in that image.
@@ -168,6 +171,7 @@ Note that the array should be 2D, as the number of channels on the original imag
 
 Prediction Format
 -----------------
+
 Semantic segmentation prediction per sample should be **predicted probabilities** per class per pixel. Specifically,
 the prediction per sample format is an array of shape ``[C, H, W]`` where ``H`` and ``W`` are the height
 and width of the corresponding image, and ``C`` is the number of possible classes
@@ -178,6 +182,7 @@ probabilities should be 1.
 
 Other Tasks
 ===========
+
 For other tasks, there is no specific format required for the labels and predictions and their format is
 not validated. There are two ways in which Deepchecks can provide value for these sort of tasks:
 
@@ -191,3 +196,4 @@ The advanced option: Add custom metrics and properties for the
 predictions and labels provided and run additional checks.
 For more information on how to do so, see the
 :ref:`vision__custom_check` tutorial.
+

--- a/docs/source/vision/usage_guides/visiondata_object.rst
+++ b/docs/source/vision/usage_guides/visiondata_object.rst
@@ -3,6 +3,7 @@
 =====================
 The Vision Data Class
 =====================
+
 The :class:`VisionData` class is the deepchecks base class for
 storing your data for a vision task. It is essentially a wrapper around a batch loader of images, labels,
 and predictions, that allows deepchecks to efficiently calculate different
@@ -39,6 +40,7 @@ To see all other class parameters, see the :class:`VisionData <deepchecks.vision
 
 Creating a VisionData Object
 ============================
+
 In the sub-sections below we will go over three different ways to create a VisionData object:
 1. `From a Generic Generator <#from-a-generic-generator>`__
 2. `From a PyTorch DataLoader <#from-pytorch-dataloader>`__
@@ -48,7 +50,8 @@ The sub-sections contain simple examples for how to create a VisionData object w
 order to learn how to supply them see the section about :ref:`adding model predictions <vision_data__adding_predictions>`.
 
 From a Generic Generator
-----------------------------
+------------------------
+
 If you are not already using a pytorch DataLoader or a tensorflow Dataset for the project, for example
 if you are using fastai, jax or any autoML framework, this is the most recommended option.
 The custom generator can be implemented in any way you like, as long as it outputs the data in the
@@ -84,6 +87,7 @@ method for the MNIST dataset can be seen at
 
 From Pytorch DataLoader
 -----------------------
+
 In order to create a VisionData object from a
 `PyTorch DataLoader <https://pytorch.org/tutorials/beginner/basics/data_tutorial.html>`_,
 all you need is to replace the default
@@ -122,6 +126,7 @@ A full code implementation of this method for the COCO128 dataset can be seen at
 
 From TensorFlow Dataset
 -----------------------
+
 There are two possible ways to create a deepchecks compatible tensorflow
 `Dataset object <https://www.tensorflow.org/api_docs/python/tf/data/Dataset>`_. You can either create it
 in a way that directly outputs the data in the required format or convert an existing dataset.
@@ -156,6 +161,7 @@ A full code implementation of this method for the COCO128 dataset can be seen at
 .. _vision_data__adding_predictions:
 Adding Model Predictions
 ========================
+
 Some checks, including the :ref:`model evaluation checks and suite <vision__checks_gallery>`,
 require model predictions in
 order to run. Model predictions are supplied via the batch loader in a similar fashion to the images and labels.
@@ -165,6 +171,7 @@ on-demand inference.
 .. _vision_data__precalculated_predictions:
 Pre-calculated Predictions
 --------------------------
+
 It is recommended to use this option if your model object is unavailable locally (for example if
 placed on a separate prediction server) or if the predicting process is computationally expensive or time consuming.
 
@@ -195,6 +202,7 @@ a csv file containing the path to the image, the label and the prediction probab
 
 On-demand Inference
 -------------------
+
 In this case we will need to incorporate the model object in the relevant format transformation function
 (the ``collate`` function for pytorch or the ``map`` function for tensorflow). This can be
 done either by using the model as a global variable, creating a wrapper class for the transformation function or

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -49,3 +49,4 @@ nltk<=3.6.7
 datasets
 langdetect
 textblob
+transformers

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -146,3 +146,6 @@ ONNX
 f1
 multiindex
 misclassified
+tokenizer
+nltk
+Tokenize

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -145,3 +145,4 @@ embeddings
 ONNX
 f1
 multiindex
+misclassified

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -98,7 +98,6 @@ qs
 urlobj
 labextension
 PredictionDrift
-PredictionDrift
 nbclassic
 REPL
 ipywidgets
@@ -149,3 +148,5 @@ misclassified
 tokenizer
 nltk
 Tokenize
+spacy
+tokenizers

--- a/tests/nlp/checks/data_integrity/unknown_tokens_test.py
+++ b/tests/nlp/checks/data_integrity/unknown_tokens_test.py
@@ -1,0 +1,185 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Test for the NLP UnknownTokens check."""
+import pytest
+from hamcrest import *
+
+from transformers import GPT2Tokenizer
+
+from deepchecks.core.errors import DeepchecksValueError
+from deepchecks.nlp.checks import UnknownTokens
+from deepchecks.nlp.text_data import TextData
+from deepchecks.utils.strings import format_percent
+from tests.base.utils import equal_condition_result
+
+
+# ====================
+# ----- Fixtures -----
+# ====================
+
+
+@pytest.fixture
+def dataset_without_unknown_tokens():
+    return TextData(
+        label=[0, 1, 2],
+        task_type="text_classification",
+        raw_text=[
+            "Explicit is better than implicit.",
+            "Simple is better than complex.",
+            "Complex is better than complicated.",
+        ]
+    )
+
+
+@pytest.fixture
+def dataset_with_unknown_tokens():
+    return TextData(
+        label=[0, 1, 2],
+        task_type="text_classification",
+        raw_text=[
+            "Explicit is better than ˚implicit.",
+            "Simple is better than ∫complex.",
+            "Complex is better than complicated.",
+        ]
+    )
+
+@pytest.fixture
+def dataset_with_reoccurring_unknown_words():
+    return TextData(
+        label=[0, 1, 2, 0, 1, 2],
+        task_type="text_classification",
+        raw_text=[
+            "Explicit is better than ˚implicit.",
+            "Simple is better than ∫complex.",
+            "Complex is better than complicated.",
+            "Explicit is better than ˚implicit.",
+            "Simple is better than ∫complex∫.",
+            "Complex is better than complicated.",
+        ]
+    )
+
+
+# =================
+# ----- Tests -----
+# =================
+
+
+def test_without_unknown_tokens(dataset_without_unknown_tokens):
+    # Arrange
+    check = UnknownTokens().add_condition_ratio_of_unknown_words_less_or_equal()
+
+    # Act
+    result = check.run(dataset=dataset_without_unknown_tokens)
+    conditions_decisions = check.conditions_decision(result)
+
+    # Assert
+    assert_that(result.value, has_entries({
+        "unknown_word_ratio": equal_to(0),
+        "unknown_word_details": instance_of(dict),
+    }))
+
+    assert_that(conditions_decisions[0], equal_condition_result(
+        is_pass=True,
+        details=f'Ratio was 0%',
+        name='Ratio of unknown words is less than 0%',
+    ))  # type: ignore
+
+    assert_that(len(result.value['unknown_word_details']), equal_to(0))
+
+    # Assert no display
+    assert_that(result.display, equal_to([]))
+
+
+def test_with_unknown_tokens(dataset_with_unknown_tokens):
+    # Arrange
+    check = UnknownTokens().add_condition_ratio_of_unknown_words_less_or_equal()
+
+    # Act
+    result = check.run(dataset=dataset_with_unknown_tokens)
+    conditions_decisions = check.conditions_decision(result)
+
+    # Assert
+    assert_that(result.value, has_entries({
+        "unknown_word_ratio": close_to(0.1111, 0.0001),
+        "unknown_word_details": instance_of(dict),
+    }))
+
+    assert_that(conditions_decisions[0], equal_condition_result(
+        is_pass=False,
+        details=f'Ratio was {format_percent(result.value["unknown_word_ratio"])}',
+        name='Ratio of unknown words is less than 0%',
+    ))  # type: ignore
+
+    assert_that(len(result.value['unknown_word_details']), equal_to(2))
+    assert_that(result.value['unknown_word_details'], has_entries({
+        "˚implicit": has_entries({
+            "ratio": close_to(0.0555, 0.0001),
+            "indexes": contains_exactly(0)
+        }),
+        "∫complex": has_entries({
+            "ratio": close_to(0.0555, 0.0001),
+            "indexes": contains_exactly(1)
+        }),
+    }))
+
+
+def test_group_singleton_words_true(dataset_with_reoccurring_unknown_words):
+    # Arrange
+    check = UnknownTokens(group_singleton_words=True).add_condition_ratio_of_unknown_words_less_or_equal()
+
+    # Act
+    result = check.run(dataset=dataset_with_reoccurring_unknown_words)
+    conditions_decisions = check.conditions_decision(result)
+
+    # Assert
+    assert_that(result.value, has_entries({
+        "unknown_word_ratio": close_to(0.1111, 0.0001),
+        "unknown_word_details": instance_of(dict),
+    }))
+
+    assert_that(conditions_decisions[0], equal_condition_result(
+        is_pass=False,
+        details=f'Ratio was {format_percent(result.value["unknown_word_ratio"])}',
+        name='Ratio of unknown words is less than 0%',
+    ))  # type: ignore
+
+    # Check if the display has a 'Other Unknown Words' label
+    display = result.display
+    assert_that(display, has_length(2))
+    pie_chart = display[0]
+    assert_that(pie_chart['data'][0]['labels'], has_item('Other Unknown Words'))
+
+
+def test_with_more_robust_tokenizer(dataset_with_unknown_tokens):
+    # Arrange
+    tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+    check = UnknownTokens(tokenizer=tokenizer)
+
+    # Act
+    result = check.run(dataset=dataset_with_unknown_tokens)
+    conditions_decisions = check.conditions_decision(result)
+
+    # Assert
+    assert_that(result.value, has_entries({
+        "unknown_word_ratio": equal_to(0),
+        "unknown_word_details": instance_of(dict),
+    }))
+
+    assert_that(len(result.value['unknown_word_details']), equal_to(0))
+
+
+def test_for_illegal_tokenizer(dataset_with_unknown_tokens):
+    # Arrange
+    tokenizer = 'a'
+
+    # Act & Assert
+    assert_that(calling(UnknownTokens).with_args(tokenizer=tokenizer),
+                raises(DeepchecksValueError, r'tokenizer must have a "tokenize" method'))

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -10,11 +10,12 @@
 #
 """Test for the nlp SingleDatasetPerformance check"""
 
+import numpy as np
 from hamcrest import assert_that, close_to, equal_to
 
 from deepchecks.core.condition import ConditionCategory
 from deepchecks.nlp.checks.model_evaluation import ConfusionMatrixReport
-from deepchecks.utils.strings import format_number
+from deepchecks.utils.strings import format_number, format_percent
 from tests.base.utils import equal_condition_result
 
 
@@ -105,16 +106,18 @@ def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_t
     ))
 
 
-def test_condition_misclassified_samples_lower_than(tweet_emotion_train_test_textdata,
-                                                    tweet_emotion_train_test_predictions):
+def test_condition_misclassified_samples_lower_than_passes(tweet_emotion_train_test_textdata,
+                                                           tweet_emotion_train_test_predictions):
 
     # Arrange
     _, test_ds = tweet_emotion_train_test_textdata
     _, test_preds = tweet_emotion_train_test_predictions
 
+    threshold = 0.1
+    thresh_samples = round(np.ceil(threshold * len(test_ds)))
+
     check = ConfusionMatrixReport() \
-            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1) \
-            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.01)
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
 
     # Act
     result = check.run(test_ds, predictions=test_preds)
@@ -122,15 +125,52 @@ def test_condition_misclassified_samples_lower_than(tweet_emotion_train_test_tex
     # Assert
     assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=True,
-        name=f'Misclassified cell size lower than {format_number(0.1 * 100)}% of the total samples',
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
         details='Number of samples in each of the misclassified cells in the confusion matrix is '
-                f'lesser than the threshold ({0.1 * len(test_ds)}) based on the ' \
-                'given misclassified_samples_threshold ratio'
+                f'lesser than the threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio'
     ))
 
-    assert_that(result.conditions_results[1], equal_condition_result(
+
+def test_condition_misclassified_samples_lower_than_fails(tweet_emotion_train_test_textdata,
+                                                          tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    threshold = 0.01
+    thresh_samples = round(np.ceil(threshold * len(test_ds)))
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    confusion_matrix = result.value
+    m, n = confusion_matrix.shape[0], confusion_matrix.shape[1]
+
+    n_cells_above_thresh = 0
+    max_samples_in_cell_above_thresh = thresh_samples
+
+    # Looping over the confusion matrix and checking only the misclassified cells
+    for i in range(m):
+        for j in range(n):
+            # omitting the principal axis of the confusion matrix
+            if i != j:
+                n_samples = confusion_matrix[i][j]
+
+                if n_samples > thresh_samples:
+                    n_cells_above_thresh += 1
+
+                    if n_samples > max_samples_in_cell_above_thresh:
+                        max_samples_in_cell_above_thresh = n_samples
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=False,
-        name=f'Misclassified cell size lower than {format_number(0.01 * 100)}% of the total samples',
-        details='Found a cell with 23 misclassified samples which is greater than the threshold '
-                f'({0.01 * len(test_ds)}) based on the given misclassified_samples_threshold ratio'
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details = f'The confusion matrix has {n_cells_above_thresh} cells with samples greater than the '
+                   f'threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio. '
+                   f'The worst performing cell has {max_samples_in_cell_above_thresh} samples'
     ))

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -12,7 +12,10 @@
 
 from hamcrest import assert_that, close_to, equal_to
 
+from deepchecks.core.condition import ConditionCategory
 from deepchecks.nlp.checks.model_evaluation import ConfusionMatrixReport
+from deepchecks.utils.strings import format_number
+from tests.base.utils import equal_condition_result
 
 
 def test_defaults(text_classification_dataset_mock):
@@ -68,3 +71,66 @@ def test_run_tweet_emotion(tweet_emotion_train_test_textdata, tweet_emotion_trai
     # Assert
     assert_that(result.value[0][0], close_to(1160, 0.001))
     assert_that(result.value.shape[0], close_to(4, 0.001))
+
+
+def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_train_test_textdata,
+                                                                 tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=-0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=1.1)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got -0.1',
+        category=ConditionCategory.ERROR
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got 1.1',
+        category=ConditionCategory.ERROR
+    ))
+
+
+def test_condition_misclassified_samples_lower_than(tweet_emotion_train_test_textdata,
+                                                    tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.01)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=True,
+        name=f'Misclassified cell size lower than {format_number(0.1 * 100)}% of the total samples',
+        details='Number of samples in each of the misclassified cells in the confusion matrix is '
+                f'lesser than the threshold ({0.1 * len(test_ds)}) based on the ' \
+                'given misclassified_samples_threshold ratio'
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(0.01 * 100)}% of the total samples',
+        details='Found a cell with 23 misclassified samples which is greater than the threshold '
+                f'({0.01 * len(test_ds)}) based on the given misclassified_samples_threshold ratio'
+    ))

--- a/tests/nlp/checks/model_evaluation/weak_segment_performance_test.py
+++ b/tests/nlp/checks/model_evaluation/weak_segment_performance_test.py
@@ -28,7 +28,7 @@ def test_tweet_emotion(tweet_emotion_train_test_textdata, tweet_emotion_train_te
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details='Found a segment with Accuracy score of 0.305 in comparison to an average score of 0.708 in sampled data.',
+                               details='Found a segment with accuracy score of 0.305 in comparison to an average score of 0.708 in sampled data.',
                                name='The relative performance of weakest segment is greater than 80% of average model performance.')
     ))
 
@@ -49,7 +49,7 @@ def test_tweet_emotion_properties(tweet_emotion_train_test_textdata, tweet_emoti
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=True,
-                               details='Found a segment with Accuracy score of 0.525 in comparison to an average score of 0.708 in sampled data.',
+                               details='Found a segment with accuracy score of 0.525 in comparison to an average score of 0.708 in sampled data.',
                                name='The relative performance of weakest segment is greater than 70% of average model performance.')
     ))
 
@@ -65,12 +65,12 @@ def test_warning_of_n_top_columns(tweet_emotion_train_test_textdata, tweet_emoti
     metadata_check = MetadataSegmentsPerformance(n_top_columns=2)
 
     property_warning = 'Parameter n_top_properties is set to 3 to avoid long computation time. This means that the ' \
-                       'check will run on the first 3 properties. If you want to run on all properties, set ' \
+                       'check will run on 3 properties selected at random. If you want to run on all properties, set ' \
                        'n_top_properties to None. Alternatively, you can set parameter properties to a list of the ' \
                        'specific properties you want to run on.'
 
     metadata_warning = 'Parameter n_top_columns is set to 2 to avoid long computation time. This means that the check ' \
-                       'will run on the first 2 metadata columns. If you want to run on all metadata columns, set ' \
+                       'will run on 2 metadata columns selected at random. If you want to run on all metadata columns, set ' \
                        'n_top_columns to None. Alternatively, you can set parameter columns to a list of the specific ' \
                        'metadata columns you want to run on.'
 

--- a/tests/nlp/checks/train_test_validation/property_drift_test.py
+++ b/tests/nlp/checks/train_test_validation/property_drift_test.py
@@ -171,14 +171,13 @@ class TestMultiLabelClassification:
     def test_with_drift(self, dummy_multilabel_textdata_train_test):
         # Arrange
         train, test = dummy_multilabel_textdata_train_test
-        train.calculate_default_properties()
-        test.calculate_default_properties()
+        train.calculate_default_properties(ignore_properties=['Lexical Density','Unique Noun Count'])
+        test.calculate_default_properties(ignore_properties=['Lexical Density','Unique Noun Count'])
         check = PropertyDrift(min_samples=20).add_condition_drift_score_less_than(max_allowed_numeric_score=0.3,
                                                                                   max_allowed_categorical_score=0.3)
         # Act
         result = check.run(train_dataset=train, test_dataset=test)
         condition_results = check.conditions_decision(result)
-
         assert_that(condition_results, has_items(
             equal_condition_result(is_pass=False,
                                    details="Failed for 1 out of 6 columns.\nFound 1 "

--- a/tests/nlp/test_context.py
+++ b/tests/nlp/test_context.py
@@ -15,7 +15,7 @@ from deepchecks.core.errors import ValidationError
 from deepchecks.nlp import Suite
 from deepchecks.nlp.checks import LabelDrift, SingleDatasetPerformance
 
-CLASSIFICATION_ERROR_FORMAT = r'Check requires classification for Train to be ' \
+CLASSIFICATION_ERROR_FORMAT = r'Check requires classification predictions for Train to be ' \
                               r'either a sequence that can be cast to a 1D numpy array of shape' \
                               r' \(n_samples,\), or a sequence of sequences that can be cast to a 2D ' \
                               r'numpy array of shape \(n_samples, n_classes\) for the multilabel case.'

--- a/tests/nlp/test_suites.py
+++ b/tests/nlp/test_suites.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Test for the default suites"""
-from deepchecks.nlp.suites import full_suite
+from deepchecks.nlp.suites import model_evaluation, full_suite
 from tests.common import get_expected_results_length, validate_suite_result
 
 
@@ -25,6 +25,27 @@ def test_full_suite(tweet_emotion_train_test_textdata, tweet_emotion_train_test_
 
     # Act
     suite = full_suite(imaginary_kwarg='just to make sure all checks have kwargs in the init')
+    result = suite.run(**kwargs)
+
+    # Assert
+    length = get_expected_results_length(suite, kwargs)
+    validate_suite_result(result, length)
+
+
+def test_model_eval_suite_with_model_classes_argument(tweet_emotion_train_test_textdata,
+                                                      tweet_emotion_train_test_predictions,
+                                                      tweet_emotion_train_test_probabilities):
+    # Arrange
+    train_data, test_data = tweet_emotion_train_test_textdata
+    train_preds, test_preds = tweet_emotion_train_test_predictions
+    train_probas, test_probas = tweet_emotion_train_test_probabilities
+
+    kwargs = dict(train_dataset=train_data, test_dataset=test_data, train_predictions=train_preds,
+                  test_predictions=test_preds, train_probabilities=train_probas, test_probabilities=test_probas,
+                  model_classes=['anger', 'happiness', 'optimism', 'sadness'])
+
+    # Act
+    suite = model_evaluation()
     result = suite.run(**kwargs)
 
     # Assert

--- a/tests/nlp/test_text_data.py
+++ b/tests/nlp/test_text_data.py
@@ -156,11 +156,11 @@ def test_properties(text_classification_dataset_mock):
     dataset.calculate_default_properties(ignore_properties=['topic'] + LONG_RUN_PROPERTIES)
     properties = dataset.properties
     assert_that(properties.shape[0], equal_to(3))
-    assert_that(properties.shape[1], equal_to(6))
+    assert_that(properties.shape[1], equal_to(7))
     assert_that(properties.columns,
                 contains_exactly('Text Length', 'Average Word Length', 'Max Word Length', '% Special Characters',
-                                 'Sentiment', 'Subjectivity'))
-    assert_that(properties.iloc[0].values, contains_exactly(22, 3.6, 9, 0.0, 0.0, 0.0))
+                                 'Sentiment', 'Subjectivity', 'Lexical Density'))
+    assert_that(properties.iloc[0].values, contains_exactly(22, 3.6, 9, 0.0, 0.0, 0.0, 80.0 ))
 
 
 def test_set_metadata(text_classification_dataset_mock):

--- a/tests/nlp/utils/test_properties.py
+++ b/tests/nlp/utils/test_properties.py
@@ -13,16 +13,15 @@ from unittest.mock import patch
 
 import pytest
 from hamcrest import assert_that, close_to, equal_to
-
+import numpy as np
 from deepchecks.nlp.utils.text_properties import calculate_default_properties
-
 
 def mock_fn(*args, **kwargs):  # pylint: disable=unused-argument
     return [0] * 20_000
 
 
 @patch('deepchecks.nlp.utils.text_properties.run_available_kwargs', mock_fn)
-def test_calculate_default_properties():
+def test_calculate_toxicity_property():
     # Arrange
     raw_text = ['This is a test sentence.'] * 20_000
 
@@ -38,3 +37,35 @@ def test_calculate_default_properties():
 
     # Assert
     assert_that(result, equal_to({'Toxicity': [0] * 20_000}))
+
+
+def test_calculate_lexical_density_property(tweet_emotion_train_test_textdata):
+    
+    # Arrange
+    _, test = tweet_emotion_train_test_textdata
+    test_text = test.text
+
+    # Act
+    result = calculate_default_properties(test_text, include_properties=['Lexical Density'])[0]
+    result_none_text = calculate_default_properties([None], include_properties=['Lexical Density'])[0]
+
+    # Assert
+    assert_that(result['Lexical Density'][0: 10], equal_to([94.44, 93.75, 100.0, 91.67, 87.5, 100.0, 100.0, 100.0, 91.67, 91.67]))
+    assert_that(result_none_text['Lexical Density'], equal_to([np.nan]))
+
+
+def test_calculate_unique_noun_count_property(tweet_emotion_train_test_textdata):
+    
+    # Arrange
+    _, test = tweet_emotion_train_test_textdata
+    test_text = test.text
+
+    # Act
+    result = calculate_default_properties(test_text, include_properties=['Unique Noun Count'], 
+                                          include_long_calculation_properties=True)[0]
+    result_none_text = calculate_default_properties([None], include_properties=['Unique Noun Count'], 
+                                                    include_long_calculation_properties=True)[0]
+
+    # Assert
+    assert_that(result['Unique Noun Count'][0: 10], equal_to([9, 2, 3, 3, 4, 10, 4, 2, 7, 5]))
+    assert_that(result_none_text['Unique Noun Count'], equal_to([np.nan]))

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -12,9 +12,11 @@
 import numpy as np
 from hamcrest import assert_that, calling, greater_than, has_length, raises
 
+from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError, ModelValidationError
 from deepchecks.tabular.checks.model_evaluation import ConfusionMatrixReport
-
+from deepchecks.utils.strings import format_number
+from tests.base.utils import equal_condition_result
 
 def test_dataset_wrong_input():
     bad_dataset = 'wrong_input'
@@ -79,3 +81,60 @@ def test_model_info_object_not_normalize(iris_labeled_dataset, iris_adaboost):
     for i in range(len(result)):
         for j in range(len(result[i])):
             assert isinstance(result[i][j], np.int64)
+
+
+def test_condition_misclassified_samples_lower_than_raises_error(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=-0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=1.1)
+
+    result = check.run(test, clf)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got -0.1',
+        category=ConditionCategory.ERROR
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got 1.1',
+        category=ConditionCategory.ERROR
+    ))
+
+
+def test_condition_misclassified_samples_lower_than(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.05)
+
+    result = check.run(test, clf)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=True,
+        name=f'Misclassified cell size lower than {format_number(0.1 * 100)}% of the total samples',
+        details='Number of samples in each of the misclassified cells in the confusion matrix is '
+                f'lesser than the threshold ({0.1 * len(test)}) based on the ' \
+                'given misclassified_samples_threshold ratio'
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(0.05 * 100)}% of the total samples',
+        details='Found a cell with 4 misclassified samples which is greater than the threshold '
+                f'({0.05 * len(test)}) based on the given misclassified_samples_threshold ratio'
+    ))

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -15,7 +15,7 @@ from hamcrest import assert_that, calling, greater_than, has_length, raises
 from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError, ModelValidationError
 from deepchecks.tabular.checks.model_evaluation import ConfusionMatrixReport
-from deepchecks.utils.strings import format_number
+from deepchecks.utils.strings import format_number, format_percent
 from tests.base.utils import equal_condition_result
 
 def test_dataset_wrong_input():
@@ -112,29 +112,66 @@ def test_condition_misclassified_samples_lower_than_raises_error(iris_split_data
     ))
 
 
-def test_condition_misclassified_samples_lower_than(iris_split_dataset_and_model):
+def test_condition_misclassified_samples_lower_than_passes(iris_split_dataset_and_model):
     # Arrange
     _, test, clf = iris_split_dataset_and_model
 
+    threshold = 0.1
+    thresh_samples = round(np.ceil(threshold * len(test)))
+
     # Act
     check = ConfusionMatrixReport() \
-            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1) \
-            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.05)
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
 
     result = check.run(test, clf)
 
     # Assert
     assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=True,
-        name=f'Misclassified cell size lower than {format_number(0.1 * 100)}% of the total samples',
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
         details='Number of samples in each of the misclassified cells in the confusion matrix is '
-                f'lesser than the threshold ({0.1 * len(test)}) based on the ' \
+                f'lesser than the threshold ({thresh_samples}) based on the ' \
                 'given misclassified_samples_threshold ratio'
     ))
 
-    assert_that(result.conditions_results[1], equal_condition_result(
+
+def test_condition_misclassified_samples_lower_than_fails(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    threshold = 0.05
+    thresh_samples = round(np.ceil(threshold * len(test)))
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    result = check.run(test, clf)
+
+    confusion_matrix = result.value
+    m, n = confusion_matrix.shape[0], confusion_matrix.shape[1]
+
+    n_cells_above_thresh = 0
+    max_samples_in_cell_above_thresh = thresh_samples
+
+    # Looping over the confusion matrix and checking only the misclassified cells
+    for i in range(m):
+        for j in range(n):
+            # omitting the principal axis of the confusion matrix
+            if i != j:
+                n_samples = confusion_matrix[i][j]
+
+                if n_samples > thresh_samples:
+                    n_cells_above_thresh += 1
+
+                    if n_samples > max_samples_in_cell_above_thresh:
+                        max_samples_in_cell_above_thresh = n_samples
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=False,
-        name=f'Misclassified cell size lower than {format_number(0.05 * 100)}% of the total samples',
-        details='Found a cell with 4 misclassified samples which is greater than the threshold '
-                f'({0.05 * len(test)}) based on the given misclassified_samples_threshold ratio'
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details = f'The confusion matrix has {n_cells_above_thresh} cells with samples greater than the '
+                   f'threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio. '
+                   f'The worst performing cell has {max_samples_in_cell_above_thresh} samples'
     ))

--- a/tests/tabular/checks/model_evaluation/weak_segments_performance_test.py
+++ b/tests/tabular/checks/model_evaluation/weak_segments_performance_test.py
@@ -88,19 +88,19 @@ def test_segment_performance_iris_with_arguments(iris_split_dataset_and_model):
     assert_that(segments.iloc[0, 0], close_to(0.4, 0.01))
 
 
-def test_regression_categorical_features_avocado(avocado_split_dataset_and_model):
+def test_regression_categorical_features_avocado(avocado_split_dataset_and_model, set_numpy_seed):
     # Arrange
     _, val, model = avocado_split_dataset_and_model
 
     # Act
-    result = WeakSegmentsPerformance().run(val, model)
+    result = WeakSegmentsPerformance(random_state=42).run(val, model, feature_importance_timeout=0)
     segments = result.value['weak_segments_list']
 
     # Assert
-    assert_that(segments, has_length(7))
-    assert_that(segments[segments['Feature1'] == 'type']['Feature1 range'].iloc[0], equal_to(['organic']))
-    assert_that(segments[segments['Feature1'] == 'type'].iloc[0, 0], close_to(-0.362,0.01))
-    assert_that(segments.iloc[0, 0], close_to(-0.379, 0.01))
+    assert_that(segments, has_length(6))
+    assert_that(segments[segments['Feature1'] == 'type']['Feature1 Range'].iloc[0], equal_to(['organic']))
+    assert_that(segments[segments['Feature1'] == 'type'].iloc[0, 0], close_to(-0.283, 0.01))
+    assert_that(segments.iloc[0, 0], close_to(-0.353, 0.01))
 
 
 def test_classes_do_not_match_proba(kiss_dataset_and_model):

--- a/tests/tabular/checks/model_evaluation/weak_segments_performance_test.py
+++ b/tests/tabular/checks/model_evaluation/weak_segments_performance_test.py
@@ -16,6 +16,8 @@ from sklearn.metrics import f1_score, make_scorer
 
 from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.tabular.checks import WeakSegmentsPerformance
+from deepchecks.tabular.datasets.classification.phishing import (
+    load_data, load_fitted_model)
 from tests.base.utils import equal_condition_result
 
 
@@ -64,7 +66,7 @@ def test_segment_performance_iris_with_condition(iris_split_dataset_and_model):
         equal_condition_result(
             is_pass=False,
             name='The relative performance of weakest segment is greater than 80% of average model performance.',
-            details='Found a segment with Accuracy score of 0.333 in comparison to an average score of 0.92 in sampled '
+            details='Found a segment with accuracy score of 0.333 in comparison to an average score of 0.92 in sampled '
                     'data.')
     ))
     assert_that(segments, has_length(5))
@@ -73,19 +75,36 @@ def test_segment_performance_iris_with_condition(iris_split_dataset_and_model):
     assert_that(segments.iloc[0, 1], equal_to('petal width (cm)'))
 
 
-def test_segment_performance_iris_with_arguments(iris_split_dataset_and_model):
+def test_segment_performance_iris_score_per_sample(iris_split_dataset_and_model):
     # Arrange
     _, val, model = iris_split_dataset_and_model
-    loss_per_sample = pd.Series(np.arange(0, 1, 1/val.n_samples, dtype=float), index=val.data.index)
-    scorer = {'f1_score': make_scorer(f1_score, average='micro')}
+
+    score_per_sample = list(range(int(np.floor(val.n_samples / 2)))) + [1] * int(np.ceil(val.n_samples / 2))
+    score_per_sample = pd.Series(score_per_sample, index=val.data.index)
 
     # Act
-    result = WeakSegmentsPerformance(loss_per_sample=loss_per_sample, alternative_scorer=scorer).run(val, model)
+    result = WeakSegmentsPerformance(score_per_sample=score_per_sample).run(val, model)
     segments = result.value['weak_segments_list']
 
     # Assert
     assert_that(segments, any_of(has_length(5), has_length(6)))
-    assert_that(segments.iloc[0, 0], close_to(0.4, 0.01))
+    assert_that(segments.iloc[0, 0], close_to(1, 0.01))
+    assert_that(segments.columns[0], equal_to('Average Score Per Sample'))
+
+
+def test_segment_performance_iris_alternative_scorer(iris_split_dataset_and_model):
+    # Arrange
+    _, val, model = iris_split_dataset_and_model
+    scorer = {'F1': make_scorer(f1_score, average='micro')}
+
+    # Act
+    result = WeakSegmentsPerformance(alternative_scorer=scorer).run(val, model)
+    segments = result.value['weak_segments_list']
+
+    # Assert
+    assert_that(segments.columns[0], equal_to('F1 Score'))
+    assert_that(segments, any_of(has_length(5), has_length(6)))
+    assert_that(segments.iloc[0, 0], close_to(0.33, 0.01))
 
 
 def test_regression_categorical_features_avocado(avocado_split_dataset_and_model, set_numpy_seed):
@@ -112,7 +131,7 @@ def test_classes_do_not_match_proba(kiss_dataset_and_model):
     assert_that(calling(check.run).with_args(val, model, model_classes=[1, 2, 3, 4, 5, 6, 7]),
                 raises(DeepchecksValueError,
                        r'Predicted probabilities shape \(2, 3\) does not match the number of classes found in the '
-                       r'labels \[1, 2, 3, 4, 5, 6, 7\]\.'))
+                       r'labels: \[1, 2, 3, 4, 5, 6, 7\]\.'))
 
 
 def test_categorical_feat_target(adult_split_dataset_and_model):
@@ -130,3 +149,24 @@ def test_categorical_feat_target(adult_split_dataset_and_model):
 
     # Assert
     assert_that(segments, has_length(10))
+
+
+# This test is similar to the one in the plot file
+def test_subset_of_columns(phishing_split_dataset_and_model):
+    # Arrange
+    _, val, model = phishing_split_dataset_and_model
+    scorer = {'f1': make_scorer(f1_score, average='micro')}
+    check = WeakSegmentsPerformance(columns=['urlLength', 'numTitles', 'ext', 'entropy'],
+                                    alternative_scorer=scorer,
+                                    segment_minimum_size_ratio=0.03,
+                                    categorical_aggregation_threshold=0.05)
+
+    # Act
+    result = check.run(val, model)
+    segments = result.value['weak_segments_list']
+
+    # Assert
+    assert_that(segments, has_length(6))
+    assert_that(segments[segments['Feature1'] == 'ext']['Feature1 Range'].iloc[1][0], equal_to('html'))
+    assert_that(segments[segments['Feature1'] == 'ext'].iloc[1, 0], close_to(0.966, 0.01))
+    assert_that(segments.iloc[0, 0], close_to(0.959, 0.01))

--- a/tests/tabular/conftest.py
+++ b/tests/tabular/conftest.py
@@ -36,7 +36,7 @@ from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksBaseError
 from deepchecks.core.suite import BaseSuite, SuiteResult
 from deepchecks.tabular import Dataset
-from deepchecks.tabular.datasets.classification import adult
+from deepchecks.tabular.datasets.classification import adult, phishing
 from deepchecks.tabular.datasets.regression import avocado
 from deepchecks.utils.logger import set_verbosity
 
@@ -253,6 +253,7 @@ def iris_dataset_no_label(iris):
     iris = iris.drop('target', axis=1)
     return Dataset(iris)
 
+
 @pytest.fixture(scope='session')
 def iris_dataset_single_class_labeled(iris):
     """Return Iris dataset modified to a binary label as Dataset object."""
@@ -267,6 +268,14 @@ def adult_split_dataset_and_model() -> Tuple[Dataset, Dataset, Pipeline]:
     """Return Adult train and val datasets and trained RandomForestClassifier model."""
     train_ds, test_ds = adult.load_data(as_train_test=True)
     model = adult.load_fitted_model()
+    return train_ds, test_ds, model
+
+
+@pytest.fixture(scope='session')
+def phishing_split_dataset_and_model() -> Tuple[Dataset, Dataset, Pipeline]:
+    """Return Phishing train and val datasets and trained RandomForestClassifier model."""
+    train_ds, test_ds = phishing.load_data(as_train_test=True)
+    model = phishing.load_fitted_model()
     return train_ds, test_ds, model
 
 
@@ -497,6 +506,7 @@ def drifted_regression_label() -> Tuple[Dataset, Dataset]:
 
     return train_ds, test_ds
 
+
 @pytest.fixture(scope='session')
 def adult_no_split():
     ds = adult.load_data(as_train_test=False)
@@ -514,6 +524,7 @@ def df_with_mixed_datatypes_and_missing_values():
         'target': [0, 1, 0, 1, 0]
     }, index=['a', 'b', 'c', 'd', 'e'])
     return df
+
 
 @pytest.fixture(scope='session')
 def missing_test_classes_binary_dataset_and_model():

--- a/tests/vision/checks/model_evaluation/weak_segments_performance_test.py
+++ b/tests/vision/checks/model_evaluation/weak_segments_performance_test.py
@@ -27,7 +27,7 @@ def test_detection_defaults(coco_visiondata_train):
 
 
 def test_detection_condition(coco_visiondata_train):
-    check = WeakSegmentsPerformance().add_condition_segments_relative_performance_greater_than(0.8)
+    check = WeakSegmentsPerformance().add_condition_segments_relative_performance_greater_than()
 
     result = check.run(coco_visiondata_train)
     condition_result = result.conditions_results
@@ -35,10 +35,10 @@ def test_detection_condition(coco_visiondata_train):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(
-            is_pass=True,
-            name='The relative performance of weakest segment is greater than 20% of average model performance.',
-            details='Found a segment with mean IoU score of 0.382 in comparison to an average score of 0.691 in '
-                    'sampled data.')
+            is_pass=False,
+            name='The relative performance of weakest segment is greater than 80% of average model performance.',
+            details='Found a segment with mean iou of 0.435 in comparison to an average score of 0.691 '
+                    'in sampled data.')
     ))
 
 
@@ -50,7 +50,7 @@ def test_classification_defaults(mnist_visiondata_train):
     result = check.run(mnist_visiondata_train)
 
     # Assert
-    assert_that(result.value['avg_score'], close_to(0.082, 0.001))
+    assert_that(result.value['avg_score'], close_to(-0.082, 0.001))
 
 
 def test_segmentation_defaults(segmentation_coco_visiondata_test):


### PR DESCRIPTION
Closes https://github.com/deepchecks/deepchecks/issues/2443.

**Description:**

Added **"Misclassified samples lower than"** condition to the Confusion Matrix Report Tabular & NLP Checks.

**Task:**

I made the following changes as suggested in the issue description.

1. Added the Condition function to the 'confusion_matrix_abstract.py' file.
2. Added the above condition to the Confusion Matrix Report Tabular & NLP Checks.
3. Updated the documentation and added relevant tests for the condition.
4. Added 'misclassified' to the 'spelling-allowlist.txt' file.