### PR TITLE
make sure the value "None" is kept as str when loading airbnb

### DIFF
--- a/deepchecks/tabular/datasets/regression/airbnb.py
+++ b/deepchecks/tabular/datasets/regression/airbnb.py
@@ -131,8 +131,10 @@ def load_data(data_format: str = 'Dataset', as_train_test: bool = True, modify_t
     train_data, test_data : Tuple[Union[deepchecks.Dataset, pd.DataFrame],Union[deepchecks.Dataset, pd.DataFrame]
         tuple if as_train_test = True. Tuple of two objects represents the dataset split to train and test sets.
     """
-    train = pd.read_csv(_TRAIN_DATA_URL, index_col=0).drop(_predictions, axis=1)
-    test = pd.read_csv(_TEST_DATA_URL, index_col=0).drop(_predictions, axis=1)
+    train = pd.read_csv(_TRAIN_DATA_URL, index_col=0, na_values=['', 'NaN'], keep_default_na=False
+                        ).drop(_predictions, axis=1)
+    test = pd.read_csv(_TEST_DATA_URL, index_col=0, na_values=['', 'NaN'], keep_default_na=False
+                       ).drop(_predictions, axis=1)
 
     if data_size is not None:
         if data_size < len(train):


### PR DESCRIPTION
Without this, in pandas 2.0.2 the value "None" in room_type is read as a null