### PR TITLE
Feat/Add Misclassified samples lower than condition to Confusion Matrix Report

### DIFF
--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -13,7 +13,9 @@ import numpy as np
 
 from deepchecks.core import CheckResult
 from deepchecks.nlp import Context, SingleDatasetCheck
-from deepchecks.utils.abstracts.confusion_matrix_abstract import run_confusion_matrix_check
+from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
+                                                                  run_confusion_matrix_check)
+from deepchecks.utils.strings import format_percent
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -63,3 +65,21 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_pred = np.array(context.model.predict(dataset)).reshape(len(y_true), )
 
         return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+
+    def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
+        """Add condition - Misclassified samples lower than threshold.
+
+        Condition validates if the misclassified cell size/samples are lower than the threshold based on the
+        `misclassified_samples_threshold` parameter.
+
+        Parameters
+        ----------
+        misclassified_samples_threshold: float, default: 0.20
+            Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
+        """
+        return self.add_condition(
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} '
+            'of the total samples',
+            misclassified_samples_lower_than_condition,
+            misclassified_samples_threshold=misclassified_samples_threshold
+        )

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -13,7 +13,9 @@ import numpy as np
 
 from deepchecks.core import CheckResult
 from deepchecks.tabular import Context, SingleDatasetCheck
-from deepchecks.utils.abstracts.confusion_matrix_abstract import run_confusion_matrix_check
+from deepchecks.utils.abstracts.confusion_matrix_abstract import (misclassified_samples_lower_than_condition,
+                                                                  run_confusion_matrix_check)
+from deepchecks.utils.strings import format_percent
 
 __all__ = ['ConfusionMatrixReport']
 
@@ -60,3 +62,21 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_pred = np.array(context.model.predict(dataset.features_columns)).reshape(len(y_true), )
 
         return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+
+    def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
+        """Add condition - Misclassified samples lower than threshold.
+
+        Condition validates if the misclassified cell size/samples are lower than the threshold based on the
+        `misclassified_samples_threshold` parameter.
+
+        Parameters
+        ----------
+        misclassified_samples_threshold: float, default: 0.20
+            Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
+        """
+        return self.add_condition(
+            f'Misclassified cell size lower than {format_percent(misclassified_samples_threshold)} '
+            'of the total samples',
+            misclassified_samples_lower_than_condition,
+            misclassified_samples_threshold=misclassified_samples_threshold
+        )

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -18,7 +18,7 @@ from sklearn.metrics import confusion_matrix
 
 from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.core import CheckResult
-from deepchecks.core.errors import ValidationError
+from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.utils.strings import format_number_if_not_nan, format_percent
 
 __all__ = ['create_confusion_matrix_figure', 'run_confusion_matrix_check']
@@ -98,7 +98,7 @@ def misclassified_samples_lower_than_condition(value: pd.DataFrame,
 
     Raises
     ------
-    ValidationError
+    DeepchecksValueError
         if the value of `misclassified_samples_threshold` parameter is not between 0 - 1 inclusive.
 
     Returns
@@ -110,7 +110,7 @@ def misclassified_samples_lower_than_condition(value: pd.DataFrame,
         are more than the `misclassified_samples_threshold` ratio
     """
     if misclassified_samples_threshold < 0 or misclassified_samples_threshold > 1:
-        raise ValidationError(
+        raise DeepchecksValueError(
            'Condition requires the parameter "misclassified_samples_threshold" '
            f'to be between 0 and 1 inclusive but got {misclassified_samples_threshold}'
         )

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -30,13 +30,13 @@ def run_confusion_matrix_check(y_pred: np.ndarray, y_true: np.ndarray, with_disp
     total_classes = sorted([str(x) for x in set(y_pred).union(set(y_true))])
     result = confusion_matrix(y_true, y_pred)
 
-    # For accessing the class names from the condition
-    result = pd.DataFrame(result, index=total_classes, columns=total_classes)
-
     if with_display:
         fig = create_confusion_matrix_figure(result, total_classes, normalize_display)
     else:
         fig = None
+
+    # For accessing the class names from the condition
+    result = pd.DataFrame(result, index=total_classes, columns=total_classes)
 
     return CheckResult(result, display=fig)
 

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -15,7 +15,9 @@ import numpy as np
 import plotly.graph_objects as go
 from sklearn.metrics import confusion_matrix
 
+from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.core import CheckResult
+from deepchecks.core.errors import ValidationError
 from deepchecks.utils.strings import format_number_if_not_nan
 
 __all__ = ['create_confusion_matrix_figure', 'run_confusion_matrix_check']
@@ -77,3 +79,77 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
     fig.update_yaxes(title='True value', type='category', constrain='domain', autorange='reversed')
 
     return fig
+
+
+def misclassified_samples_lower_than_condition(value: np.ndarray,
+                                               misclassified_samples_threshold: float) -> ConditionResult:
+    """Condition function that checks if the misclassified samples in the confusion matrix is below threshold.
+
+    Parameters
+    ----------
+    value: np.ndarray
+        Value of the confusion matrix
+    misclassified_samples_threshold: float
+        Ratio of samples to be used for comparison in the condition (Value should be between 0 - 1 inclusive)
+
+    Raises
+    ------
+    ValidationError
+        if the value of `misclassified_samples_threshold` parameter is not between 0 - 1 inclusive.
+
+    Returns
+    -------
+    ConditionResult
+        - ConditionCategory.PASS, if all the misclassified samples in the confusion
+        matrix are less than `misclassified_samples_threshold` ratio
+        - ConditionCategory.FAIL, if the misclassified samples in the confusion matrix
+        are more than the `misclassified_samples_threshold` ratio
+    """
+    if misclassified_samples_threshold < 0 or misclassified_samples_threshold > 1:
+        raise ValidationError(
+           'Condition requires the parameter "misclassified_samples_threshold" '
+           f'to be between 0 and 1 inclusive but got {misclassified_samples_threshold}'
+        )
+
+    # Computing the total number of samples from the confusion matrix
+    total_samples = np.sum(value)
+
+    # Number of threshold samples based on the 'misclassified_samples_threshold' parameter
+    thresh_samples = round(np.ceil(misclassified_samples_threshold * total_samples))
+
+    # m is the number of rows in the confusion matrix and
+    # n is the number of columns in the confusion matrix
+    m, n = value.shape[0], value.shape[1]
+
+    # Variables to keep track of cells above 'thresh_samples'
+    n_cells_above_thresh = 0
+    max_samples_in_cell_above_thresh = thresh_samples
+
+    # Looping over the confusion matrix and checking only the misclassified cells
+    for i in range(m):
+        for j in range(n):
+            # omitting the principal axis of the confusion matrix
+            if i != j:
+                n_samples = value[i][j]
+
+                if n_samples > thresh_samples:
+                    n_cells_above_thresh += 1
+
+                    if n_samples > max_samples_in_cell_above_thresh:
+                        max_samples_in_cell_above_thresh = n_samples
+
+    # There are misclassified cells in the confusion matrix with samples more than 'thresh_samples'
+    if n_cells_above_thresh > 0:
+        details = f'The confusion matrix has {n_cells_above_thresh} cells with samples ' \
+                  f'greater than the threshold ({thresh_samples}) based on the ' \
+                  'given misclassified_samples_threshold ratio. The worst performing cell ' \
+                  f'has {max_samples_in_cell_above_thresh} samples'
+
+        return ConditionResult(ConditionCategory.FAIL, details)
+
+    # No cell has more than 'thresh_samples' misclassified samples
+    details = 'Number of samples in each of the misclassified cells in the ' \
+              f'confusion matrix is lesser than the threshold ({thresh_samples}) ' \
+              'based on the given misclassified_samples_threshold ratio'
+
+    return ConditionResult(ConditionCategory.PASS, details)

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -76,7 +76,7 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
     fig.update_layout(title=plot_title)
     fig.update_layout(height=600)
     fig.update_xaxes(title='Predicted Value', type='category', scaleanchor='y', constrain='domain')
-    fig.update_yaxes(title='True value', type='category', constrain='domain', autorange='reversed')
+    fig.update_yaxes(title='True Value', type='category', constrain='domain', autorange='reversed')
 
     return fig
 

--- a/docs/source/checks/nlp/model_evaluation/plot_confusion_matrix_report.py
+++ b/docs/source/checks/nlp/model_evaluation/plot_confusion_matrix_report.py
@@ -45,3 +45,18 @@ result = check.run(tweets_dataset, predictions=predictions)
 result.show()
 
 #%%
+# Define a condition
+# ==================
+# We can define our check a condition that will validate if all the misclassified
+# cells/samples in the confusion matrix is below a certain threshold. Using the 
+# ``misclassified_samples_threshold`` argument, we can specify what percentage of the total samples
+# our condition should use to validate the misclassified cells.
+
+# Let's add a condition and re-run the check:
+
+check = ConfusionMatrixReport()
+check.add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.1)
+result = check.run(tweets_dataset, predictions=predictions)
+result.show()
+
+#%%

--- a/docs/source/checks/tabular/model_evaluation/plot_confusion_matrix_report.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_confusion_matrix_report.py
@@ -53,3 +53,18 @@ result = check.run(ds, clf)
 result.show()
 
 #%%
+# Define a condition
+# ==================
+# We can define our check a condition that will validate if all the misclassified
+# cells/samples in the confusion matrix is below a certain threshold. Using the 
+# ``misclassified_samples_threshold`` argument, we can specify what percentage of the total samples
+# our condition should use to validate the misclassified cells.
+
+# Let's add a condition and re-run the check:
+
+check = ConfusionMatrixReport()
+check.add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=0.2)
+result = check.run(ds, clf)
+result.show()
+
+#%%

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -149,3 +149,4 @@ nltk
 Tokenize
 spacy
 tokenizers
+misclassified

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -100,7 +100,7 @@ def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_t
     assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
-        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
                 'to be between 0 and 1 inclusive but got -0.1',
         category=ConditionCategory.ERROR
     ))
@@ -108,7 +108,7 @@ def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_t
     assert_that(result.conditions_results[1], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
-        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
                 'to be between 0 and 1 inclusive but got 1.1',
         category=ConditionCategory.ERROR
     ))

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -10,9 +10,13 @@
 #
 """Test for the nlp SingleDatasetPerformance check"""
 
+import numpy as np
 from hamcrest import assert_that, close_to, equal_to
 
+from deepchecks.core.condition import ConditionCategory
 from deepchecks.nlp.checks.model_evaluation import ConfusionMatrixReport
+from deepchecks.utils.strings import format_number, format_percent
+from tests.base.utils import equal_condition_result
 
 
 def test_defaults(text_classification_dataset_mock):
@@ -68,3 +72,105 @@ def test_run_tweet_emotion(tweet_emotion_train_test_textdata, tweet_emotion_trai
     # Assert
     assert_that(result.value[0][0], close_to(1160, 0.001))
     assert_that(result.value.shape[0], close_to(4, 0.001))
+
+
+def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_train_test_textdata,
+                                                                 tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=-0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=1.1)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got -0.1',
+        category=ConditionCategory.ERROR
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got 1.1',
+        category=ConditionCategory.ERROR
+    ))
+
+
+def test_condition_misclassified_samples_lower_than_passes(tweet_emotion_train_test_textdata,
+                                                           tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    threshold = 0.1
+    thresh_samples = round(np.ceil(threshold * len(test_ds)))
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=True,
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details='Number of samples in each of the misclassified cells in the confusion matrix is '
+                f'lesser than the threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio'
+    ))
+
+
+def test_condition_misclassified_samples_lower_than_fails(tweet_emotion_train_test_textdata,
+                                                          tweet_emotion_train_test_predictions):
+
+    # Arrange
+    _, test_ds = tweet_emotion_train_test_textdata
+    _, test_preds = tweet_emotion_train_test_predictions
+
+    threshold = 0.01
+    thresh_samples = round(np.ceil(threshold * len(test_ds)))
+
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    # Act
+    result = check.run(test_ds, predictions=test_preds)
+
+    confusion_matrix = result.value
+    m, n = confusion_matrix.shape[0], confusion_matrix.shape[1]
+
+    n_cells_above_thresh = 0
+    max_samples_in_cell_above_thresh = thresh_samples
+
+    # Looping over the confusion matrix and checking only the misclassified cells
+    for i in range(m):
+        for j in range(n):
+            # omitting the principal axis of the confusion matrix
+            if i != j:
+                n_samples = confusion_matrix[i][j]
+
+                if n_samples > thresh_samples:
+                    n_cells_above_thresh += 1
+
+                    if n_samples > max_samples_in_cell_above_thresh:
+                        max_samples_in_cell_above_thresh = n_samples
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details = f'The confusion matrix has {n_cells_above_thresh} cells with samples greater than the '
+                   f'threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio. '
+                   f'The worst performing cell has {max_samples_in_cell_above_thresh} samples'
+    ))

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -122,7 +122,6 @@ def test_condition_misclassified_samples_lower_than_passes(tweet_emotion_train_t
     _, test_preds = tweet_emotion_train_test_predictions
 
     threshold = 0.1
-    thresh_samples = round(np.ceil(threshold * len(test_ds)))
 
     check = ConfusionMatrixReport() \
             .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -100,7 +100,7 @@ def test_condition_misclassified_samples_lower_than_raises_error(iris_split_data
     assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
-        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
                 'to be between 0 and 1 inclusive but got -0.1',
         category=ConditionCategory.ERROR
     ))
@@ -108,7 +108,7 @@ def test_condition_misclassified_samples_lower_than_raises_error(iris_split_data
     assert_that(result.conditions_results[1], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
-        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
                 'to be between 0 and 1 inclusive but got 1.1',
         category=ConditionCategory.ERROR
     ))

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -119,7 +119,6 @@ def test_condition_misclassified_samples_lower_than_passes(iris_split_dataset_an
     _, test, clf = iris_split_dataset_and_model
 
     threshold = 0.1
-    thresh_samples = round(np.ceil(threshold * len(test)))
 
     # Act
     check = ConfusionMatrixReport() \

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -12,8 +12,11 @@
 import numpy as np
 from hamcrest import assert_that, calling, greater_than, has_length, raises
 
+from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError, ModelValidationError
 from deepchecks.tabular.checks.model_evaluation import ConfusionMatrixReport
+from deepchecks.utils.strings import format_number, format_percent
+from tests.base.utils import equal_condition_result
 
 
 def test_dataset_wrong_input():
@@ -79,3 +82,98 @@ def test_model_info_object_not_normalize(iris_labeled_dataset, iris_adaboost):
     for i in range(len(result)):
         for j in range(len(result[i])):
             assert isinstance(result[i][j], np.int64)
+
+
+
+def test_condition_misclassified_samples_lower_than_raises_error(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=-0.1) \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=1.1)
+
+    result = check.run(test, clf)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got -0.1',
+        category=ConditionCategory.ERROR
+    ))
+
+    assert_that(result.conditions_results[1], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
+        details='Exception in condition: ValidationError: Condition requires the parameter "misclassified_samples_threshold" '
+                'to be between 0 and 1 inclusive but got 1.1',
+        category=ConditionCategory.ERROR
+    ))
+
+
+def test_condition_misclassified_samples_lower_than_passes(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    threshold = 0.1
+    thresh_samples = round(np.ceil(threshold * len(test)))
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    result = check.run(test, clf)
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=True,
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details='Number of samples in each of the misclassified cells in the confusion matrix is '
+                f'lesser than the threshold ({thresh_samples}) based on the ' \
+                'given misclassified_samples_threshold ratio'
+    ))
+
+
+def test_condition_misclassified_samples_lower_than_fails(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    threshold = 0.05
+    thresh_samples = round(np.ceil(threshold * len(test)))
+
+    # Act
+    check = ConfusionMatrixReport() \
+            .add_condition_misclassified_samples_lower_than_condition(misclassified_samples_threshold=threshold)
+
+    result = check.run(test, clf)
+
+    confusion_matrix = result.value
+    m, n = confusion_matrix.shape[0], confusion_matrix.shape[1]
+
+    n_cells_above_thresh = 0
+    max_samples_in_cell_above_thresh = thresh_samples
+
+    # Looping over the confusion matrix and checking only the misclassified cells
+    for i in range(m):
+        for j in range(n):
+            # omitting the principal axis of the confusion matrix
+            if i != j:
+                n_samples = confusion_matrix[i][j]
+
+                if n_samples > thresh_samples:
+                    n_cells_above_thresh += 1
+
+                    if n_samples > max_samples_in_cell_above_thresh:
+                        max_samples_in_cell_above_thresh = n_samples
+
+    # Assert
+    assert_that(result.conditions_results[0], equal_condition_result(
+        is_pass=False,
+        name=f'Misclassified cell size lower than {format_percent(threshold)} of the total samples',
+        details = f'The confusion matrix has {n_cells_above_thresh} cells with samples greater than the '
+                   f'threshold ({thresh_samples}) based on the given misclassified_samples_threshold ratio. '
+                   f'The worst performing cell has {max_samples_in_cell_above_thresh} samples'
+    ))


### PR DESCRIPTION
Closes https://github.com/deepchecks/deepchecks/issues/2443.

**Description:**

Added **"Misclassified samples lower than"** condition to the Confusion Matrix Report Tabular & NLP Checks.

**Task:**

I made the following changes as suggested in the issue description.

1. Added the Condition function to the 'confusion_matrix_abstract.py' file.
2. Added the above condition to the Confusion Matrix Report Tabular & NLP Checks.
3. Updated the documentation and added relevant tests for the condition.
4. Added 'misclassified' to the 'spelling-allowlist.txt' file.