### PR TITLE
Remove heatmap and display pie charts for confusion matrix

### DIFF
--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -35,13 +35,11 @@ class ConfusionMatrixReport(SingleDatasetCheck):
     """
 
     def __init__(self,
-                 normalize_display: bool = True,
                  n_samples: int = 1_000_000,
                  random_state: int = 42,
                  max_num_labels_to_show: int = 5,
                  **kwargs):
         super().__init__(**kwargs)
-        self.normalize_display = normalize_display
         self.n_samples = n_samples
         self.random_state = random_state
         self.max_num_labels_to_show = max_num_labels_to_show

--- a/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/nlp/checks/model_evaluation/confusion_matrix_report.py
@@ -25,8 +25,9 @@ class ConfusionMatrixReport(SingleDatasetCheck):
 
     Parameters
     ----------
-    normalize_display : bool , default: True:
-        boolean that determines whether to normalize the values of the matrix in the display.
+    max_num_labels_to_show : int, default: 5
+        The threshold to display the maximum number of labels on the label prediction distribution pie
+        charts and display rest of the labels under "Others" category.
     n_samples : int , default: 10_000
         number of samples to use for this check.
     random_state : int, default: 42
@@ -37,11 +38,13 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                  normalize_display: bool = True,
                  n_samples: int = 1_000_000,
                  random_state: int = 42,
+                 max_num_labels_to_show: int = 5,
                  **kwargs):
         super().__init__(**kwargs)
         self.normalize_display = normalize_display
         self.n_samples = n_samples
         self.random_state = random_state
+        self.max_num_labels_to_show = max_num_labels_to_show
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
         """Run check.
@@ -64,7 +67,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_true = np.asarray(dataset.label)
         y_pred = np.array(context.model.predict(dataset)).reshape(len(y_true), )
 
-        return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+        return run_confusion_matrix_check(y_pred, y_true, self.max_num_labels_to_show, context.with_display)
 
     def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
         """Add condition - Misclassified samples lower than threshold.

--- a/deepchecks/nlp/utils/text_data_plot.py
+++ b/deepchecks/nlp/utils/text_data_plot.py
@@ -279,7 +279,6 @@ def text_data_describe_plot(n_samples: int, max_num_labels_to_show: int,
             labels_to_display.index = [break_to_lines_and_trim(str(label)) for label in list(labels_to_display.index)]
             count_other_labels = label_counts[max_num_labels_to_show:].sum()
             labels_to_display['Others'] = count_other_labels
-            
 
         # Pie chart for label distribution
         fig.add_trace(go.Pie(labels=list(labels_to_display.index), values=list(labels_to_display),

--- a/deepchecks/nlp/utils/text_data_plot.py
+++ b/deepchecks/nlp/utils/text_data_plot.py
@@ -273,11 +273,13 @@ def text_data_describe_plot(n_samples: int, max_num_labels_to_show: int,
         else:
             label_counts = pd.Series(label).value_counts()
 
-        label_counts.sort_values(ascending=False, inplace=True)
-        labels_to_display = label_counts[:max_num_labels_to_show]
-        labels_to_display.index = [break_to_lines_and_trim(str(label)) for label in list(labels_to_display.index)]
-        count_other_labels = label_counts[max_num_labels_to_show + 1:].sum()
-        labels_to_display['Others'] = count_other_labels
+        labels_to_display = label_counts.sort_values(ascending=False)
+        if len(label_counts) > max_num_labels_to_show:
+            labels_to_display = label_counts[:max_num_labels_to_show]
+            labels_to_display.index = [break_to_lines_and_trim(str(label)) for label in list(labels_to_display.index)]
+            count_other_labels = label_counts[max_num_labels_to_show:].sum()
+            labels_to_display['Others'] = count_other_labels
+            
 
         # Pie chart for label distribution
         fig.add_trace(go.Pie(labels=list(labels_to_display.index), values=list(labels_to_display),

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -35,13 +35,11 @@ class ConfusionMatrixReport(SingleDatasetCheck):
     """
 
     def __init__(self,
-                 normalize_display: bool = True,
                  n_samples: int = 1_000_000,
                  random_state: int = 42,
                  max_num_labels_to_show: int = 5,
                  **kwargs):
         super().__init__(**kwargs)
-        self.normalize_display = normalize_display
         self.n_samples = n_samples
         self.random_state = random_state
         self.max_num_labels_to_show = max_num_labels_to_show

--- a/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
+++ b/deepchecks/tabular/checks/model_evaluation/confusion_matrix_report.py
@@ -25,8 +25,9 @@ class ConfusionMatrixReport(SingleDatasetCheck):
 
     Parameters
     ----------
-    normalize_display : bool , default: True:
-        boolean that determines whether to normalize the values of the matrix in the display.
+    max_num_labels_to_show : int, default: 5
+        The threshold to display the maximum number of labels on the label prediction distribution pie
+        charts and display rest of the labels under "Others" category.
     n_samples : int , default: 1_000_000
         number of samples to use for this check.
     random_state : int, default: 42
@@ -37,11 +38,13 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                  normalize_display: bool = True,
                  n_samples: int = 1_000_000,
                  random_state: int = 42,
+                 max_num_labels_to_show: int = 5,
                  **kwargs):
         super().__init__(**kwargs)
         self.normalize_display = normalize_display
         self.n_samples = n_samples
         self.random_state = random_state
+        self.max_num_labels_to_show = max_num_labels_to_show
 
     def run_logic(self, context: Context, dataset_kind) -> CheckResult:
         """Run check.
@@ -61,7 +64,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         y_true = dataset.label_col
         y_pred = np.array(context.model.predict(dataset.features_columns)).reshape(len(y_true), )
 
-        return run_confusion_matrix_check(y_pred, y_true, context.with_display, self.normalize_display)
+        return run_confusion_matrix_check(y_pred, y_true, self.max_num_labels_to_show, context.with_display)
 
     def add_condition_misclassified_samples_lower_than_condition(self, misclassified_samples_threshold: float = 0.2):
         """Add condition - Misclassified samples lower than threshold.

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -103,9 +103,9 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
                                 f'<b>{confusion_matrix_data[index][index]} ({accuracy_array[index]}%)</b> correct predictions'
                                 f'<br>Having <b>{format_percent(n_samples_with_label/total_samples)}</b> of labeled data '
                                 f'in the dataset', labels=labels, showlegend=False, textposition='inside', textinfo='label+percent',
-                                customdata=[[classes_names[index], accuracy_array[index], n_samples_with_label]],
-                                hovertemplate='Label: %{customdata[0][0]}<br>Accuracy: %{customdata[0][1]}%<br>'
-                                   'Samples: %{customdata[0][2]}<extra></extra>'), row=1, col=curr_col)
+                                customdata=[[label, values[index]] for index, label in enumerate(labels)],
+                                hovertemplate='Label: %{customdata[0][0]}<br>Samples: %{customdata[0][1]}<extra></extra>'),
+                                row=1, col=curr_col)
             curr_col += 1
         fig.update_layout(title='Worst Performing Classes', title_x=0.5)
         display.append(fig)

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -91,10 +91,10 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
     if len(worst_class_indices) > 0:
         fig = make_subplots(rows=1, cols=min(MAX_WORST_CLASSES_TO_DISPLAY, len(worst_class_indices)),
                             specs=[[{'type': 'pie'}] * min(MAX_WORST_CLASSES_TO_DISPLAY, len(worst_class_indices))])
-        total_samples = np.sum(confusion_matrix_data, axis=None)
+        total_samples = np.nansum(confusion_matrix_data, axis=None)
         for idx in worst_class_indices:
             values = np.delete(confusion_matrix_data[idx], idx)
-            n_samples_with_label = np.sum(confusion_matrix_data[idx])
+            n_samples_with_label = np.nansum(confusion_matrix_data[idx])
             label_percentage = format_percent(n_samples_with_label/total_samples)
             labels = np.delete(classes_names, idx)
             if len(values) > max_num_labels_to_show:

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """The confusion_matrix_report check module."""
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -82,8 +82,9 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
 
     display_msg = textwrap.dedent(
         f'The overall accuracy of your model is: {round(np.sum(accuracy_array)/len(accuracy_array), 2)}%.<br>'
-        f'Best accuracy achieved on samples with <b>{classes_names[np.argmax(accuracy_array)]}</b> label ({np.max(accuracy_array)}%).<br>'
-        f'Worst accuracy achieved on samples with <b>{classes_names[np.argmin(accuracy_array)]}</b> label ({np.min(accuracy_array)}%).<br>'
+        f'Best accuracy achieved on samples with <b>{classes_names[np.argmax(accuracy_array)]}</b> '
+        f'label ({np.max(accuracy_array)}%).<br>Worst accuracy achieved on samples with '
+        f'<b>{classes_names[np.argmin(accuracy_array)]}</b> label ({np.min(accuracy_array)}%).<br>'
         'Below are pie charts showing the prediction distribution for samples grouped based on their label.'
     )
     display.append(display_msg)
@@ -113,8 +114,8 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
                                  f'Accuracy: <b>{confusion_matrix_data[idx][idx]} ({accuracy_array[idx]}%)</b>'
                                  f'<br>Percentage of data with label <b>{classes_names[idx]}: {label_percentage}</b>',
                                  labels=labels, showlegend=False, textposition='inside', textinfo='label+percent',
-                                 customdata=[[label, values[idx]] if label != 'Others' else [other_label_names, values[idx]] 
-                                             for idx, label in enumerate(labels)],
+                                 customdata=[[label, values[idx]] if label != 'Others' else
+                                             [other_label_names, values[idx]] for idx, label in enumerate(labels)],
                                  hovertemplate='Label: %{customdata[0][0]}<br>Samples: %{customdata[0][1]}'
                                                '<extra></extra>'), row=1, col=curr_col)
             curr_col += 1

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -9,34 +9,35 @@
 # ----------------------------------------------------------------------------
 #
 """The confusion_matrix_report check module."""
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from sklearn.metrics import confusion_matrix
-
+import textwrap
 from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.core import CheckResult
 from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.utils.strings import format_percent
+from deepchecks.nlp.utils.text import break_to_lines_and_trim
 
 __all__ = ['create_confusion_matrix_figure', 'run_confusion_matrix_check']
 
 MAX_WORST_CLASSES_TO_DISPLAY = 3
 MAX_TOP_CLASSES_TO_DISPLAY = 3
-MIN_ACCURACY_FOR_GOOD_CLASSES = 85.0
+MIN_ACCURACY_FOR_GOOD_CLASSES = 100.0
 
 
-def run_confusion_matrix_check(y_pred: np.ndarray, y_true: np.ndarray, with_display=True,
-                               normalize_display=True) -> CheckResult:
+def run_confusion_matrix_check(y_pred: np.ndarray, y_true: np.ndarray, max_num_labels_to_show: int,
+                               with_display=True) -> CheckResult:
     """Calculate confusion matrix based on predictions and true label values."""
     total_classes = sorted([str(x) for x in set(y_pred).union(set(y_true))])
     result = confusion_matrix(y_true, y_pred)
 
     if with_display:
-        displays = create_confusion_matrix_figure(result, total_classes)
+        displays = create_confusion_matrix_figure(result, total_classes, max_num_labels_to_show)
     else:
         displays = None
 
@@ -46,7 +47,8 @@ def run_confusion_matrix_check(y_pred: np.ndarray, y_true: np.ndarray, with_disp
     return CheckResult(result, display=displays)
 
 
-def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_names: List[str]):
+def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_names: List[str],
+                                   max_num_labels_to_show: int):
     """Create a confusion matrix figure.
 
     Parameters
@@ -55,6 +57,9 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
         2D array containing the confusion matrix.
     classes_names: List[str]
         the names of the classes to display as the axis.
+    max_num_labels_to_show : int
+        The threshold to display the maximum number of labels on the label prediction distribution pie
+        charts and display rest of the labels under "Others" category.
 
     Returns
     -------
@@ -67,50 +72,53 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
         (confusion_matrix_data.sum(axis=1)[:, np.newaxis] + np.finfo(float).eps) * 100
 
     accuracy_array = np.diag(confusion_matrix_norm).round(decimals=2)
-    worst_class_indices = [index for index, acc in enumerate(accuracy_array) if acc < MIN_ACCURACY_FOR_GOOD_CLASSES]
+    index_accuracy_map = {index: acc for index, acc in enumerate(accuracy_array)}
+    sorted_map = {key: value for key, value in sorted(index_accuracy_map.items(), key=lambda item: item[1])}
+
+    worst_class_indices = [index for index, acc in sorted_map.items() if acc < MIN_ACCURACY_FOR_GOOD_CLASSES]
 
     if len(accuracy_array) > MAX_WORST_CLASSES_TO_DISPLAY:
         worst_class_indices = worst_class_indices[:MAX_WORST_CLASSES_TO_DISPLAY]
 
-    top_classes_names = []
-    top_class_accuracy = []
-    for index, acc in enumerate(accuracy_array):
-        if index not in worst_class_indices:
-            top_classes_names.append(classes_names[index])
-            top_class_accuracy.append(acc)
-
-    # Pie chart for label distribution
-    total_samples_per_label = np.sum(confusion_matrix_data, axis=0)
-    customdata = [[classes_names[idx], acc, total_samples_per_label[idx]] for idx, acc in enumerate(accuracy_array)]
-    fig_pie = go.Figure(go.Pie(labels=classes_names, values=total_samples_per_label, textposition='inside',
-                               title='Label Distribution<br><sup>(with accuracy and number of samples per label)</sup>',
-                               customdata=customdata, showlegend=False, textinfo='label+percent',
-                               hovertemplate='Label:%{customdata[0][0]}<br>Accuracy: %{customdata[0][1]}%<br>'
-                                             'Samples:%{customdata[0][2]}<extra></extra>'))
-
-    display_msg = f'The overall accuracy of your model is: {round(np.sum(accuracy_array)/len(accuracy_array), 2)}%'
+    display_msg = textwrap.dedent(
+        f'The overall accuracy of your model is: {round(np.sum(accuracy_array)/len(accuracy_array), 2)}%.<br>'
+        f'Best accuracy achieved on samples with <b>{classes_names[np.argmax(accuracy_array)]}</b> label ({np.max(accuracy_array)}%).<br>'
+        f'Worst accuracy achieved on samples with <b>{classes_names[np.argmin(accuracy_array)]}</b> label ({np.min(accuracy_array)}%).<br>'
+        'Below are pie charts showing the prediction distribution for samples grouped based on their label.'
+    )
     display.append(display_msg)
-    display.append(fig_pie)
-
     curr_col = 1
     if len(worst_class_indices) > 0:
         fig = make_subplots(rows=1, cols=min(MAX_WORST_CLASSES_TO_DISPLAY, len(worst_class_indices)),
                             specs=[[{'type': 'pie'}] * min(MAX_WORST_CLASSES_TO_DISPLAY, len(worst_class_indices))])
+        total_samples = np.sum(confusion_matrix_data, axis=None)
         for idx in worst_class_indices:
             values = np.delete(confusion_matrix_data[idx], idx)
             n_samples_with_label = np.sum(confusion_matrix_data[idx])
-            total_samples = np.sum(confusion_matrix_data, axis=None)
             label_percentage = format_percent(n_samples_with_label/total_samples)
             labels = np.delete(classes_names, idx)
-            fig.add_trace(go.Pie(values=values, title=f'Label Prediction Distribution: <b>{classes_names[idx]}</b><br>'
-                                 f'with <b>{confusion_matrix_data[idx][idx]} ({accuracy_array[idx]}%)</b> correct '
-                                 f'predictions<br>Having <b>{label_percentage}</b> of labeled data in the dataset',
+            labels = np.array([break_to_lines_and_trim(str(label)) for label in labels])
+            if len(values) > max_num_labels_to_show:
+                sorted_indices = np.argsort(values)[::-1]
+                values = values[sorted_indices]
+                labels = labels[sorted_indices]
+                other_labels_sum = np.sum(values[max_num_labels_to_show:])
+                other_label_names = ', '.join(labels[max_num_labels_to_show:])
+                labels = labels[:max_num_labels_to_show]
+                values = values[:max_num_labels_to_show]
+                values = np.append(values, other_labels_sum)
+                labels = np.append(labels, 'Others')
+
+            fig.add_trace(go.Pie(values=values, title=f'Label: <b>{classes_names[idx]}</b><br>'
+                                 f'Accuracy: <b>{confusion_matrix_data[idx][idx]} ({accuracy_array[idx]}%)</b>'
+                                 f'<br>Percentage of data with label <b>{classes_names[idx]}: {label_percentage}</b>',
                                  labels=labels, showlegend=False, textposition='inside', textinfo='label+percent',
-                                 customdata=[[label, values[idx]] for idx, label in enumerate(labels)],
+                                 customdata=[[label, values[idx]] if label != 'Others' else [other_label_names, values[idx]] 
+                                             for idx, label in enumerate(labels)],
                                  hovertemplate='Label: %{customdata[0][0]}<br>Samples: %{customdata[0][1]}'
                                                '<extra></extra>'), row=1, col=curr_col)
             curr_col += 1
-        fig.update_layout(title='Worst Performing Classes', title_x=0.5)
+        fig.update_layout(title='Prediction distribution for worst performing classes', title_x=0.5)
         display.append(fig)
     return display
 

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -9,6 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """The confusion_matrix_report check module."""
+import textwrap
 from typing import List
 
 import numpy as np
@@ -16,7 +17,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from sklearn.metrics import confusion_matrix
-import textwrap
+
 from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.core import CheckResult
 from deepchecks.core.errors import DeepchecksValueError

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -103,9 +103,9 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
                                 f'<b>{confusion_matrix_data[index][index]} ({accuracy_array[index]}%)</b> correct predictions'
                                 f'<br>Having <b>{format_percent(n_samples_with_label/total_samples)}</b> of labeled data '
                                 f'in the dataset', labels=labels, showlegend=False, textposition='inside', textinfo='label+percent',
-                                customdata=[classes_names[index], accuracy_array[index], n_samples_with_label],
-                                hovertemplate='Label:%{customdata[0]}<br>Accuracy: %{customdata[1]}%<br>'
-                                   'Samples:%{customdata[2]}<extra></extra>'), row=1, col=curr_col)
+                                customdata=[[classes_names[index], accuracy_array[index], n_samples_with_label]],
+                                hovertemplate='Label: %{customdata[0][0]}<br>Accuracy: %{customdata[0][1]}%<br>'
+                                   'Samples: %{customdata[0][2]}<extra></extra>'), row=1, col=curr_col)
             curr_col += 1
         fig.update_layout(title='Worst Performing Classes', title_x=0.5)
         display.append(fig)

--- a/deepchecks/utils/abstracts/confusion_matrix_abstract.py
+++ b/deepchecks/utils/abstracts/confusion_matrix_abstract.py
@@ -21,7 +21,6 @@ from deepchecks import ConditionCategory, ConditionResult
 from deepchecks.core import CheckResult
 from deepchecks.core.errors import DeepchecksValueError
 from deepchecks.utils.strings import format_percent
-from deepchecks.nlp.utils.text import break_to_lines_and_trim
 
 __all__ = ['create_confusion_matrix_figure', 'run_confusion_matrix_check']
 
@@ -72,8 +71,7 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
         (confusion_matrix_data.sum(axis=1)[:, np.newaxis] + np.finfo(float).eps) * 100
 
     accuracy_array = np.diag(confusion_matrix_norm).round(decimals=2)
-    index_accuracy_map = {index: acc for index, acc in enumerate(accuracy_array)}
-    sorted_map = {key: value for key, value in sorted(index_accuracy_map.items(), key=lambda item: item[1])}
+    sorted_map = dict(sorted(dict(enumerate(accuracy_array)).items(), key=lambda item: item[1]))
 
     worst_class_indices = [index for index, acc in sorted_map.items() if acc < MIN_ACCURACY_FOR_GOOD_CLASSES]
 
@@ -98,7 +96,6 @@ def create_confusion_matrix_figure(confusion_matrix_data: np.ndarray, classes_na
             n_samples_with_label = np.sum(confusion_matrix_data[idx])
             label_percentage = format_percent(n_samples_with_label/total_samples)
             labels = np.delete(classes_names, idx)
-            labels = np.array([break_to_lines_and_trim(str(label)) for label in labels])
             if len(values) > max_num_labels_to_show:
                 sorted_indices = np.argsort(values)[::-1]
                 values = values[sorted_indices]

--- a/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
+++ b/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
@@ -81,7 +81,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         self.categories_to_display = categories_to_display
         self.iou_threshold = iou_threshold
         self.matrix = None
-        self.max_num_labels_to_show =max_num_labels_to_show
+        self.max_num_labels_to_show = max_num_labels_to_show
 
     def initialize_run(self, context: Context, dataset_kind: DatasetKind = None):
         """Initialize run by creating an empty matrix the size of the data."""

--- a/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
+++ b/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
@@ -146,7 +146,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                     y.append('No overlapping')
 
             description.append(
-                create_confusion_matrix_figure(confusion_matrix, x, self.normalized)
+                create_confusion_matrix_figure(confusion_matrix, x)
             )
         else:
             description = None

--- a/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
+++ b/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
@@ -62,8 +62,9 @@ class ConfusionMatrixReport(SingleDatasetCheck):
         Threshold to consider bounding box as detected.
     iou_threshold (float, default 0.5):
         Threshold to consider detected bounding box as labeled bounding box.
-    normalized (bool, default True):
-        boolean that determines whether to normalize the true values of the matrix.
+    max_num_labels_to_show : int, default: 5
+        The threshold to display the maximum number of labels on the label prediction distribution pie
+        charts and display rest of the labels under "Others" category.
     {additional_check_init_params:2*indent}
     """
 
@@ -71,16 +72,16 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                  categories_to_display: int = 10,
                  confidence_threshold: float = 0.3,
                  iou_threshold: float = 0.5,
-                 normalized: bool = True,
                  n_samples: t.Optional[int] = 10000,
+                 max_num_labels_to_show: int = 5,
                  **kwargs):
         super().__init__(**kwargs)
         self.n_samples = n_samples
         self.confidence_threshold = confidence_threshold
         self.categories_to_display = categories_to_display
         self.iou_threshold = iou_threshold
-        self.normalized = normalized
         self.matrix = None
+        self.max_num_labels_to_show =max_num_labels_to_show
 
     def initialize_run(self, context: Context, dataset_kind: DatasetKind = None):
         """Initialize run by creating an empty matrix the size of the data."""
@@ -146,7 +147,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                     y.append('No overlapping')
 
             description.append(
-                create_confusion_matrix_figure(confusion_matrix, x)
+                *create_confusion_matrix_figure(confusion_matrix, x, self.max_num_labels_to_show)
             )
         else:
             description = None

--- a/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
+++ b/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
@@ -146,7 +146,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                     x.append('No overlapping')
                     y.append('No overlapping')
 
-            description.append(
+            description.extend(
                 *create_confusion_matrix_figure(confusion_matrix, x, self.max_num_labels_to_show)
             )
         else:

--- a/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
+++ b/deepchecks/vision/checks/model_evaluation/confusion_matrix.py
@@ -113,7 +113,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
             confusion_matrix, categories = filter_confusion_matrix(matrix, self.categories_to_display)
             confusion_matrix = np.nan_to_num(confusion_matrix)
 
-            description = [f'Showing {self.categories_to_display} of {len(dataset.get_observed_classes())} classes:']
+            description = []
             classes_to_display = []
             classes_map = dict(enumerate(classes))  # class index -> class label
 
@@ -147,7 +147,7 @@ class ConfusionMatrixReport(SingleDatasetCheck):
                     y.append('No overlapping')
 
             description.extend(
-                *create_confusion_matrix_figure(confusion_matrix, x, self.max_num_labels_to_show)
+                create_confusion_matrix_figure(confusion_matrix, x, self.max_num_labels_to_show)
             )
         else:
             description = None

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -100,16 +100,16 @@ def test_condition_misclassified_samples_lower_than_raises_error(tweet_emotion_t
     assert_that(result.conditions_results[0], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(-0.1 * 100)}% of the total samples',
-        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
-                'to be between 0 and 1 inclusive but got -0.1',
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter '
+                '"misclassified_samples_threshold" to be between 0 and 1 inclusive but got -0.1',
         category=ConditionCategory.ERROR
     ))
 
     assert_that(result.conditions_results[1], equal_condition_result(
         is_pass=False,
         name=f'Misclassified cell size lower than {format_number(1.1 * 100)}% of the total samples',
-        details='Exception in condition: DeepchecksValueError: Condition requires the parameter "misclassified_samples_threshold" '
-                'to be between 0 and 1 inclusive but got 1.1',
+        details='Exception in condition: DeepchecksValueError: Condition requires the parameter '
+                '"misclassified_samples_threshold" to be between 0 and 1 inclusive but got 1.1',
         category=ConditionCategory.ERROR
     ))
 
@@ -189,3 +189,23 @@ def test_condition_misclassified_samples_lower_than_fails(tweet_emotion_train_te
                   f'Largest misclassified cell ({format_percent(max_misclassified_samples_ratio)} of the data) ' \
                   f'is samples with a true value of "{class_names[x]}" and a predicted value of "{class_names[y]}".'
     ))
+
+
+def test_confusion_matrix_report_display(tweet_emotion_train_test_textdata, tweet_emotion_train_test_predictions):
+    # Arrange and Act
+    check = ConfusionMatrixReport()
+    result = check.run(tweet_emotion_train_test_textdata[0], predictions=tweet_emotion_train_test_predictions[0])
+
+    # Assert
+    assert_that(result.display[0],
+                equal_to('The overall accuracy of your model is: 92.04%.<br>Best accuracy achieved on samples with '
+                         '<b>anger</b> label (96.59%).<br>Worst accuracy achieved on samples with <b>sadness</b> '
+                         'label (88.86%).<br>Below are pie charts showing the prediction distribution for samples '
+                         'grouped based on their label.'))
+    # First is the text description and second a row of max 3 pie charts
+    assert_that(len(result.display), equal_to(2))
+    # 3 Pie charts are generated
+    assert_that(len(result.display[1].data), equal_to(3))
+    assert_that(result.display[1].data[0].type, equal_to('pie'))
+    assert_that(result.display[1].data[1].type, equal_to('pie'))
+    assert_that(result.display[1].data[2].type, equal_to('pie'))

--- a/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/nlp/checks/model_evaluation/confusion_matrix_test.py
@@ -200,8 +200,7 @@ def test_confusion_matrix_report_display(tweet_emotion_train_test_textdata, twee
     assert_that(result.display[0],
                 equal_to('The overall accuracy of your model is: 92.04%.<br>Best accuracy achieved on samples with '
                          '<b>anger</b> label (96.59%).<br>Worst accuracy achieved on samples with <b>sadness</b> '
-                         'label (88.86%).<br>Below are pie charts showing the prediction distribution for samples '
-                         'grouped based on their label.'))
+                         'label (88.86%).'))
     # First is the text description and second a row of max 3 pie charts
     assert_that(len(result.display), equal_to(2))
     # 3 Pie charts are generated

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -10,7 +10,7 @@
 #
 """Contains unit tests for the confusion_matrix_report check."""
 import numpy as np
-from hamcrest import assert_that, calling, greater_than, has_length, raises
+from hamcrest import assert_that, calling, greater_than, has_length, raises, equal_to
 
 from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError, ModelValidationError
@@ -183,3 +183,25 @@ def test_condition_misclassified_samples_lower_than_fails(iris_split_dataset_and
                   f'Largest misclassified cell ({format_percent(max_misclassified_samples_ratio)} of the data) ' \
                   f'is samples with a true value of "{class_names[x]}" and a predicted value of "{class_names[y]}".'
     ))
+
+
+def test_confusion_matrix_report_display(iris_split_dataset_and_model):
+    # Arrange
+    _, test, clf = iris_split_dataset_and_model
+
+    # Act
+    check = ConfusionMatrixReport()
+
+    result = check.run(test, clf)
+
+    # Assert
+    assert_that(result.display[0],
+                equal_to('The overall accuracy of your model is: 91.67%.<br>Best accuracy achieved on samples with '
+                         '<b>0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>2</b> label (75.0%).'
+                         '<br>Below are pie charts showing the prediction distribution for samples '
+                         'grouped based on their label.'))
+    # # First is the text description and second a row of 1 pie chart since accuracy for other labels is 100%
+    assert_that(len(result.display), equal_to(2))
+    # 1 Pie chart is generated
+    assert_that(len(result.display[1].data), equal_to(1))
+    assert_that(result.display[1].data[0].type, equal_to('pie'))

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -196,10 +196,8 @@ def test_confusion_matrix_report_display(iris_split_dataset_and_model):
 
     # Assert
     assert_that(result.display[0],
-                equal_to('The overall accuracy of your model is: 91.67%.<br>Best accuracy achieved on samples with '
-                         '<b>0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>2</b> label (75.0%).'
-                         '<br>Below are pie charts showing the prediction distribution for samples '
-                         'grouped based on their label.'))
+                equal_to('The overall accuracy of your model is: 91.67%.<br>Best accuracy achieved on samples with <b>'
+                         '0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>2</b> label (75.0%).'))
     # # First is the text description and second a row of 1 pie chart since accuracy for other labels is 100%
     assert_that(len(result.display), equal_to(2))
     # 1 Pie chart is generated

--- a/tests/vision/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/vision/checks/model_evaluation/confusion_matrix_test.py
@@ -40,7 +40,7 @@ def test_classification_without_display(mnist_visiondata_train):
 
 def test_classification_not_normalize(mnist_visiondata_train):
     # Arrange
-    check = ConfusionMatrixReport(normalized=False)
+    check = ConfusionMatrixReport()
     # Act
     result = check.run(mnist_visiondata_train)
     # Assert
@@ -67,10 +67,8 @@ def test_confusion_matrix_report_display(mnist_visiondata_train):
 
     # Assert
     assert_that(result.display[0],
-                equal_to('The overall accuracy of your model is: 97.45%.<br>Best accuracy achieved on samples with '
-                         '<b>0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>9</b> label (86.96%).'
-                         '<br>Below are pie charts showing the prediction distribution for samples '
-                         'grouped based on their label.'))
+                equal_to('The overall accuracy of your model is: 97.45%.<br>Best accuracy achieved on samples with <b>'
+                         '0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>9</b> label (86.96%).'))
     # First is the text description and second a row of 3 pie charts
     assert_that(len(result.display), equal_to(2))
     # 3 Pie charts are generated

--- a/tests/vision/checks/model_evaluation/confusion_matrix_test.py
+++ b/tests/vision/checks/model_evaluation/confusion_matrix_test.py
@@ -56,3 +56,25 @@ def test_detection(coco_visiondata_train):
     # Assert
     num_of_classes = len(coco_visiondata_train.get_observed_classes()) + 1  # plus no-overlapping
     assert_that(result.value.shape, le((num_of_classes, num_of_classes)))
+
+
+def test_confusion_matrix_report_display(mnist_visiondata_train):
+    # Arrange
+    check = ConfusionMatrixReport()
+
+    # Act
+    result = check.run(mnist_visiondata_train)
+
+    # Assert
+    assert_that(result.display[0],
+                equal_to('The overall accuracy of your model is: 97.45%.<br>Best accuracy achieved on samples with '
+                         '<b>0</b> label (100.0%).<br>Worst accuracy achieved on samples with <b>9</b> label (86.96%).'
+                         '<br>Below are pie charts showing the prediction distribution for samples '
+                         'grouped based on their label.'))
+    # First is the text description and second a row of 3 pie charts
+    assert_that(len(result.display), equal_to(2))
+    # 3 Pie charts are generated
+    assert_that(len(result.display[1].data), equal_to(3))
+    assert_that(result.display[1].data[0].type, equal_to('pie'))
+    assert_that(result.display[1].data[1].type, equal_to('pie'))
+    assert_that(result.display[1].data[2].type, equal_to('pie'))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2427 and [DEE-439 - "[FEAT] improve confusion matrix display" (deepchecks/deepchecks #2427)](https://linear.app/deepchecks/issue/DEE-439/[feat]-improve-confusion-matrix-display-deepchecksdeepchecks-2427)

#### What does this implement/fix? Explain your changes.
Removed the heatmap and added following information in the display:
- Added a piece of text displaying the overall accuracy of the model (by summing up all the accuracies and diving by the number of labels) and other relevant stats.
- After that, we display a max of 3 pie charts denoting the worst performing classes. Note that, we only consider the wrong predicted classes. We will consider the top three least accuracy classes and then will display a maximum of 3 pie charts based on the number of worst classes found. On hover on these pies, it displays the label name, the number of samples which are detected as the hovered label. Also, there is a threshold upto which the number of labels will be displayed in the pie chart. Above which, we will display as "Others" category. However, on hover, we display a comma separated list of label names for "Others"
- Added the relevant test cases for vision, NLP, tabular confusion matrix report.

#### Any other comments?
Its an initial PR for everyone to review the below displays and provide feedback.
- For NLP confusion matrix:
    - <img width="666" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/7f33fe45-52b4-4873-bbee-438ac9e74e51">


- For Tabular confusion matrix:
    - If all classes have accuracy of 100%: 
         -  <img width="665" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/f332d0fa-a728-4719-936c-4d24f474af0f">
    - If all classes does not have accuracy of 100%:
        - <img width="666" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/b33c8e8b-ca76-41c8-998c-87ed4c5336ab">


- For Vision confusion matrix:
      -  <img width="667" alt="image" src="https://github.com/deepchecks/deepchecks/assets/136261806/3fb6ce18-c4a2-451c-a76e-0eb81a428126">


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
