### PR TITLE
data duplicates takes a long time for long docs

### DIFF
--- a/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
+++ b/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
@@ -117,7 +117,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
             'Text': dataset.text,
         })
 
-        return df, labels
+        return df
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
         """Run check."""
@@ -132,7 +132,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
         # Reduce dataset by first checking on truncated strings
         truncated_samples = [cut_string(x) for x in dataset.text]
 
-        df, labels = self._get_df_and_labels(dataset, truncated_samples)
+        df = self._get_df_and_labels(dataset, truncated_samples)
 
         ambiguous_samples_hashes = self._get_conflicting_indices(df)
         indices_to_reinspect = df[df['hash'].isin(ambiguous_samples_hashes)].index.to_list()
@@ -146,7 +146,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
             return CheckResult(value=result_value)
 
         # Now that we have narrowed down the dataset, we can check on full strings
-        df, labels = self._get_df_and_labels(dataset, dataset.text)
+        df = self._get_df_and_labels(dataset, dataset.text)
 
         ambiguous_samples_hashes = self._get_conflicting_indices(df)
 

--- a/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
+++ b/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
@@ -133,10 +133,9 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
         dataset = dataset.copy(rows_to_use=indices_to_reinspect)
 
         if len(dataset) == 0:
-            result_value = {
-                'percent_of_conflicting_samples': 0,
-                'conflicting_samples': None
-            }
+            result_value = dict(percent_of_conflicting_samples=0, conflicting_samples=pd.DataFrame(
+                index=pd.MultiIndex(levels=[[], [], []], codes=[[], [], []], names=['Duplicate', 'Sample ID', 'Label']),
+                columns=['Text']))
             return CheckResult(value=result_value)
 
         # Now that we have narrowed down the dataset, we can check on full strings

--- a/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
+++ b/deepchecks/nlp/checks/data_integrity/conflicting_labels.py
@@ -20,7 +20,7 @@ from deepchecks.nlp import Context, SingleDatasetCheck
 from deepchecks.nlp._shared_docs import docstrings
 from deepchecks.nlp.task_type import TaskType
 from deepchecks.nlp.text_data import TextData
-from deepchecks.nlp.utils.text import hash_samples, normalize_samples
+from deepchecks.nlp.utils.text import cut_string, hash_samples, normalize_samples
 from deepchecks.utils.abstracts.conflicting_labels import ConflictingLabelsAbstract
 from deepchecks.utils.other import to_ordional_enumeration
 from deepchecks.utils.strings import format_list
@@ -46,17 +46,17 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
     """
 
     def __init__(
-        self,
-        ignore_case: bool = True,
-        remove_punctuation: bool = True,
-        normalize_unicode: bool = True,
-        remove_stopwords: bool = True,
-        ignore_whitespace: bool = False,
-        n_to_show: int = 5,
-        n_samples: int = 10_000_000,
-        random_state: int = 42,
-        max_text_length_for_display: int = 30,
-        **kwargs
+            self,
+            ignore_case: bool = True,
+            remove_punctuation: bool = True,
+            normalize_unicode: bool = True,
+            remove_stopwords: bool = True,
+            ignore_whitespace: bool = False,
+            n_to_show: int = 5,
+            n_samples: int = 10_000_000,
+            random_state: int = 42,
+            max_text_length_for_display: int = 30,
+            **kwargs
     ):
         super().__init__(**kwargs)
         self.ignore_case = ignore_case
@@ -82,22 +82,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
     def _truncate_text(self, x: str) -> str:
         return truncate_string(x, self.max_text_length_for_display)
 
-    def run_logic(self, context: Context, dataset_kind) -> CheckResult:
-        """Run check."""
-        dataset = context.get_data_by_kind(dataset_kind)
-        dataset = dataset.sample(self.n_samples, random_state=self.random_state, drop_na_label=True)
-        dataset = t.cast(TextData, dataset)
-        samples = dataset.text
-        n_of_samples = len(samples)
-
-        if n_of_samples == 0:
-            raise DeepchecksValueError('Dataset cannot be empty')
-
-        samples_hashes = hash_samples(normalize_samples(
-            dataset.text,
-            **self._text_normalization_kwargs
-        ))
-
+    def _get_labels(self, dataset):
         if dataset.task_type is TaskType.TOKEN_CLASSIFICATION:
             labels = [tuple(t.cast(t.Sequence[t.Any], it)) for it in dataset.label]
         elif dataset.is_multi_label_classification():
@@ -106,6 +91,61 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
             labels = dataset.label
         else:
             raise DeepchecksValueError(f'Unknown task type - {dataset.task_type}')
+        return labels
+
+    @staticmethod
+    def _get_conflicting_indices(df: pd.DataFrame):
+        by_hash = df.loc[:, ['hash', 'Label']].groupby(['hash'], dropna=False)
+        count_labels = lambda x: len(set(x.to_list()))
+        n_of_labels_per_sample = by_hash['Label'].aggregate(count_labels)
+
+        ambiguous_samples_hashes = n_of_labels_per_sample[n_of_labels_per_sample > 1]
+        return frozenset(ambiguous_samples_hashes.index.to_list())
+
+    def run_logic(self, context: Context, dataset_kind) -> CheckResult:
+        """Run check."""
+        dataset = context.get_data_by_kind(dataset_kind)
+        dataset = dataset.sample(self.n_samples, random_state=self.random_state, drop_na_label=True)
+        dataset = t.cast(TextData, dataset)
+        n_of_samples = len(dataset)
+
+        if n_of_samples == 0:
+            raise DeepchecksValueError('Dataset cannot be empty')
+
+        # Reduce dataset by first checking on truncated strings
+        truncated_samples = [cut_string(x) for x in dataset.text]
+        truncated_samples_hashes = hash_samples(normalize_samples(
+            truncated_samples,
+            **self._text_normalization_kwargs
+        ))
+
+        labels = self._get_labels(dataset)
+
+        df = pd.DataFrame({
+            'hash': truncated_samples_hashes,
+            'Sample ID': dataset.get_original_text_indexes(),
+            'Label': labels,
+            'Text': dataset.text,
+        })
+
+        ambiguous_samples_hashes = self._get_conflicting_indices(df)
+        indices_to_reinspect = df[df['hash'].isin(ambiguous_samples_hashes)].index.to_list()
+        dataset = dataset.copy(rows_to_use=indices_to_reinspect)
+
+        if len(dataset) == 0:
+            result_value = {
+                'percent_of_conflicting_samples': 0,
+                'conflicting_samples': None
+            }
+            return CheckResult(value=result_value)
+
+        # Now that we have narrowed down the dataset, we can check on full strings
+        samples_hashes = hash_samples(normalize_samples(
+            dataset.text,
+            **self._text_normalization_kwargs
+        ))
+
+        labels = self._get_labels(dataset)
 
         df = pd.DataFrame({
             'hash': samples_hashes,
@@ -114,12 +154,7 @@ class ConflictingLabels(SingleDatasetCheck, ConflictingLabelsAbstract):
             'Text': dataset.text,
         })
 
-        by_hash = df.loc[:, ['hash', 'Label']].groupby(['hash'], dropna=False)
-        count_labels = lambda x: len(set(x.to_list()))
-        n_of_labels_per_sample = by_hash['Label'].aggregate(count_labels)
-
-        ambiguous_samples_hashes = n_of_labels_per_sample[n_of_labels_per_sample > 1]
-        ambiguous_samples_hashes = frozenset(ambiguous_samples_hashes.index.to_list())
+        ambiguous_samples_hashes = self._get_conflicting_indices(df)
 
         ambiguous_samples = df[df['hash'].isin(ambiguous_samples_hashes)].copy()
         num_of_ambiguous_samples = ambiguous_samples['Text'].count()

--- a/deepchecks/nlp/checks/train_test_validation/train_test_sample_mix.py
+++ b/deepchecks/nlp/checks/train_test_validation/train_test_sample_mix.py
@@ -102,7 +102,7 @@ class TrainTestSamplesMix(TrainTestCheck, TrainTestSamplesMixAbstract):
 
         hash_intersection = set(train_sample_hashes).intersection(set(test_sample_hashes))
         df = pd.concat([test_df, train_df])
-        return df['hash'].isin(hash_intersection), df, test_df
+        return df['hash'].isin(hash_intersection), df
 
     def run_logic(self, context: Context) -> CheckResult:
         """Run check."""
@@ -146,7 +146,7 @@ class TrainTestSamplesMix(TrainTestCheck, TrainTestSamplesMixAbstract):
             }
             return CheckResult(value=result_value)
 
-        bool_df, df, test_df = self._get_duplicate_indices(train, test, train_samples, test_samples)
+        bool_df, df = self._get_duplicate_indices(train, test, train_samples, test_samples)
         df = df[bool_df]
 
         n_of_test_duplicates = df[df['Dataset'] == 'test']['Text'].count()

--- a/deepchecks/nlp/checks/train_test_validation/train_test_sample_mix.py
+++ b/deepchecks/nlp/checks/train_test_validation/train_test_sample_mix.py
@@ -11,6 +11,7 @@
 """Module contains train-test samples mix check."""
 import typing as t
 
+import numpy as np
 import pandas as pd
 
 from deepchecks.core import CheckResult
@@ -18,7 +19,7 @@ from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.nlp import Context, TrainTestCheck
 from deepchecks.nlp._shared_docs import docstrings
 from deepchecks.nlp.text_data import TextData
-from deepchecks.nlp.utils.text import hash_samples, normalize_samples
+from deepchecks.nlp.utils.text import cut_string, hash_samples, normalize_samples
 from deepchecks.utils.abstracts.train_test_samples_mix import TrainTestSamplesMixAbstract
 from deepchecks.utils.other import to_ordional_enumeration
 from deepchecks.utils.strings import format_list, format_percent
@@ -80,20 +81,8 @@ class TrainTestSamplesMix(TrainTestCheck, TrainTestSamplesMixAbstract):
     def _truncate_text(self, x: str) -> str:
         return truncate_string(x, self.max_text_length_for_display)
 
-    def run_logic(self, context: Context) -> CheckResult:
-        """Run check."""
-        train = context.train.sample(self.n_samples, random_state=self.random_state)
-        test = context.test.sample(self.n_samples, random_state=self.random_state)
-        train = t.cast(TextData, train)
-        test = t.cast(TextData, test)
-        train_samples = t.cast(t.Sequence[str], train.text)
-        test_samples = t.cast(t.Sequence[str], test.text)
-
-        if len(train_samples) == 0:
-            raise DeepchecksValueError('Train dataset cannot be empty')
-        if len(test_samples) == 0:
-            raise DeepchecksValueError('Test dataset cannot be empty')
-
+    def _get_duplicate_indices(self, train: TextData, test: TextData,
+                               train_samples: t.Sequence[str], test_samples: t.Sequence[str]):
         normalization_kwargs = self._text_normalization_kwargs
         train_sample_hashes = hash_samples(normalize_samples(train_samples, **normalization_kwargs))
         test_sample_hashes = hash_samples(normalize_samples(test_samples, **normalization_kwargs))
@@ -113,7 +102,49 @@ class TrainTestSamplesMix(TrainTestCheck, TrainTestSamplesMixAbstract):
 
         hash_intersection = set(train_sample_hashes).intersection(set(test_sample_hashes))
         df = pd.concat([test_df, train_df])
-        df = df[df['hash'].isin(hash_intersection)]
+        return df['hash'].isin(hash_intersection), df, train_df, test_df
+
+    def run_logic(self, context: Context) -> CheckResult:
+        """Run check."""
+        train = context.train.sample(self.n_samples, random_state=self.random_state)
+        test = context.test.sample(self.n_samples, random_state=self.random_state)
+        train = t.cast(TextData, train)
+        test = t.cast(TextData, test)
+        train_samples = t.cast(t.Sequence[str], train.text)
+        test_samples = t.cast(t.Sequence[str], test.text)
+
+        if len(train_samples) == 0:
+            raise DeepchecksValueError('Train dataset cannot be empty')
+        if len(test_samples) == 0:
+            raise DeepchecksValueError('Test dataset cannot be empty')
+
+        # First run on truncated dataset
+        train_truncated = [cut_string(x) for x in train_samples]
+        test_truncated = [cut_string(x) for x in test_samples]
+
+        duplicate_bool_df = self._get_duplicate_indices(train, test, train_truncated, test_truncated)[0]
+        train_indices_reinspect = duplicate_bool_df.iloc[:len(train_samples)]
+        train_indices_reinspect = np.where(train_indices_reinspect.values)[0]
+        test_indices_reinspect = duplicate_bool_df.iloc[len(train_samples):]
+        test_indices_reinspect = np.where(test_indices_reinspect.values)[0]
+
+        # keep only samples that where found to be duplicates after cut_string
+        train = train.copy(train_indices_reinspect.tolist())
+        test = test.copy(test_indices_reinspect.tolist())
+
+        train_samples = t.cast(t.Sequence[str], train.text)
+        test_samples = t.cast(t.Sequence[str], test.text)
+
+        if (len(train_samples) == 0) or (len(test_samples) == 0):
+            result_value = {
+                'ratio': 0,
+                'duplicates': None
+            }
+            return CheckResult(value=result_value)
+
+        bool_df, df, train_df, test_df = self._get_duplicate_indices(train, test, train_samples, test_samples)
+        df = df[bool_df]
+
         n_of_test_duplicates = df[df['Dataset'] == 'test']['Text'].count()
         n_of_test_samples = test_df.shape[0]
         duplicates_ratio = n_of_test_duplicates / n_of_test_samples
@@ -126,9 +157,7 @@ class TrainTestSamplesMix(TrainTestCheck, TrainTestSamplesMixAbstract):
 
         result_value = {
             'ratio': duplicates_ratio,
-            'duplicates': result_df,
-            'train': train_df,
-            'test': test_df
+            'duplicates': result_df
         }
 
         if context.with_display is False or duplicates_ratio == 0:

--- a/deepchecks/nlp/utils/text.py
+++ b/deepchecks/nlp/utils/text.py
@@ -117,6 +117,15 @@ def normalize_text(
     return text_sample
 
 
+def cut_string(input_str: str, cut_length: int = 200) -> str:
+    """Cut a string to 200 characters, but cut only at whitespaces."""
+    if len(input_str) > cut_length:
+        index = input_str.find(' ', cut_length)
+        if index != -1:
+            return input_str[:index]
+    return input_str
+
+
 def normalize_samples(
     text_samples: t.Sequence[str],
     *,

--- a/tests/nlp/checks/data_integrity/conflicting_labels_test.py
+++ b/tests/nlp/checks/data_integrity/conflicting_labels_test.py
@@ -277,3 +277,25 @@ def assert_display_table(display: t.Sequence[t.Any]):
     assert_that(table.index.names,equal_to(["Observed Labels", "Sample IDs"]))
     assert_that(table.columns,equal_to(["Text"]))
 
+
+def test_inspect_long_samples():
+    # Arrange
+    dataset = TextData(
+        label=[0, 1, 2],
+        task_type="text_classification",
+        raw_text=[
+            ' '.join(["aa"] * 500),
+            ' '.join(["aa"] * 500),
+            ' '.join(["aa"] * 600),
+        ]
+    )
+    check = ConflictingLabels()
+
+    # Act
+    result = check.run(dataset=dataset)
+
+    # Assert
+    assert_that(result.value, has_entries({
+        "percent_of_conflicting_samples": close_to(0.66, 0.01),
+        "conflicting_samples": instance_of(pd.DataFrame),
+    }))

--- a/tests/nlp/checks/data_integrity/text_duplicates_test.py
+++ b/tests/nlp/checks/data_integrity/text_duplicates_test.py
@@ -196,3 +196,24 @@ def assert_display(display: t.Sequence[t.Any]):
         table.columns,
         equal_to(["Text"])
     )
+
+
+def test_inspect_long_samples():
+    # Arrange
+    dataset = TextData(raw_text=[
+        ''.join(['aa'] * 500),
+        ''.join(['aa'] * 500),
+        ''.join(['aa'] * 600)
+    ])
+
+    check = TextDuplicates()
+
+    # Act
+    result = check.run(dataset=dataset)
+
+    # Assert
+    assert_that(result, instance_of(CheckResult))
+    assert_that(result.value, has_entries({
+        "percent_of_duplicates": close_to(0.33, 0.01),
+        "duplicates": instance_of(pd.DataFrame)
+    }))

--- a/tests/nlp/checks/train_test_validation/train_test_samples_mix_test.py
+++ b/tests/nlp/checks/train_test_validation/train_test_samples_mix_test.py
@@ -257,3 +257,31 @@ def assert_display(display: t.Sequence[t.Any]):
     table = display[1]
     assert_that(table.index.names, equal_to(["Train Sample IDs", "Test Sample IDs"]))
     assert_that(table.columns.to_list(), equal_to(["Test Text Sample", "Number of Test Duplicates"]))
+
+
+def test_long_samples():
+    # Arrange
+    train = TextData(
+        raw_text=[
+            ' '.join(['aa'] * 500),
+            ' '.join(['bb'] * 500),
+            ' '.join(['cc'] * 500)
+        ]
+    )
+    test = TextData(
+        raw_text=[
+            ' '.join(['aa'] * 500),
+            ' '.join(['dd'] * 500),
+            ' '.join(['aa'] * 600)
+        ]
+    )
+
+    # Act
+    check = TrainTestSamplesMix()
+
+    # Assert
+    result = check.run(train_dataset=train, test_dataset=test)
+    assert_that(result.value, has_entries({
+        "ratio": close_to(0.333, 0.001),
+        "duplicates": instance_of(pd.DataFrame),
+    }))


### PR DESCRIPTION
Solution (idea by @nirhutnik) is to further inspect only samples identified as duplicates when looking at their first 200 characters.  