### PR TITLE
Added label_classes to TextData

### DIFF
--- a/deepchecks/nlp/context.py
+++ b/deepchecks/nlp/context.py
@@ -27,10 +27,8 @@ from deepchecks.nlp.text_data import TextData
 from deepchecks.nlp.utils.data_inference import infer_observed_and_model_labels
 from deepchecks.tabular.metric_utils import DeepcheckScorer, get_default_scorers
 from deepchecks.tabular.utils.task_type import TaskType as TabularTaskType
-from deepchecks.utils.docref import doclink
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.typing import BasicModel
-from deepchecks.utils.validation import is_sequence_not_str
 
 __all__ = [
     'Context',
@@ -297,7 +295,7 @@ class Context(BaseContext):
                                             model_classes=model_classes, task_type=self.task_type)
 
         # Temporary fix, remove when context + model_classes is better sorted out:
-        if label_classes is None and self.model_classes is not None:
+        if label_classes is None and self.model_classes:
             train_dataset.set_label_classes(self.model_classes)
             if test_dataset:
                 test_dataset.set_label_classes(self.model_classes)

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 def validate_class_list(class_list: Sequence[str], parameter_name: str):
-    """Validates model_classes argument."""
+    """Validate list of label classes."""
     if class_list is not None:
         if (not is_sequence_not_str(class_list)) or len(class_list) == 0:
             raise DeepchecksValueError(f'{parameter_name} must be a non-empty sequence')

--- a/deepchecks/nlp/input_validations.py
+++ b/deepchecks/nlp/input_validations.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from deepchecks.core.errors import DeepchecksValueError, ValidationError
 from deepchecks.nlp.task_type import TaskType, TTextLabel
+from deepchecks.utils.docref import doclink
 from deepchecks.utils.logger import get_logger
 from deepchecks.utils.metrics import is_label_none
 from deepchecks.utils.type_inference import infer_categorical_features
@@ -24,6 +25,18 @@ from deepchecks.utils.validation import is_sequence_not_str
 
 if TYPE_CHECKING:
     from deepchecks.nlp.text_data import TextData
+
+
+def validate_class_list(class_list: Sequence[str], parameter_name: str):
+    """Validates model_classes argument."""
+    if class_list is not None:
+        if (not is_sequence_not_str(class_list)) or len(class_list) == 0:
+            raise DeepchecksValueError(f'{parameter_name} must be a non-empty sequence')
+        if sorted(class_list) != class_list:
+            supported_models_link = doclink(
+                'nlp-supported-predictions-format',
+                template='For more information please refer to the Supported Tasks guide {link}')
+            raise DeepchecksValueError(f'Received unsorted {parameter_name}. {supported_models_link}')
 
 
 def validate_tokenized_text(tokenized_text: Optional[Sequence[Sequence[str]]]):

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -18,9 +18,9 @@ import numpy as np
 import pandas as pd
 
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError
-from deepchecks.nlp.input_validations import (validate_length_and_calculate_column_types, validate_length_and_type,
-                                              validate_modify_label, validate_raw_text, validate_tokenized_text,
-                                              validate_class_list)
+from deepchecks.nlp.input_validations import (validate_class_list, validate_length_and_calculate_column_types,
+                                              validate_length_and_type, validate_modify_label, validate_raw_text,
+                                              validate_tokenized_text)
 from deepchecks.nlp.task_type import TaskType, TTextLabel
 from deepchecks.nlp.utils.text_embeddings import calculate_default_embeddings
 from deepchecks.nlp.utils.text_properties import calculate_default_properties

--- a/deepchecks/nlp/text_data.py
+++ b/deepchecks/nlp/text_data.py
@@ -507,16 +507,18 @@ class TextData:
                                        'to run the requested functionalities')
         return self._label
 
-    @property
-    def label_for_display(self) -> TTextLabel:
-        """Return the label defined in the dataset.
+    def label_for_display(self, model_classes: list = None) -> TTextLabel:
+        """Return the label defined in the dataset in a format that can be displayed.
 
         Returns
         -------
         TTextLabel
         """
         if self.is_multi_label_classification():
-            return [np.argwhere(x == 1).flatten().tolist() for x in self.label]
+            ret_labels = [np.argwhere(x == 1).flatten().tolist() for x in self.label]
+            if model_classes:
+                ret_labels = [[model_classes[i] for i in x] for x in ret_labels]
+            return ret_labels
         else:
             return self.label
 

--- a/deepchecks/nlp/utils/nlp_plot.py
+++ b/deepchecks/nlp/utils/nlp_plot.py
@@ -258,7 +258,7 @@ def two_datasets_scatter_plot(plot_title: str, plot_data: pd.DataFrame, train_da
 
     plot_data['Dataset'] = [dataset_names[0]] * len(train_dataset) + [dataset_names[1]] * len(test_dataset)
     if train_dataset.has_label():
-        plot_data['Label'] = np.concatenate([train_dataset.label_for_display, test_dataset.label_for_display])
+        plot_data['Label'] = np.concatenate([train_dataset.label_for_display(), test_dataset.label_for_display()])
     else:
         plot_data['Label'] = None
     plot_data['Sample'] = np.concatenate([train_dataset.text, test_dataset.text])

--- a/deepchecks/nlp/utils/nlp_plot.py
+++ b/deepchecks/nlp/utils/nlp_plot.py
@@ -258,7 +258,7 @@ def two_datasets_scatter_plot(plot_title: str, plot_data: pd.DataFrame, train_da
 
     plot_data['Dataset'] = [dataset_names[0]] * len(train_dataset) + [dataset_names[1]] * len(test_dataset)
     if train_dataset.has_label():
-        plot_data['Label'] = np.concatenate([train_dataset.label_for_display(), test_dataset.label_for_display()])
+        plot_data['Label'] = list(train_dataset.label_for_display) + list(test_dataset.label_for_display)
     else:
         plot_data['Label'] = None
     plot_data['Sample'] = np.concatenate([train_dataset.text, test_dataset.text])

--- a/tests/nlp/test_text_data.py
+++ b/tests/nlp/test_text_data.py
@@ -170,12 +170,12 @@ def test_label_for_display():
     assert_that(result[0], contains_exactly(0, 2))
 
     # Act
-    dataset.set_label_classes(['PER', 'ORG', 'GEO'])
+    dataset.set_label_classes(['GEO', 'ORG', 'PER'])
     result = dataset.label_for_display
 
     # Assert
     assert_that(len(result), equal_to(3))
-    assert_that(result[0], contains_exactly('PER', 'GEO'))
+    assert_that(result[0], contains_exactly('GEO', 'PER'))
 
 
 def test_properties(text_classification_dataset_mock):

--- a/tests/nlp/test_text_data.py
+++ b/tests/nlp/test_text_data.py
@@ -147,6 +147,35 @@ def test_head_functionality():
     assert_that(list(result.index), contains_exactly(0, 1))
 
 
+def test_label_for_display():
+    # Arrange
+    text = ['a', 'b b b', 'c c c c']
+    single_label = ['PER', 'ORG', 'GEO']
+    multi_label = np.array([[1, 0, 1], [0, 1, 0], [1, 1, 1]])
+
+    # Act
+    dataset = TextData(raw_text=text, task_type='text_classification', label=single_label)
+    result = dataset.label_for_display()
+
+    # Assert
+    assert_that(len(result), equal_to(3))
+    assert_that(result, contains_exactly('PER', 'ORG', 'GEO'))
+
+    # Act
+    dataset = TextData(raw_text=text, task_type='text_classification', label=multi_label)
+    result = dataset.label_for_display()
+
+    # Assert
+    assert_that(len(result), equal_to(3))
+    assert_that(result[0], contains_exactly(0, 2))
+
+    # Act
+    result = dataset.label_for_display(model_classes=['PER', 'ORG', 'GEO'])
+
+    # Assert
+    assert_that(len(result), equal_to(3))
+    assert_that(result[0], contains_exactly('PER', 'GEO'))
+
 def test_properties(text_classification_dataset_mock):
     # Arrange
     dataset = text_classification_dataset_mock

--- a/tests/nlp/test_text_data.py
+++ b/tests/nlp/test_text_data.py
@@ -155,7 +155,7 @@ def test_label_for_display():
 
     # Act
     dataset = TextData(raw_text=text, task_type='text_classification', label=single_label)
-    result = dataset.label_for_display()
+    result = dataset.label_for_display
 
     # Assert
     assert_that(len(result), equal_to(3))
@@ -163,18 +163,20 @@ def test_label_for_display():
 
     # Act
     dataset = TextData(raw_text=text, task_type='text_classification', label=multi_label)
-    result = dataset.label_for_display()
+    result = dataset.label_for_display
 
     # Assert
     assert_that(len(result), equal_to(3))
     assert_that(result[0], contains_exactly(0, 2))
 
     # Act
-    result = dataset.label_for_display(model_classes=['PER', 'ORG', 'GEO'])
+    dataset.set_label_classes(['PER', 'ORG', 'GEO'])
+    result = dataset.label_for_display
 
     # Assert
     assert_that(len(result), equal_to(3))
     assert_that(result[0], contains_exactly('PER', 'GEO'))
+
 
 def test_properties(text_classification_dataset_mock):
     # Arrange


### PR DESCRIPTION
In the future, we'll probably deprecate model_classes from .run() function. For now, in order to be able to display the label names for multilabel cases, added label_classes to the TextData object.