### PR TITLE
Fix the property drift check name and others various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ tweet_emotion_*.csv
 
 # docs build files
 docs/source/_build
+docs/html
+docs/doctrees
 
 # build folders of sphinx gallery
 docs/source/general/usage/customizations/auto_examples/
@@ -119,6 +121,8 @@ docs/source/vision/auto_tutorials
 
 docs/source/user-guide/tabular/auto_quickstarts
 docs/source/user-guide/vision/auto_quickstarts
+
+docs/source/checks_gallery
 
 # build artificats from running docs (vision, nlp, wandb export)
 docs/source/vision/tutorials/quickstarts/*.html

--- a/deepchecks/analytics/anonymous_telemetry.py
+++ b/deepchecks/analytics/anonymous_telemetry.py
@@ -44,7 +44,7 @@ def validate_latest_version():
             is_on_latest = result.read().decode() == 'True'
             if not is_on_latest:
                 get_logger().warning('You are using deepchecks version %s, however a newer version is available.'
-                                     'Deepchecks is frequently updated with major improvements. You should consider '
+                                     ' Deepchecks is frequently updated with major improvements. You should consider '
                                      'upgrading via the "python -m pip install --upgrade deepchecks" command.',
                                      deepchecks.__version__)
         except Exception:  # pylint: disable=broad-except

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -153,6 +153,11 @@ class UnknownTokens(SingleDatasetCheck):
             # Batch tokenization
             # ------------------
             # Needed to avoid warning when used after loading a hub dataset
+            # We divert the printing to stdout (done by the rust code within the HuggingFace tokenizer)
+            # into this filter, that will filter out any print containging the str 'huggingface/tokenizers'
+            # This warning printout is activated when running this check after loading a HuggingFace dataset,
+            # and is irrelevant to us because we're not forking the process.
+            # see: https://github.com/huggingface/transformers/issues/5486
             with contextlib.redirect_stdout(PrintFilter(sys.stdout)):
                 tokenized_samples = self.tokenizer(list(samples), return_offsets_mapping=True,
                                                    is_split_into_words=False, truncation=False)

--- a/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
+++ b/deepchecks/nlp/checks/data_integrity/unknown_tokens.py
@@ -153,7 +153,7 @@ class UnknownTokens(SingleDatasetCheck):
             # ------------------
             # Needed to avoid warning when used after loading a hub dataset
             # We divert the printing to stdout (done by the rust code within the HuggingFace tokenizer)
-            # into this filter, that will filter out any print containging the str 'huggingface/tokenizers'
+            # into this filter, that will filter out any print containing the str 'huggingface/tokenizers'
             # This warning printout is activated when running this check after loading a HuggingFace dataset,
             # and is irrelevant to us because we're not forking the process.
             # see: https://github.com/huggingface/transformers/issues/5486

--- a/deepchecks/nlp/checks/train_test_validation/property_drift.py
+++ b/deepchecks/nlp/checks/train_test_validation/property_drift.py
@@ -151,5 +151,5 @@ class PropertyDrift(TrainTestCheck, FeatureDriftAbstract):
         return CheckResult(
             value=results,
             display=displays,
-            header='Properties Drift'
+            header='Property Drift'
         )

--- a/docs/source/nlp/tutorials/quickstarts/plot_multi_label_classification.py
+++ b/docs/source/nlp/tutorials/quickstarts/plot_multi_label_classification.py
@@ -96,7 +96,9 @@ dataset.properties.head(2)
 #
 # Deepchecks comes with a set of pre-built suites that can be used to run a set of checks on your data, alongside
 # with their default conditions and thresholds. You can read more about customizing and creating your own suites in the
-# :ref:`Customizations Guide <general__customizations>`.
+# :ref:`Customizations Guide <general__customizations>`. In this guide we'll be using 3 suites - the data integrity
+# suite, the train test validation suite and the model evaluation suite. You can also run all the checks at once using
+# the :mod:`full_suite <deepchecks.nlp.suites>`.
 #
 # Data Integrity
 # --------------

--- a/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
+++ b/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
@@ -47,7 +47,8 @@ Setting Up
 Load Data
 ---------
 For the purpose of this guide, we'll use a small subset of the
-`tweet emotion <https://github.com/cardiffnlp/tweeteval>`__ dataset:
+`tweet emotion <https://github.com/cardiffnlp/tweeteval>`__ dataset. This dataset contains tweets and their
+corresponding emotion - Anger, Happiness, Optimism, and Sadness.
 
 """
 

--- a/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
+++ b/docs/source/nlp/tutorials/quickstarts/plot_text_classification.py
@@ -115,7 +115,9 @@ train.properties.head(2)
 #
 # Deepchecks comes with a set of pre-built suites that can be used to run a set of checks on your data, alongside
 # with their default conditions and thresholds. You can read more about customizing and creating your own suites in the
-# :ref:`Customizations Guide <general__customizations>`.
+# :ref:`Customizations Guide <general__customizations>`. In this guide we'll be using 3 suites - the data integrity
+# suite, the train test validation suite and the model evaluation suite. You can also run all the checks at once using
+# the :mod:`full_suite <deepchecks.nlp.suites>`.
 #
 # Data Integrity
 # --------------

--- a/spelling-allowlist.txt
+++ b/spelling-allowlist.txt
@@ -155,3 +155,4 @@ misclassified
 Uncomment
 dimensionality
 tokenization
+huggingface


### PR DESCRIPTION
This PR was originally intended to only fix the printed name of the property drift check, but was hijacked to do other things as well:
1. Avoid an annoying printout by the Fast Tokenizers
2. Fix a print in the analytics section
3. Small improvements to the quickstarts.
4. Small fix to the gitignore