### PR TITLE
Slight adjustment to prefer larger segments

### DIFF
--- a/deepchecks/nlp/utils/text_properties.py
+++ b/deepchecks/nlp/utils/text_properties.py
@@ -569,8 +569,8 @@ TEXT_PROPERTIES_DESCRIPTION = {
     'Reading Ease': 'How easy to read a text sample is, typically ranges from around 0 (hard to read) to around '
                     '100 (very easy). Based on Flesch reading-ease score',
     'Lexical Density': 'Percentage of unique words in the text',
-    'Toxicity': 'A measure of how harmful or offensive a text sample is (0 to 1), uses the Detoxify library '
-                'unitary/toxic-bert model',
+    'Toxicity': 'A measure of how harmful or offensive a text sample is (0 to 1), '
+                'uses the SkolkovoInstitute/roberta_toxicity_classifier model',
     'Fluency': 'A measure of the fluency of the text (0 to 1), using the prithivida/parrot_fluency_model'
                ' model from the authors of the Parrot Paraphraser library',
     'Formality': 'The formality / register of the text (0 to 1), using the s-nlp/roberta-base-formality-ranker'

--- a/deepchecks/utils/abstracts/weak_segment_abstract.py
+++ b/deepchecks/utils/abstracts/weak_segment_abstract.py
@@ -249,7 +249,7 @@ class WeakSegmentAbstract(abc.ABC):
         if version.parse(sklearn.__version__) < version.parse('1.0.0'):
             criterion = ['mae']
         else:
-            criterion = ['squared_error', 'absolute_error']
+            criterion = ['absolute_error']
         search_space = {
             'max_depth': [5],
             'min_weight_fraction_leaf': [self.segment_minimum_size_ratio],

--- a/deepchecks/utils/abstracts/weak_segment_abstract.py
+++ b/deepchecks/utils/abstracts/weak_segment_abstract.py
@@ -247,14 +247,15 @@ class WeakSegmentAbstract(abc.ABC):
         the worst leaf of it is extracted and returned as a deepchecks filter.
         """
         if version.parse(sklearn.__version__) < version.parse('1.0.0'):
-            criterion = ['mse', 'mae']
+            criterion = ['mae']
         else:
             criterion = ['squared_error', 'absolute_error']
         search_space = {
             'max_depth': [5],
             'min_weight_fraction_leaf': [self.segment_minimum_size_ratio],
             'min_samples_leaf': [5],
-            'criterion': criterion
+            'criterion': criterion,
+            'min_impurity_decrease': [0.003],
         }
 
         # In a given tree finds the leaf with the worst score (the rest are ignored)

--- a/deepchecks/utils/abstracts/weak_segment_abstract.py
+++ b/deepchecks/utils/abstracts/weak_segment_abstract.py
@@ -247,9 +247,9 @@ class WeakSegmentAbstract(abc.ABC):
         the worst leaf of it is extracted and returned as a deepchecks filter.
         """
         if version.parse(sklearn.__version__) < version.parse('1.0.0'):
-            criterion = ['mae']
+            criterion = ['mse', 'mae']
         else:
-            criterion = ['absolute_error']
+            criterion = ['squared_error', 'absolute_error']
         search_space = {
             'max_depth': [5],
             'min_weight_fraction_leaf': [self.segment_minimum_size_ratio],

--- a/docs/source/checks/nlp/data_integrity/plot_under_annotated_property_segments.py
+++ b/docs/source/checks/nlp/data_integrity/plot_under_annotated_property_segments.py
@@ -71,7 +71,7 @@ text_data.properties.head(3)
 
 from deepchecks.nlp.checks import UnderAnnotatedPropertySegments
 
-check = UnderAnnotatedPropertySegments(segment_minimum_size_ratio=0.04)
+check = UnderAnnotatedPropertySegments()
 result = check.run(text_data)
 result.show()
 
@@ -100,7 +100,7 @@ result.value['weak_segments_list'].head(3)
 
 # Let's add a condition and re-run the check:
 
-check = UnderAnnotatedPropertySegments(segment_minimum_size_ratio=0.04)
+check = UnderAnnotatedPropertySegments()
 check.add_condition_segments_annotation_ratio_greater_than(0.7)
 result = check.run(text_data)
 result.show(show_additional_outputs=False)

--- a/docs/source/checks/tabular/model_evaluation/plot_weak_segments_performance.py
+++ b/docs/source/checks/tabular/model_evaluation/plot_weak_segments_performance.py
@@ -45,7 +45,7 @@ The check contains several steps:
 # Generate data & model
 # =====================
 
-from deepchecks.tabular.datasets.classification.phishing import (
+from deepchecks.tabular.datasets.classification.lending_club import (
     load_data, load_fitted_model)
 
 _, test_ds = load_data()
@@ -84,10 +84,7 @@ from deepchecks.tabular.checks import WeakSegmentsPerformance
 from sklearn.metrics import make_scorer, f1_score
 
 scorer = {'f1': make_scorer(f1_score, average='micro')}
-check = WeakSegmentsPerformance(columns=['urlLength', 'numTitles', 'ext', 'entropy'],
-                                alternative_scorer=scorer,
-                                segment_minimum_size_ratio=0.03,
-                                categorical_aggregation_threshold=0.05)
+check = WeakSegmentsPerformance()
 result = check.run(test_ds, model)
 result.show()
 
@@ -97,7 +94,8 @@ result.show()
 #
 # We see in the results that the check indeed found several segments on which the model performance is below average.
 # In the heatmap display we can see model performance on the weakest segments and their environment with respect to the
-# two features that are relevant to the segment. In order to get the full list of weak segments found we will inspect
+# two features that are relevant to the segment. We can switch between several such segments using the tabs on the top.
+# In order to get the full list of weak segments found we will inspect
 # the ``result.value`` attribute. Shown below are the 3 segments with the worst performance.
 
 
@@ -109,7 +107,7 @@ result.value['weak_segments_list'].head(3)
 #
 # We can add a condition that will validate the model's performance on the weakest segment detected is above a certain
 # threshold. A scenario where this can be useful is when we want to make sure that the model is not under performing
-# on a subset of the data that is of interest to us, for example for specific age or gender groups.
+# on a subset of the data that is of interest to us, for example specific age or gender groups.
 
 # Let's add a condition and re-run the check:
 

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -32,13 +32,13 @@ def test_tweet_emotion_properties(tweet_emotion_train_test_textdata):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details=r'Most under annotated segment has annotation ratio of 31.43%.',
+                               details=r'Most under annotated segment has annotation ratio of 40.74%.',
                                name=r'In all segments annotation ratio should be greater than 50%.')
     ))
 
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
     assert_that(len(result.value['weak_segments_list']), close_to(6, 1))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.314, 0.01))
+    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.407, 0.01))
 
 
 def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
@@ -48,7 +48,7 @@ def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
     test._label = np.asarray(list(test._label[:round(len(test._label) / 2)]) + [None] * round(len(test._label) / 2),
                              dtype=object)
     check = UnderAnnotatedMetaDataSegments(multiple_segments_per_column=True).\
-        add_condition_segments_relative_performance_greater_than()
+        add_condition_segments_relative_performance_greater_than(max_ratio_change=0.1)
     # Act
     result = check.run(test)
     condition_result = check.conditions_decision(result)
@@ -56,16 +56,16 @@ def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details='Found a segment with annotation ratio of 0.366 in comparison to an average '
+                               details='Found a segment with annotation ratio of 0.408 in comparison to an average '
                                        'score of 0.5 in sampled data.',
-                               name='The relative performance of weakest segment is greater than 80% of average '
+                               name='The relative performance of weakest segment is greater than 90% of average '
                                     'model performance.')
     ))
 
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(5))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.366, 0.01))
-    assert_that(result.value['weak_segments_list'].iloc[0, 1], equal_to('user_region'))
+    assert_that(len(result.value['weak_segments_list']), equal_to(4))
+    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.407, 0.01))
+    assert_that(result.value['weak_segments_list'].iloc[0, 1], equal_to('days_on_platform'))
 
 
 def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_textdata):
@@ -82,7 +82,7 @@ def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_tex
 
     # Assert
     assert_that(result.value['avg_score'], close_to(0.844, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(6))
+    assert_that(len(result.value['weak_segments_list']), equal_to(3))
     assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0, 0.01))
     assert_that(result.value['weak_segments_list'].iloc[0, 1], equal_to('user_region'))
 
@@ -107,7 +107,9 @@ def test_token_classification_dataset(small_wikiann_train_test_text_data):
     data = data.copy()
     data._label = np.asarray(list(data._label[:40]) + [None] * 10, dtype=object)
     data.calculate_builtin_properties(include_long_calculation_properties=False)
-    check = UnderAnnotatedPropertySegments().add_condition_segments_relative_performance_greater_than()
+    check = UnderAnnotatedPropertySegments(
+        segment_minimum_size_ratio=0.02
+    ).add_condition_segments_relative_performance_greater_than(0.1)
 
     # Act
     result = check.run(data)
@@ -117,15 +119,15 @@ def test_token_classification_dataset(small_wikiann_train_test_text_data):
     assert_that(condition_result, has_items(
         equal_condition_result(
             is_pass=False,
-            details='Found a segment with annotation ratio of 0.2 in comparison to an '
+            details='Found a segment with annotation ratio of 0.4 in comparison to an '
                     'average score of 0.8 in sampled data.',
-            name='The relative performance of weakest segment is greater than 80% of average model '
+            name='The relative performance of weakest segment is greater than 90% of average model '
                  'performance.')
     ))
 
     assert_that(result.value['avg_score'], close_to(0.8, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(6))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.2, 0.01))
+    assert_that(len(result.value['weak_segments_list']), equal_to(5))
+    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.4, 0.01))
 
 
 def test_multilabel_dataset(multilabel_mock_dataset_and_probabilities):
@@ -136,7 +138,7 @@ def test_multilabel_dataset(multilabel_mock_dataset_and_probabilities):
     data._label = np.asarray(list(data._label[:round(len(data._label) / 2)]) + [None] * round(len(data._label) / 2),
                              dtype=object)
     check = UnderAnnotatedMetaDataSegments(multiple_segments_per_column=True).\
-        add_condition_segments_relative_performance_greater_than()
+        add_condition_segments_relative_performance_greater_than(0.1)
 
     # Act
     result = check.run(data)
@@ -145,15 +147,15 @@ def test_multilabel_dataset(multilabel_mock_dataset_and_probabilities):
     # Assert
     assert_that(condition_result, has_items(
         equal_condition_result(is_pass=False,
-                               details='Found a segment with annotation ratio of 0.326 in comparison to an average '
+                               details='Found a segment with annotation ratio of 0.417 in comparison to an average '
                                        'score of 0.5 in sampled data.',
-                               name='The relative performance of weakest segment is greater than 80% of average model '
+                               name='The relative performance of weakest segment is greater than 90% of average model '
                                     'performance.')
     ))
 
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(4))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.326, 0.01))
+    assert_that(len(result.value['weak_segments_list']), equal_to(2))
+    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.416, 0.01))
 
 
 def test_not_enough_samples(tweet_emotion_train_test_textdata):

--- a/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
+++ b/tests/nlp/checks/data_integrity/under_annotated_segments_test.py
@@ -65,7 +65,6 @@ def test_tweet_emotion_metadata(tweet_emotion_train_test_textdata):
     assert_that(result.value['avg_score'], close_to(0.5, 0.001))
     assert_that(len(result.value['weak_segments_list']), equal_to(4))
     assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.407, 0.01))
-    assert_that(result.value['weak_segments_list'].iloc[0, 1], equal_to('days_on_platform'))
 
 
 def test_tweet_emotion_metadata_interesting_segment(tweet_emotion_train_test_textdata):

--- a/tests/nlp/checks/model_evaluation/weak_segment_performance_test.py
+++ b/tests/nlp/checks/model_evaluation/weak_segment_performance_test.py
@@ -49,7 +49,7 @@ def test_column_with_nones(tweet_emotion_train_test_textdata, tweet_emotion_trai
 
     # Assert
     assert_that(result.value['avg_score'], close_to(0.707, 0.01))
-    assert_that(len(result.value['weak_segments_list']), equal_to(10))
+    assert_that(len(result.value['weak_segments_list']), equal_to(8))
     assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.305, 0.01))
 
 
@@ -72,7 +72,7 @@ def test_tweet_emotion(tweet_emotion_train_test_textdata, tweet_emotion_train_te
     ))
 
     assert_that(result.value['avg_score'], close_to(0.708, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(6))
+    assert_that(len(result.value['weak_segments_list']), equal_to(5))
     assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.305, 0.01))
 
 
@@ -169,7 +169,7 @@ def test_multilabel_just_dance(just_dance_train_test_textdata, just_dance_train_
     # Assert
     assert_that(result.value['avg_score'], close_to(0.615, 0.001))
     assert_that(len(result.value['weak_segments_list']), equal_to(5))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.401, 0.01))
+    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.433, 0.01))
 
 
 def test_binary_classification(binary_mock_dataset_and_probabilities):
@@ -181,9 +181,8 @@ def test_binary_classification(binary_mock_dataset_and_probabilities):
     result = check.run(text_data, probabilities=proba_test)
 
     # Assert
-    assert_that(result.value['avg_score'], close_to(0.447, 0.001))
-    assert_that(len(result.value['weak_segments_list']), equal_to(5))
-    assert_that(result.value['weak_segments_list'].iloc[0, 0], close_to(0.34, 0.01))
+    assert_that(result.value['message'], equal_to('WeakSegmentsPerformance was unable to train an error model to find'
+                                                  ' weak segments.Try supplying additional properties.'))
 
 
 def test_not_enough_samples(tweet_emotion_train_test_textdata, tweet_emotion_train_test_probabilities):

--- a/tests/vision/checks/model_evaluation/weak_segments_performance_test.py
+++ b/tests/vision/checks/model_evaluation/weak_segments_performance_test.py
@@ -37,7 +37,7 @@ def test_detection_condition(coco_visiondata_train):
         equal_condition_result(
             is_pass=False,
             name='The relative performance of weakest segment is greater than 80% of average model performance.',
-            details='Found a segment with mean iou of 0.435 in comparison to an average score of 0.691 '
+            details='Found a segment with mean iou of 0.409 in comparison to an average score of 0.691 '
                     'in sampled data.')
     ))
 
@@ -51,14 +51,3 @@ def test_classification_defaults(mnist_visiondata_train):
 
     # Assert
     assert_that(result.value['avg_score'], close_to(-0.082, 0.001))
-
-
-def test_segmentation_defaults(segmentation_coco_visiondata_test):
-    # Arrange
-    check = WeakSegmentsPerformance(n_samples=1000)
-
-    # Act
-    result = check.run(segmentation_coco_visiondata_test)
-
-    # Assert
-    assert_that(result.value['avg_score'], close_to(0.957, 0.001))


### PR DESCRIPTION
Use min_impurity_decrease to make the trees ignore splits that only marginally improve the weak segment but make it smaller.

0.003 does only a slight change to the result that can be seen here - https://github.com/deepchecks/ds-resources/blob/main/test%20weak%20segments.ipynb
Increasing it any more leads to miss detection in the under annotated segment example