### PR TITLE
Changed model_classes logger warning and made sure tabular only warns once

### DIFF
--- a/deepchecks/nlp/context.py
+++ b/deepchecks/nlp/context.py
@@ -343,7 +343,9 @@ class Context(BaseContext):
             # If in infer_observed_and_model_labels we didn't find classes on model, or user didn't pass any,
             # then using the observed
             self._model_classes = self._observed_classes
-            get_logger().warning('Could not find model\'s classes, using the observed classes')
+            get_logger().warning('Could not find model\'s classes, using the observed classes. '
+                                 'In order to make sure the classes used by the model are inferred correctly, '
+                                 'please use the model_classes argument')
         return self._model_classes
 
     @property

--- a/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
+++ b/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
@@ -81,7 +81,7 @@ class PartialBoostingModel:
             self.model = model
 
     @classmethod
-    def _raise_not_suppored_model_error(cls, model_class):
+    def _raise_not_supported_model_error(cls, model_class):
         if model_class != '_DummyModel':
             raise ModelValidationError(cls._UNSUPPORTED_MODEL_ERROR.format(
                 supported_models=cls._SUPPORTED_MODELS,
@@ -100,7 +100,7 @@ class PartialBoostingModel:
         elif self.model_class == 'CatBoostClassifier':
             return self.model.predict_proba(x, ntree_end=self.step)
         else:
-            self._raise_not_suppored_model_error(self.model_class)
+            self._raise_not_supported_model_error(self.model_class)
 
     def predict(self, x):
         if self.model_class in ['AdaBoostClassifier', 'GradientBoostingClassifier', 'AdaBoostRegressor',
@@ -113,7 +113,7 @@ class PartialBoostingModel:
         elif self.model_class in ['CatBoostClassifier', 'CatBoostRegressor']:
             return self.model.predict(x, ntree_end=self.step)
         else:
-            self._raise_not_suppored_model_error(self.model_class)
+            self._raise_not_supported_model_error(self.model_class)
 
     @classmethod
     def n_estimators(cls, model):
@@ -129,7 +129,7 @@ class PartialBoostingModel:
         elif model_class in ['CatBoostClassifier', 'CatBoostRegressor']:
             return model.tree_count_
         else:
-            cls._raise_not_suppored_model_error(model_class=model_class)
+            cls._raise_not_supported_model_error(model_class=model_class)
 
 
 class BoostingOverfit(TrainTestCheck):

--- a/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
+++ b/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
@@ -130,10 +130,6 @@ class PartialBoostingModel:
             return model.tree_count_
         else:
             cls._raise_not_suppored_model_error(model_class=model_class)
-            # raise ModelValidationError(cls._UNSUPPORTED_MODEL_ERROR.format(
-            #     supported_models=cls._SUPPORTED_MODELS,
-            #     model_type=model_class
-            # ))
 
 
 class BoostingOverfit(TrainTestCheck):

--- a/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
+++ b/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
@@ -32,10 +32,12 @@ __all__ = ['BoostingOverfit']
 class PartialBoostingModel:
     """Wrapper for boosting models which limits the number of estimators being used in the prediction."""
 
-    _UNSUPPORTED_MODEL_ERROR = (
-        'Check is relevant for Boosting models of type '
-        '{supported_models}, but received model of type {model_type}'
-    )
+    _UNSUPPORTED_MODEL_ERROR = \
+        'Check is relevant for Boosting models of type {supported_models}, but received model of type {model_type}'
+
+    _NO_MODEL_ERROR = \
+        'Check is relevant only when receiving the model, but predictions/probabilities were received instead. ' \
+        'In order to use this check, please pass the model to the run() method.'
 
     _SUPPORTED_CLASSIFICATION_MODELS = (
         'AdaBoostClassifier',
@@ -78,6 +80,16 @@ class PartialBoostingModel:
         else:
             self.model = model
 
+    @classmethod
+    def _raise_not_suppored_model_error(cls, model_class):
+        if model_class != '_DummyModel':
+            raise ModelValidationError(cls._UNSUPPORTED_MODEL_ERROR.format(
+                supported_models=cls._SUPPORTED_MODELS,
+                model_type=model_class
+            ))
+        else:
+            raise ModelValidationError(cls._NO_MODEL_ERROR)
+
     def predict_proba(self, x):
         if self.model_class in ['AdaBoostClassifier', 'GradientBoostingClassifier']:
             return self.model.predict_proba(x)
@@ -88,10 +100,7 @@ class PartialBoostingModel:
         elif self.model_class == 'CatBoostClassifier':
             return self.model.predict_proba(x, ntree_end=self.step)
         else:
-            raise ModelValidationError(self._UNSUPPORTED_MODEL_ERROR.format(
-                supported_models=self._SUPPORTED_CLASSIFICATION_MODELS,
-                model_type=self.model_class
-            ))
+            self._raise_not_suppored_model_error(self.model_class)
 
     def predict(self, x):
         if self.model_class in ['AdaBoostClassifier', 'GradientBoostingClassifier', 'AdaBoostRegressor',
@@ -104,10 +113,7 @@ class PartialBoostingModel:
         elif self.model_class in ['CatBoostClassifier', 'CatBoostRegressor']:
             return self.model.predict(x, ntree_end=self.step)
         else:
-            raise ModelValidationError(self._UNSUPPORTED_MODEL_ERROR.format(
-                supported_models=self._SUPPORTED_MODELS,
-                model_type=self.model_class
-            ))
+            self._raise_not_suppored_model_error(self.model_class)
 
     @classmethod
     def n_estimators(cls, model):
@@ -123,10 +129,11 @@ class PartialBoostingModel:
         elif model_class in ['CatBoostClassifier', 'CatBoostRegressor']:
             return model.tree_count_
         else:
-            raise ModelValidationError(cls._UNSUPPORTED_MODEL_ERROR.format(
-                supported_models=cls._SUPPORTED_MODELS,
-                model_type=model_class
-            ))
+            cls._raise_not_suppored_model_error(model_class=model_class)
+            # raise ModelValidationError(cls._UNSUPPORTED_MODEL_ERROR.format(
+            #     supported_models=cls._SUPPORTED_MODELS,
+            #     model_type=model_class
+            # ))
 
 
 class BoostingOverfit(TrainTestCheck):

--- a/deepchecks/tabular/context.py
+++ b/deepchecks/tabular/context.py
@@ -291,8 +291,11 @@ class Context(BaseContext):
         """Return ordered list of possible label classes for classification tasks or None for regression."""
         if self._model_classes is None and self.task_type in (TaskType.BINARY, TaskType.MULTICLASS):
             # If in infer_task_type we didn't find classes on model, or user didn't pass any, then using the observed
-            get_logger().warning('Could not find model\'s classes, using the observed classes')
-            return self.observed_classes
+            get_logger().warning('Could not find model\'s classes, using the observed classes. '
+                                 'In order to make sure the classes used by the model are inferred correctly, '
+                                 'please use the model_classes argument')
+            self._model_classes = self.observed_classes
+
         return self._model_classes
 
     @property


### PR DESCRIPTION
1. Fixed recurring model_classes error (kept sending them when running suite)
2. Fixed error message in BoostingOverfit (if DummyModel was used, the error message was unclear)