### PR TITLE
Update scipy version and broken pillow dependencies in requirements

### DIFF
--- a/deepchecks/vision/utils/image_functions.py
+++ b/deepchecks/vision/utils/image_functions.py
@@ -268,8 +268,8 @@ def prepare_thumbnail(
         # Takes the minimum factor in order for the image to not exceed the size in either width or height
         factor = min(width_factor, height_factor)
         size = (int(image.size[0] * factor), int(image.size[1] * factor))
-        # Resize the image by Resampling.LANCZOS
-        image = image.resize(size, pilimage.Resampling.LANCZOS)
+        # Resize the image by Image.LANCZOS
+        image = image.resize(size, pilimage.LANCZOS)
     else:
         image = ensure_image(image, copy=False)
 

--- a/deepchecks/vision/utils/image_functions.py
+++ b/deepchecks/vision/utils/image_functions.py
@@ -225,7 +225,7 @@ def get_font_with_size(text, desired_width):
     desired_width = max(100, desired_width)
     jump_size = 100
     while jump_size > 1:
-        if font.getsize(text)[0] < desired_width:
+        if font.size(text)[0] < desired_width:
             font_size += jump_size
         else:
             jump_size = jump_size // 2

--- a/deepchecks/vision/utils/image_functions.py
+++ b/deepchecks/vision/utils/image_functions.py
@@ -225,7 +225,9 @@ def get_font_with_size(text, desired_width):
     desired_width = max(100, desired_width)
     jump_size = 100
     while jump_size > 1:
-        if font.size(text)[0] < desired_width:
+        left, _, right, _ = font.getbbox(text)
+        width = right - left
+        if width < desired_width:
             font_size += jump_size
         else:
             jump_size = jump_size // 2

--- a/deepchecks/vision/utils/image_functions.py
+++ b/deepchecks/vision/utils/image_functions.py
@@ -266,8 +266,8 @@ def prepare_thumbnail(
         # Takes the minimum factor in order for the image to not exceed the size in either width or height
         factor = min(width_factor, height_factor)
         size = (int(image.size[0] * factor), int(image.size[1] * factor))
-        # Resize the image
-        image = image.resize(size, pilimage.ANTIALIAS)
+        # Resize the image by Resampling.LANCZOS
+        image = image.resize(size, pilimage.Resampling.LANCZOS)
     else:
         image = ensure_image(image, copy=False)
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -37,7 +37,7 @@ opencv-python>=4.1.2
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
-scipy>=1.4.1
+scipy>=1.4.1, <=1.10.1;
 tqdm>=4.41.0
 seaborn>=0.11.0
 wandb>=0.12.15,<0.13.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -34,7 +34,7 @@ kaleido  # optional dependency, used by plotly to transform figures into images
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.2
-Pillow>=7.1.2
+Pillow>=7.1.2, <=9.5.0
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1, <=1.10.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -37,6 +37,8 @@ opencv-python>=4.1.2
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
+# Remove the <=1.10.1 dependency below once sklearn's issue is fixed. The higher version causes
+# issues with sklear's _most_frequent() function using scipy's mode() function
 scipy>=1.4.1, <=1.10.1
 tqdm>=4.41.0
 seaborn>=0.11.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -34,7 +34,7 @@ kaleido  # optional dependency, used by plotly to transform figures into images
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.2
-Pillow>=7.1.2, <=9.5.0
+Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1, <=1.10.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -37,7 +37,7 @@ opencv-python>=4.1.2
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
-scipy>=1.4.1, <=1.10.1;
+scipy>=1.4.1, <=1.10.1
 tqdm>=4.41.0
 seaborn>=0.11.0
 wandb>=0.12.15,<0.13.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -38,7 +38,7 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 # Remove the <=1.10.1 dependency below once sklearn's issue is fixed. The higher version causes
-# issues with sklear's _most_frequent() function using scipy's mode() function
+# issues with sklearn's _most_frequent() function using scipy's mode() function
 scipy>=1.4.1, <=1.10.1
 tqdm>=4.41.0
 seaborn>=0.11.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ importlib_metadata>=1.4; python_version < '3.8'
 statsmodels>=0.11.0; python_version < '3.7'
 statsmodels>=0.13.5; python_version >= '3.7'
 # Remove the <=1.10.1 dependency below once sklearn's issue is fixed. The higher version causes
-# issues with sklear's _most_frequent() function using scipy's mode() function
+# issues with sklearn's _most_frequent() function using scipy's mode() function
 scipy>=1.4.1, <=1.10.1
 dataclasses>=0.6; python_version < '3.7'
 plotly>=5.13.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,7 +25,7 @@ importlib_metadata>=1.4; python_version < '3.8'
 # is updated, explicitly add it here
 statsmodels>=0.11.0; python_version < '3.7'
 statsmodels>=0.13.5; python_version >= '3.7'
-scipy>=1.4.1
+scipy>=1.4.1, <=1.10.1;
 dataclasses>=0.6; python_version < '3.7'
 plotly>=5.13.1
 matplotlib>=3.3.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,6 +25,8 @@ importlib_metadata>=1.4; python_version < '3.8'
 # is updated, explicitly add it here
 statsmodels>=0.11.0; python_version < '3.7'
 statsmodels>=0.13.5; python_version >= '3.7'
+# Remove the <=1.10.1 dependency below once sklearn's issue is fixed. The higher version causes
+# issues with sklear's _most_frequent() function using scipy's mode() function
 scipy>=1.4.1, <=1.10.1
 dataclasses>=0.6; python_version < '3.7'
 plotly>=5.13.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,7 +25,7 @@ importlib_metadata>=1.4; python_version < '3.8'
 # is updated, explicitly add it here
 statsmodels>=0.11.0; python_version < '3.7'
 statsmodels>=0.13.5; python_version >= '3.7'
-scipy>=1.4.1, <=1.10.1;
+scipy>=1.4.1, <=1.10.1
 dataclasses>=0.6; python_version < '3.7'
 plotly>=5.13.1
 matplotlib>=3.3.4


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2619 
Important fix since it is breaking a lot of tests. In recent scipy's version which is anything greater than 1.10.1 possibly 1.11.X causes the issue to have the index error.
Failing tests here: 
- https://github.com/deepchecks/deepchecks/pull/2617
- https://github.com/deepchecks/deepchecks/pull/2616

The recent version of scipy was released on 29th June.

#### What does this implement/fix? Explain your changes.
Restricting the version to be less than or equal to 1.10.1 (since I have been testing on this and all things works pretty fine)


---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
