### PR TITLE
Use second column level as type indicator in properties

### DIFF
--- a/requirements/nlp-requirements.txt
+++ b/requirements/nlp-requirements.txt
@@ -2,3 +2,4 @@ seqeval>=1.0.0
 nltk>=3.4.0,<=3.6.7
 textblob>=0.17.1
 umap-learn
+sentence_transformers>=2.0.0


### PR DESCRIPTION
The property dataframe has two column level - first is the propety name and second is the data type
In csv this means the two first rows are these two column headers