### PR TITLE
Not raise DeepchecksProcessError for UnderAnnotated + WeakSegments

### DIFF
--- a/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
+++ b/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
@@ -42,8 +42,7 @@ class UnderAnnotatedSegments(SingleDatasetCheck, WeakSegmentAbstract):
     def __init__(self, segment_by: str, columns: Union[Hashable, List[Hashable], None],
                  ignore_columns: Union[Hashable, List[Hashable], None], n_top_features: int,
                  segment_minimum_size_ratio: float, n_samples: int,  n_to_show: int,
-                 categorical_aggregation_threshold: float, annotation_ratio_threshold: float,
-                 **kwargs):
+                 categorical_aggregation_threshold: float, **kwargs):
         super().__init__(**kwargs)
         self.segment_by = segment_by
         self.columns = columns
@@ -53,7 +52,7 @@ class UnderAnnotatedSegments(SingleDatasetCheck, WeakSegmentAbstract):
         self.n_samples = n_samples
         self.n_to_show = n_to_show
         self.categorical_aggregation_threshold = categorical_aggregation_threshold
-        self.annotation_ratio_threshold = annotation_ratio_threshold
+        self.annotation_ratio_threshold = ANNOTATION_RATIO_THRESHOLD
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
         """Run check."""
@@ -249,8 +248,6 @@ class UnderAnnotatedPropertySegments(UnderAnnotatedSegments):
         Maximum number of samples to use for this check.
     n_to_show : int , default: 3
         number of segments with the weakest performance to show.
-    annotation_ratio_threshold : float , default: 95.0
-        The threshold ranging from 1 to 100 for the under annotated property segement check to run.
     categorical_aggregation_threshold : float , default: 0.05
         In each categorical column, categories with frequency below threshold will be merged into "Other" category.
     """
@@ -263,7 +260,6 @@ class UnderAnnotatedPropertySegments(UnderAnnotatedSegments):
                  n_samples: int = 10_000,
                  categorical_aggregation_threshold: float = 0.05,
                  n_to_show: int = 3,
-                 annotation_ratio_threshold: float = ANNOTATION_RATIO_THRESHOLD,
                  **kwargs):
         super().__init__(segment_by='properties',
                          columns=properties,
@@ -273,7 +269,6 @@ class UnderAnnotatedPropertySegments(UnderAnnotatedSegments):
                          n_samples=n_samples,
                          n_to_show=n_to_show,
                          categorical_aggregation_threshold=categorical_aggregation_threshold,
-                         annotation_ratio_threshold=annotation_ratio_threshold,
                          **kwargs)
 
 
@@ -304,8 +299,6 @@ class UnderAnnotatedMetaDataSegments(UnderAnnotatedSegments):
         Maximum number of samples to use for this check.
     n_to_show : int , default: 3
         number of segments with the weakest performance to show.
-    annotation_ratio_threshold : float , default: 95.0
-        The threshold ranging from 1 to 100 for the under annotated metatdata segement check to run.
     categorical_aggregation_threshold : float , default: 0.05
         In each categorical column, categories with frequency below threshold will be merged into "Other" category.
     """
@@ -318,7 +311,6 @@ class UnderAnnotatedMetaDataSegments(UnderAnnotatedSegments):
                  n_samples: int = 10_000,
                  categorical_aggregation_threshold: float = 0.05,
                  n_to_show: int = 3,
-                 annotation_ratio_threshold: float = ANNOTATION_RATIO_THRESHOLD,
                  **kwargs):
         super().__init__(segment_by='metadata',
                          columns=columns,
@@ -328,5 +320,4 @@ class UnderAnnotatedMetaDataSegments(UnderAnnotatedSegments):
                          n_samples=n_samples,
                          n_to_show=n_to_show,
                          categorical_aggregation_threshold=categorical_aggregation_threshold,
-                         annotation_ratio_threshold=annotation_ratio_threshold,
                          **kwargs)

--- a/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
+++ b/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
@@ -67,7 +67,7 @@ class UnderAnnotatedSegments(SingleDatasetCheck, WeakSegmentAbstract):
         if annotation_ratio > MAX_ANNOTATION_RATIO:
             display_msg = f'Under annotated {self.segment_by} segments check is skipped since your data ' \
                           f'annotation ratio is > {MAX_ANNOTATION_RATIO * 100}%.'
-            return CheckResult(value={'error': display_msg}, display=[display_msg])
+            return CheckResult(value={'message': display_msg}, display=[display_msg])
 
         if text_data.n_samples < MIN_TEXT_SAMPLES:
             raise NotEnoughSamplesError(f'Not enough samples to calculate under annotated {self.segment_by} '
@@ -84,7 +84,7 @@ class UnderAnnotatedSegments(SingleDatasetCheck, WeakSegmentAbstract):
         if len(weak_segments) == 0:
             display_msg = 'Check was unable to find under annotated segments. Try ' \
                             f'supplying more {self.segment_by}.'
-            return CheckResult(value={'error': display_msg}, display=[display_msg])
+            return CheckResult(value={'message': display_msg}, display=[display_msg])
 
         check_result_value = self._generate_check_result_value(weak_segments, cat_features, avg_score)
         display_msg = f'Showcasing intersections of {self.segment_by} that result in the most ' \

--- a/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
+++ b/deepchecks/nlp/checks/data_integrity/under_annotated_segments.py
@@ -250,7 +250,7 @@ class UnderAnnotatedPropertySegments(UnderAnnotatedSegments):
     n_to_show : int , default: 3
         number of segments with the weakest performance to show.
     annotation_ratio_threshold : float , default: 95.0
-        The threshold ranging from 1 to 100 for the under annotated property segement check to run. 
+        The threshold ranging from 1 to 100 for the under annotated property segement check to run.
     categorical_aggregation_threshold : float , default: 0.05
         In each categorical column, categories with frequency below threshold will be merged into "Other" category.
     """
@@ -305,7 +305,7 @@ class UnderAnnotatedMetaDataSegments(UnderAnnotatedSegments):
     n_to_show : int , default: 3
         number of segments with the weakest performance to show.
     annotation_ratio_threshold : float , default: 95.0
-        The threshold ranging from 1 to 100 for the under annotated metatdata segement check to run. 
+        The threshold ranging from 1 to 100 for the under annotated metatdata segement check to run.
     categorical_aggregation_threshold : float , default: 0.05
         In each categorical column, categories with frequency below threshold will be merged into "Other" category.
     """

--- a/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
@@ -111,7 +111,7 @@ class WeakSegmentsAbstractText(SingleDatasetCheck, WeakSegmentAbstract):
 
         if len(weak_segments) == 0:
             display_msg = 'WeakSegmentsPerformance was unable to train an error model to find weak segments.'\
-                          f'Try supplying more {self.segment_by}.'
+                          f'Try supplying additional {self.segment_by}.'
             return CheckResult(value={'message': display_msg}, display=[display_msg])
 
         if context.with_display:

--- a/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
@@ -112,7 +112,7 @@ class WeakSegmentsAbstractText(SingleDatasetCheck, WeakSegmentAbstract):
         if len(weak_segments) == 0:
             display_msg = 'WeakSegmentsPerformance was unable to train an error model to find weak segments.'\
                           f'Try supplying more {self.segment_by}.'
-            return CheckResult(value={'error': display_msg}, display=[display_msg])
+            return CheckResult(value={'message': display_msg}, display=[display_msg])
 
         if context.with_display:
             display = self._create_heatmap_display(data=encoded_dataset.data, weak_segments=weak_segments,

--- a/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
+++ b/deepchecks/nlp/checks/model_evaluation/weak_segments_performance.py
@@ -59,7 +59,7 @@ class WeakSegmentsAbstractText(SingleDatasetCheck, WeakSegmentAbstract):
 
         if text_data.n_samples < MIN_TEXT_SAMPLES:
             raise NotEnoughSamplesError(f'Not enough samples to find weak {self.segment_by} segments.'
-                                        ' Minimum 10 samples required.')
+                                        f' Minimum {MIN_TEXT_SAMPLES} samples required.')
         features, cat_features = get_relevant_data_table(text_data, data_type=self.segment_by,
                                                          columns=self.columns, ignore_columns=self.ignore_columns,
                                                          n_top_features=self.n_top_features)

--- a/deepchecks/utils/abstracts/weak_segment_abstract.py
+++ b/deepchecks/utils/abstracts/weak_segment_abstract.py
@@ -330,6 +330,9 @@ class WeakSegmentAbstract(abc.ABC):
         """
 
         def condition(result: Dict) -> ConditionResult:
+            if 'message' in result:
+                return ConditionResult(ConditionCategory.PASS, result['message'])
+
             weakest_segment_score = result['weak_segments_list'].iloc[0, 0]
             scorer_name = result['weak_segments_list'].columns[0].lower()
             msg = f'Found a segment with {scorer_name} of {format_number(weakest_segment_score, 3)} ' \

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -95,7 +95,7 @@ def test_tweet_emotion_metadata_fully_annotated(tweet_emotion_train_test_textdat
     result = check.run(test)
 
     # Assert
-    assert_that(result.value['error'], equal_to('Under annotated metadata segments check is skipped '
+    assert_that(result.value['message'], equal_to('Under annotated metadata segments check is skipped '
                                                 'since your data annotation ratio is > 90.0%.'))
 
 

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -55,9 +55,9 @@ def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details='Found a segment with annotation ratio of 0.366 in comparison to an average'
+                               details='Found a segment with annotation ratio of 0.366 in comparison to an average '
                                        'score of 0.5 in sampled data.',
-                               name='The relative performance of weakest segment is greater than 80% of average'
+                               name='The relative performance of weakest segment is greater than 80% of average '
                                     'model performance.')
     ))
 
@@ -89,14 +89,17 @@ def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_tex
 def test_tweet_emotion_metadata_fully_annotated(tweet_emotion_train_test_textdata):
     # Arrange
     _, test = tweet_emotion_train_test_textdata
-    check = UnderAnnotatedMetaDataSegments().add_condition_segments_relative_performance_greater_than()
+    check = UnderAnnotatedMetaDataSegments(
+                annotation_ratio_threshold=90
+            ).add_condition_segments_relative_performance_greater_than()
 
     # Act
     result = check.run(test)
 
     # Assert
     assert_that(result.value['message'], equal_to('Under annotated metadata segments check is skipped '
-                                                'since your data annotation ratio is > 90.0%.'))
+                                                  'since your data annotation ratio is > 90%. Try '
+                                                  'increasing the annotation_ratio_threshold parameter.'))
 
 
 def test_token_classification_dataset(small_wikiann_train_test_text_data):

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -89,17 +89,24 @@ def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_tex
 def test_tweet_emotion_metadata_fully_annotated(tweet_emotion_train_test_textdata):
     # Arrange
     _, test = tweet_emotion_train_test_textdata
-    check = UnderAnnotatedMetaDataSegments(
+    check_one = UnderAnnotatedMetaDataSegments(
                 annotation_ratio_threshold=90
             ).add_condition_segments_relative_performance_greater_than()
 
+    check_two = UnderAnnotatedMetaDataSegments(
+                annotation_ratio_threshold=100
+                ).add_condition_segments_relative_performance_greater_than()
+
     # Act
-    result = check.run(test)
+    result_one = check_one.run(test)
+    result_two = check_two.run(test)
 
     # Assert
-    assert_that(result.value['message'], equal_to('Under annotated metadata segments check is skipped '
-                                                  'since your data annotation ratio is > 90%. Try '
-                                                  'increasing the annotation_ratio_threshold parameter.'))
+    assert_that(result_one.value['message'], equal_to('Under annotated metadata segments check is '
+                                                      'skipped since your data annotation ratio is > 90%. '
+                                                      'Try increasing the annotation_ratio_threshold parameter.'))
+    assert_that(result_two.value['message'], equal_to('Check was unable to find under annotated segments. Try '
+                                                      'supplying more metadata.'))
 
 
 def test_token_classification_dataset(small_wikiann_train_test_text_data):

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -12,7 +12,7 @@
 import numpy as np
 from hamcrest import assert_that, calling, close_to, equal_to, has_items, raises
 
-from deepchecks.core.errors import DeepchecksProcessError
+from deepchecks.core.errors import NotEnoughSamplesError
 from deepchecks.nlp.checks import UnderAnnotatedMetaDataSegments, UnderAnnotatedPropertySegments
 from tests.base.utils import equal_condition_result
 
@@ -55,8 +55,10 @@ def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details='Found a segment with annotation ratio of 0.366 in comparison to an average score of 0.5 in sampled data.',
-                               name='The relative performance of weakest segment is greater than 80% of average model performance.')
+                               details='Found a segment with annotation ratio of 0.366 in comparison to an average'
+                                       'score of 0.5 in sampled data.',
+                               name='The relative performance of weakest segment is greater than 80% of average'
+                                    'model performance.')
     ))
 
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
@@ -89,13 +91,12 @@ def test_tweet_emotion_metadata_fully_annotated(tweet_emotion_train_test_textdat
     _, test = tweet_emotion_train_test_textdata
     check = UnderAnnotatedMetaDataSegments().add_condition_segments_relative_performance_greater_than()
 
-    # Act & Assert
-    assert_that(
-        calling(check.run).with_args(test),
-        raises(DeepchecksProcessError, 'Check was unable to find under annotated segments. This is expected if '
-                                       'your data is well annotated. If this is not the case, try increasing '
-                                       'n_samples or supply more metadata.')
-    )
+    # Act
+    result = check.run(test)
+
+    # Assert
+    assert_that(result.value['error'], equal_to('Under annotated metadata segments check is skipped '
+                                                'since your data annotation ratio is > 90.0%.'))
 
 
 def test_token_classification_dataset(small_wikiann_train_test_text_data):
@@ -150,3 +151,25 @@ def test_multilabel_dataset(multilabel_mock_dataset_and_probabilities):
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
     assert_that(len(result.value['weak_segments_list']), equal_to(4))
     assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.326, 0.01))
+
+
+def test_not_enough_samples(tweet_emotion_train_test_textdata):
+    # Arrange
+    _, test = tweet_emotion_train_test_textdata
+    text_data = test.sample(5)
+    text_data.label[0] = np.nan
+    text_data.label[3] = None
+
+    # Act & Assert
+    property_check = UnderAnnotatedPropertySegments(segment_minimum_size_ratio=0.04)
+    metadata_check = UnderAnnotatedMetaDataSegments(segment_minimum_size_ratio=0.04)
+    assert_that(
+        calling(property_check.run).with_args(text_data),
+        raises(NotEnoughSamplesError,
+               'Not enough samples to calculate under annotated properties segments. Minimum 10 samples required.'
+               ))
+    assert_that(
+        calling(metadata_check.run).with_args(text_data),
+        raises(NotEnoughSamplesError,
+               'Not enough samples to calculate under annotated metadata segments. Minimum 10 samples required.'
+               ))

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -89,24 +89,15 @@ def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_tex
 def test_tweet_emotion_metadata_fully_annotated(tweet_emotion_train_test_textdata):
     # Arrange
     _, test = tweet_emotion_train_test_textdata
-    check_one = UnderAnnotatedMetaDataSegments(
-                annotation_ratio_threshold=90
-            ).add_condition_segments_relative_performance_greater_than()
-
-    check_two = UnderAnnotatedMetaDataSegments(
-                annotation_ratio_threshold=100
-                ).add_condition_segments_relative_performance_greater_than()
+    check = UnderAnnotatedMetaDataSegments().add_condition_segments_relative_performance_greater_than()
 
     # Act
-    result_one = check_one.run(test)
-    result_two = check_two.run(test)
+    result = check.run(test)
 
     # Assert
-    assert_that(result_one.value['message'], equal_to('Under annotated metadata segments check is '
-                                                      'skipped since your data annotation ratio is > 90%. '
-                                                      'Try increasing the annotation_ratio_threshold parameter.'))
-    assert_that(result_two.value['message'], equal_to('Check was unable to find under annotated segments. Try '
-                                                      'supplying more metadata.'))
+    assert_that(result.value['message'], equal_to('Under annotated metadata segments check is '
+                                                  'skipped since your data annotation ratio is > 95.0%. '
+                                                  'Try increasing the annotation_ratio_threshold parameter.'))
 
 
 def test_token_classification_dataset(small_wikiann_train_test_text_data):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes [DEE-621 - WeakSegments + Under annotated checks return error if no segments found](https://linear.app/deepchecks/issue/DEE-621/weaksegments-under-annotated-checks-return-error-if-no-segments-found)


#### What does this implement/fix? Explain your changes.
The WeakSegments and UnderAnnotated checks earlier returns DeepchecksProcessError. But now, after the change, it will return a empty CheckResult in the following cases:
- If annotation ratio of the data is > 95%. (Only for UnderAnnotated check). This is a configurable parameter accepted by property and metadata checks.
- If weak segments is empty, it will return a message to try increasing the segment_by (either properties or metadata).

Also, both checks return a NotEnoughSamplesError if there are less than 10 samples. 

Below is the output for data integrity suite when Under annotated checks are skipped based on the above mentioned conditions: 
<img width="600" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/a019763e-5d1c-4720-9bb7-86efb8807d77">

Running stand-alone under annotated check: 
<img width="600" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/02b06ddd-a712-4dfa-b16b-34616ea58abe">
