### PR TITLE
cache models on cpu + hugging face based quantization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       with:
         requirements: 'requirements-all.txt'
         fail: 'Copyleft,Other,Error'
-        exclude: '(pyzmq.*23\.2\.1|debugpy.*1\.6\.7\.post1|certifi.*2023\.7\.22|tqdm.*4\.66\.1|webencodings.*0\.5\.1|torch.*1\.10\.2.*|torchvision.*0\.11\.3.*|terminado.*0\.15\.0.*|urllib3.*1\.26\.11.*|imageio.*2\.20\.0.*|jsonschema.*4\.8\.0.*|qudida.*0\.0\.4)'
+        exclude: '(pyzmq.*23\.2\.1|debugpy.*1\.6\.7\.post1|certifi.*2023\.7\.22|tqdm.*4\.66\.1|webencodings.*0\.5\.1|torch.*1\.10\.2.*|torchvision.*0\.11\.3.*|terminado.*0\.15\.0.*|urllib3.*1\.26\.11.*|imageio.*2\.20\.0.*|jsonschema.*4\.8\.0.*|qudida.*0\.0\.4*|tbb.*2021\.10\.0)'
         # pyzmq is Revised BSD https://github.com/zeromq/pyzmq/blob/main/examples/LICENSE
         # debugpy is MIT https://github.com/microsoft/debugpy/blob/main/LICENSE
         # certifi is MPL-2.0 https://github.com/certifi/python-certifi/blob/master/LICENSE
@@ -142,6 +142,7 @@ jobs:
         # jsonschema is MIT license https://github.com/python-jsonschema/jsonschema/blob/main/COPYING
         # debugpy is MIT license https://github.com/microsoft/debugpy/blob/main/LICENSE
         # qudida is MIT license https://github.com/arsenyinfo/qudida/blob/main/LICENSE
+        # tbb is Apache License 2.0 https://github.com/oneapi-src/oneTBB/blob/master/LICENSE
     - name: Print report
       if: ${{ always() }}
       run: echo "${{ steps.license_check_report.outputs.report }}"

--- a/deepchecks/nlp/utils/text_properties.py
+++ b/deepchecks/nlp/utils/text_properties.py
@@ -613,16 +613,18 @@ def _select_properties(
     ignore_properties = [prop.lower() for prop in ignore_properties] if ignore_properties else None
 
     if include_properties is not None:
-        properties = [prop for prop in ALL_PROPERTIES if prop['name'].lower() in include_properties]
+        properties = [prop for prop in ALL_PROPERTIES if
+                      prop['name'].lower() in include_properties]  # pylint: disable=unsupported-membership-test
         if len(properties) < len(include_properties):
             not_found_properties = sorted(set(include_properties) - set(prop['name'].lower() for prop in properties))
             raise DeepchecksValueError('include_properties contains properties that were not found: '
                                        f'{not_found_properties}.')
     elif ignore_properties is not None:
-        properties = [prop for prop in DEFAULT_PROPERTIES if prop['name'].lower() not in ignore_properties]
+        properties = [prop for prop in DEFAULT_PROPERTIES if
+                      prop['name'].lower() not in ignore_properties]  # pylint: disable=unsupported-membership-test
         if len(properties) + len(ignore_properties) != len(DEFAULT_PROPERTIES):
-            not_found_properties = \
-                [prop for prop in ignore_properties if prop not in [prop['name'] for prop in DEFAULT_PROPERTIES]]
+            default_property_names = [prop['name'].lower() for prop in DEFAULT_PROPERTIES]
+            not_found_properties = [prop for prop in list(ignore_properties) if prop not in default_property_names]
             raise DeepchecksValueError('ignore_properties contains properties that were not found: '
                                        f'{not_found_properties}.')
     else:

--- a/deepchecks/nlp/utils/text_properties.py
+++ b/deepchecks/nlp/utils/text_properties.py
@@ -589,17 +589,13 @@ TEXT_PROPERTIES_DESCRIPTION = {
 
 
 def _select_properties(
-        *,
         n_of_samples: int,
         include_properties: Optional[List[str]] = None,
         ignore_properties: Optional[List[str]] = None,
         include_long_calculation_properties: bool = False,
         device: Optional[str] = None,
 ) -> Sequence[TextProperty]:
-    """Select properties."""
-    all_properties = ALL_PROPERTIES
-    default_properties = DEFAULT_PROPERTIES
-
+    """Select properties to calculate based on provided parameters."""
     if include_properties is not None and ignore_properties is not None:
         raise ValueError('Cannot use properties and ignore_properties parameters together.')
     if include_properties is not None:
@@ -615,47 +611,42 @@ def _select_properties(
     ignore_properties = [prop.lower() for prop in ignore_properties] if ignore_properties else None
 
     if include_properties is not None:
-        properties = [prop for prop in all_properties if prop['name'].lower() in include_properties]
+        properties = [prop for prop in ALL_PROPERTIES if prop['name'].lower() in include_properties]
         if len(properties) < len(include_properties):
             not_found_properties = sorted(set(include_properties) - set(prop['name'].lower() for prop in properties))
             raise DeepchecksValueError('include_properties contains properties that were not found: '
                                        f'{not_found_properties}.')
     elif ignore_properties is not None:
-        properties = [prop for prop in default_properties if prop['name'].lower() not in ignore_properties]
-        if len(properties) + len(ignore_properties) != len(default_properties):
+        properties = [prop for prop in DEFAULT_PROPERTIES if prop['name'].lower() not in ignore_properties]
+        if len(properties) + len(ignore_properties) != len(DEFAULT_PROPERTIES):
             not_found_properties = \
-                [prop for prop in ignore_properties if prop not in [prop['name'] for prop in default_properties]]
+                [prop for prop in ignore_properties if prop not in [prop['name'] for prop in DEFAULT_PROPERTIES]]
             raise DeepchecksValueError('ignore_properties contains properties that were not found: '
                                        f'{not_found_properties}.')
     else:
-        properties = default_properties
+        properties = DEFAULT_PROPERTIES
 
     # include_long_calculation_properties is only applicable when include_properties is None
-    if not include_long_calculation_properties and include_properties is None:
+    if include_properties is None and not include_long_calculation_properties:
         return [
             prop for prop in properties
             if prop['name'] not in LONG_RUN_PROPERTIES
         ]
-
-    heavy_properties = [
-        prop for prop in properties
-        if prop['name'] in LONG_RUN_PROPERTIES
-    ]
-
-    if heavy_properties and n_of_samples > LARGE_SAMPLE_SIZE:
-        h_prop_names = [
-            prop['name']
-            for prop in heavy_properties
+    else:
+        heavy_properties = [
+            prop['name'] for prop in properties
+            if prop['name'] in LONG_RUN_PROPERTIES
         ]
-        warning_message = (
-            f'Calculating the properties {h_prop_names} on a large dataset may take a long time. '
-            'Consider using a smaller sample size or running this code on better hardware.'
-        )
-        if device is None or device == 'cpu':
-            warning_message += ' Consider using a GPU or a similar device to run these properties.'
-        warnings.warn(warning_message, UserWarning)
+        if heavy_properties and n_of_samples > LARGE_SAMPLE_SIZE:
+            warning_message = (
+                f'Calculating the properties {heavy_properties} on a large dataset may take a long time. '
+                'Consider using a smaller sample size or running this code on better hardware.'
+            )
+            if device is None or device == 'cpu':
+                warning_message += ' Consider using a GPU or a similar device to run these properties.'
+            warnings.warn(warning_message, UserWarning)
 
-    return properties
+        return properties
 
 
 def calculate_builtin_properties(
@@ -713,7 +704,9 @@ def calculate_builtin_properties(
     batch_size : int, default 8
         The batch size.
     cache_models : bool, default False
-        cache the models being used in this function, to save load time in next execution
+        If True, will store the models in CPU RAM memory. This will speed up the calculation, but will take up
+        more memory. If device is not CPU, the models will be moved from CPU RAM memory to relevant device before
+        calculation.
 
     Returns
     -------
@@ -735,42 +728,36 @@ def calculate_builtin_properties(
     }
 
     kwargs = dict(device=device, models_storage=models_storage)
-    english_properties_names = set(ENGLISH_ONLY_PROPERTIES)
-    text_properties_names = [it['name'] for it in text_properties]
-    calculated_properties = {k: [] for k in text_properties_names}
+    calculated_properties = {k: [] for k in properties_types.keys()}
 
     # Prepare kwargs for properties that require outside resources:
-    if 'fasttext_model' not in kwargs:
-        kwargs['fasttext_model'] = get_fasttext_model(models_storage=models_storage, use_cache=cache_models)
+    kwargs['fasttext_model'] = get_fasttext_model(models_storage=models_storage, use_cache=cache_models)
 
-    if 'cmudict_dict' not in kwargs:
-        properties_requiring_cmudict = list(set(CMUDICT_PROPERTIES) & set(text_properties_names))
-        if properties_requiring_cmudict:
-            if not nltk_download('cmudict', quiet=True):
-                _warn_if_missing_nltk_dependencies('cmudict', format_list(properties_requiring_cmudict))
-                for prop in properties_requiring_cmudict:
-                    calculated_properties[prop] = [np.nan] * len(raw_text)
-            kwargs['cmudict_dict'] = get_cmudict_dict(use_cache=cache_models)
+    properties_requiring_cmudict = list(set(CMUDICT_PROPERTIES) & set(properties_types.keys()))
+    if properties_requiring_cmudict:
+        if not nltk_download('cmudict', quiet=True):
+            _warn_if_missing_nltk_dependencies('cmudict', format_list(properties_requiring_cmudict))
+            for prop in properties_requiring_cmudict:
+                calculated_properties[prop] = [np.nan] * len(raw_text)
+        kwargs['cmudict_dict'] = get_cmudict_dict(use_cache=cache_models)
 
-    if 'Toxicity' in text_properties_names and 'toxicity_classifier' not in kwargs:
+    if 'Toxicity' in properties_types and 'toxicity_classifier' not in kwargs:
         kwargs['toxicity_classifier'] = get_transformer_pipeline(
             property_name='toxicity', model_name=TOXICITY_MODEL_NAME, device=device,
             models_storage=models_storage, use_cache=cache_models)
 
-    if 'Formality' in text_properties_names and 'formality_classifier' not in kwargs:
+    if 'Formality' in properties_types and 'formality_classifier' not in kwargs:
         kwargs['formality_classifier'] = get_transformer_pipeline(
             property_name='formality', model_name=FORMALITY_MODEL_NAME, device=device,
             models_storage=models_storage, use_cache=cache_models)
 
-    if 'Fluency' in text_properties_names and 'fluency_classifier' not in kwargs:
+    if 'Fluency' in properties_types and 'fluency_classifier' not in kwargs:
         kwargs['fluency_classifier'] = get_transformer_pipeline(
             property_name='fluency', model_name=FLUENCY_MODEL_NAME, device=device,
             models_storage=models_storage, use_cache=cache_models)
 
-    is_language_property_requested = 'Language' in [prop['name'] for prop in text_properties]
     # Remove language property from the list of properties to calculate as it will be calculated separately:
-    if is_language_property_requested:
-        text_properties = [prop for prop in text_properties if prop['name'] != 'Language']
+    text_properties = [prop for prop in text_properties if prop['name'] != 'Language']
 
     warning_message = (
         'Failed to calculate property {0}. '
@@ -779,6 +766,7 @@ def calculate_builtin_properties(
     )
     import_warnings = set()
 
+    # Calculate all properties for a specific batch than continue to the next batch
     for i in tqdm(range(0, len(raw_text), batch_size)):
         batch = raw_text[i:i + batch_size]
         batch_properties = defaultdict(list)
@@ -788,46 +776,47 @@ def calculate_builtin_properties(
         filtered_sequences = [e for i, e in enumerate(batch) if i not in nan_indices]
 
         samples_language = _batch_wrapper(text_batch=filtered_sequences, func=language, **kwargs)
-        if is_language_property_requested:
+        if 'Language' in properties_types:
             batch_properties['Language'].extend(samples_language)
             calculated_properties['Language'].extend(samples_language)
         kwargs['language_property_result'] = samples_language  # Pass the language property to other properties
+        kwargs['batch_size'] = batch_size
 
         non_english_indices = set()
         if ignore_non_english_samples_for_english_properties:
             non_english_indices = {i for i, (seq, lang) in enumerate(zip(filtered_sequences, samples_language))
                                    if lang != 'en'}
+
         for prop in text_properties:
             if prop['name'] in import_warnings:  # Skip properties that failed to import:
                 batch_properties[prop['name']].extend([np.nan] * len(batch))
-            else:
-                if prop['name'] in english_properties_names \
-                        and ignore_non_english_samples_for_english_properties is True:
-                    filtered_sequences = [e for i, e in enumerate(filtered_sequences) if i not in non_english_indices]
-                kwargs['batch_size'] = batch_size
-                try:
-                    if prop['name'] in BATCH_PROPERTIES:
-                        value = run_available_kwargs(func=prop['method'], text_batch=filtered_sequences, **kwargs)
-                    else:
-                        value = _batch_wrapper(text_batch=filtered_sequences, func=prop['method'], **kwargs)
-                    batch_properties[prop['name']].extend(value)
-                except ImportError as e:
-                    warnings.warn(warning_message.format(prop['name'], str(e)))
-                    batch_properties[prop['name']].extend([np.nan] * len(batch))
-                    import_warnings.add(prop['name'])
+                continue
 
+            sequences_to_use = list(filtered_sequences)
+            if prop['name'] in ENGLISH_ONLY_PROPERTIES and ignore_non_english_samples_for_english_properties:
+                sequences_to_use = [e for i, e in enumerate(sequences_to_use) if i not in non_english_indices]
+            try:
+                if prop['name'] in BATCH_PROPERTIES:
+                    value = run_available_kwargs(text_batch=sequences_to_use, func=prop['method'], **kwargs)
+                else:
+                    value = _batch_wrapper(text_batch=sequences_to_use, func=prop['method'], **kwargs)
+                batch_properties[prop['name']].extend(value)
+            except ImportError as e:
+                warnings.warn(warning_message.format(prop['name'], str(e)))
+                batch_properties[prop['name']].extend([np.nan] * len(batch))
+                import_warnings.add(prop['name'])
+                continue
+
+            # Fill in nan values for samples that were filtered out:
             result_index = 0
-
             for index, seq in enumerate(batch):
                 if index in nan_indices or (index in non_english_indices and
                                             ignore_non_english_samples_for_english_properties and
-                                            prop['name'] in english_properties_names):
+                                            prop['name'] in ENGLISH_ONLY_PROPERTIES):
                     calculated_properties[prop['name']].append(np.nan)
                 else:
                     calculated_properties[prop['name']].append(batch_properties[prop['name']][result_index])
                     result_index += 1
-
-            filtered_sequences = [e for i, e in enumerate(batch) if i not in nan_indices]
 
         # Clear property caches:
         textblob_cache.clear()

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -101,15 +101,15 @@ def _log_suppressor():
     is_progress_bar_enabled = transformers_logging.is_progress_bar_enabled()
 
     transformers_logging.set_verbosity_error()
-    logging.getLogger( __name__).setLevel(50)
+    logging.getLogger(__name__).setLevel(50)
     transformers_logging.disable_progress_bar()
-    logging.getLogger("transformers").setLevel(50)
+    logging.getLogger('transformers').setLevel(50)
 
     with warnings.catch_warnings():
         yield
 
     transformers_logging.set_verbosity(user_transformer_log_level)
-    logging.getLogger("transformers").setLevel(user_logger_level)
+    logging.getLogger('transformers').setLevel(user_logger_level)
     logging.getLogger(__name__).setLevel(deepchecks_logger_level)
     if is_progress_bar_enabled:
         transformers_logging.enable_progress_bar()

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -154,7 +154,8 @@ def _get_transformer_model_and_tokenizer(
             model = transformers.AutoModelForSequenceClassification.from_pretrained(model_name, **model_kwargs)
             model.save_pretrained(model_path)
 
-            tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+            # tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, device_map=None)
             tokenizer.save_pretrained(model_path)
 
     model.eval()

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -10,7 +10,6 @@
 #
 """Module containing the text properties models for the NLP module."""
 import pathlib
-import warnings
 from functools import lru_cache
 from importlib import import_module
 from importlib.util import find_spec
@@ -100,12 +99,14 @@ def _get_transformer_model_and_tokenizer(
     """Return a transformers' model and tokenizer in cpu memory."""
     transformers = import_optional_property_dependency('transformers', property_name=property_name)
     models_storage = get_create_model_storage(models_storage=models_storage)
-    model_path = models_storage / model_name
 
     model_kwargs = dict(device_map=None)
     if quantize_model:
         model_kwargs['load_in_8bit'] = True
         model_kwargs['torch_dtype'] = torch.float32
+        model_path = models_storage / 'quantized' / model_name
+    else:
+        model_path = models_storage / model_name
 
     if model_path.exists():
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_path, device_map=None)

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -126,7 +126,7 @@ def get_transformer_loader_params(model_name: str,
         model_path = models_storage / 'quantized' / model_name
         model_kwargs['load_in_8bit'] = True
         model_kwargs['torch_dtype'] = torch.float16
-        tokenizer_kwargs['torch_dtype'] = torch.float16
+        # tokenizer_kwargs['torch_dtype'] = torch.float16
     else:
         model_path = models_storage / model_name
 

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -126,7 +126,6 @@ def get_transformer_loader_params(model_name: str,
         model_path = models_storage / 'quantized' / model_name
         model_kwargs['load_in_8bit'] = True
         model_kwargs['torch_dtype'] = torch.float16
-        # tokenizer_kwargs['torch_dtype'] = torch.float16
     else:
         model_path = models_storage / model_name
 
@@ -154,9 +153,7 @@ def _get_transformer_model_and_tokenizer(
             model = transformers.AutoModelForSequenceClassification.from_pretrained(model_name, **model_kwargs)
             model.save_pretrained(model_path)
 
-            # tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
-            print(model_name)
-            tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, device_map=None)
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
             tokenizer.save_pretrained(model_path)
 
     model.eval()

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -101,9 +101,10 @@ def _log_suppressor():
     is_progress_bar_enabled = transformers_logging.is_progress_bar_enabled()
 
     transformers_logging.set_verbosity_error()
-    logging.getLogger("transformers").setLevel(50)
     logging.getLogger( __name__).setLevel(50)
     transformers_logging.disable_progress_bar()
+    logging.getLogger("transformers").setLevel(50)
+
     with warnings.catch_warnings():
         yield
 

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -155,6 +155,7 @@ def _get_transformer_model_and_tokenizer(
             model.save_pretrained(model_path)
 
             # tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+            print(model_name)
             tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, device_map=None)
             tokenizer.save_pretrained(model_path)
 

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -9,6 +9,7 @@
 # ----------------------------------------------------------------------------
 #
 """Module containing the text properties models for the NLP module."""
+import logging
 import pathlib
 from contextlib import contextmanager
 from functools import lru_cache
@@ -95,8 +96,14 @@ def get_transformer_pipeline(
 def _log_suppressor():
     user_log_level = transformers_logging.get_verbosity()
     transformers_logging.set_verbosity_error()
+    is_progress_bar_enabled = transformers_logging.is_progress_bar_enabled()
+    transformers_logging.disable_progress_bar()
+
+    logging.getLogger('transformers').setLevel(logging.ERROR)
     yield
     transformers_logging.set_verbosity(user_log_level)
+    if is_progress_bar_enabled:
+        transformers_logging.enable_progress_bar()
 
 
 @lru_cache(maxsize=5)

--- a/deepchecks/nlp/utils/text_properties_models.py
+++ b/deepchecks/nlp/utils/text_properties_models.py
@@ -97,16 +97,19 @@ def get_transformer_pipeline(
 def _log_suppressor():
     user_transformer_log_level = transformers_logging.get_verbosity()
     user_logger_level = logging.getLogger('transformers').getEffectiveLevel()
+    deepchecks_logger_level = logging.getLogger(__name__).getEffectiveLevel()
     is_progress_bar_enabled = transformers_logging.is_progress_bar_enabled()
 
     transformers_logging.set_verbosity_error()
     logging.getLogger("transformers").setLevel(50)
+    logging.getLogger( __name__).setLevel(50)
     transformers_logging.disable_progress_bar()
     with warnings.catch_warnings():
         yield
 
     transformers_logging.set_verbosity(user_transformer_log_level)
     logging.getLogger("transformers").setLevel(user_logger_level)
+    logging.getLogger(__name__).setLevel(deepchecks_logger_level)
     if is_progress_bar_enabled:
         transformers_logging.enable_progress_bar()
 

--- a/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
+++ b/deepchecks/tabular/checks/model_evaluation/boosting_overfit.py
@@ -119,17 +119,23 @@ class PartialBoostingModel:
     def n_estimators(cls, model):
         model = get_model_of_pipeline(model)
         model_class = model.__class__.__name__
+        n_estimator = None
         if model_class in ['AdaBoostClassifier', 'GradientBoostingClassifier', 'AdaBoostRegressor',
                            'GradientBoostingRegressor']:
-            return len(model.estimators_)
+            n_estimator = len(model.estimators_)
         elif model_class in ['LGBMClassifier', 'LGBMRegressor']:
-            return model.n_estimators
+            n_estimator = model.n_estimators
         elif model_class in ['XGBClassifier', 'XGBRegressor']:
-            return model.n_estimators
+            n_estimator = model.n_estimators
         elif model_class in ['CatBoostClassifier', 'CatBoostRegressor']:
-            return model.tree_count_
+            n_estimator = model.tree_count_
         else:
             cls._raise_not_supported_model_error(model_class=model_class)
+
+        if n_estimator is None:
+            raise ModelValidationError('Could not extract number of estimators from model')
+
+        return n_estimator
 
 
 class BoostingOverfit(TrainTestCheck):

--- a/deepchecks/utils/gpu_utils.py
+++ b/deepchecks/utils/gpu_utils.py
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""Utils for GPU management."""
+import gc
+
+import torch.cuda
+
+
+def empty_gpu(device):
+    gc.collect()
+    device = str(device)
+    if 'cuda' in device.lower():
+        torch.cuda.empty_cache()
+    elif 'mps' in device.lower():
+        try:
+            from torch import mps # pylint: disable=import-outside-toplevel
+
+            mps.empty_cache()
+        except Exception: # pylint: disable=broad-except
+            pass

--- a/deepchecks/utils/gpu_utils.py
+++ b/deepchecks/utils/gpu_utils.py
@@ -15,14 +15,15 @@ import torch.cuda
 
 
 def empty_gpu(device):
+    """Empty GPU or MPS memory and run garbage collector."""
     gc.collect()
     device = str(device)
     if 'cuda' in device.lower():
         torch.cuda.empty_cache()
     elif 'mps' in device.lower():
         try:
-            from torch import mps # pylint: disable=import-outside-toplevel
+            from torch import mps  # pylint: disable=import-outside-toplevel
 
             mps.empty_cache()
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             pass

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -23,7 +23,7 @@ pandas==1.3.5; python_version >= '3.7'
 
 catboost
 lightgbm
-xgboost==1.7.5
+xgboost<=1.7.5
 
 jupyter
 jupyterlab

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -23,7 +23,7 @@ pandas==1.3.5; python_version >= '3.7'
 
 catboost
 lightgbm
-xgboost
+xgboost==1.7.5
 
 jupyter
 jupyterlab

--- a/requirements/nlp-prop-requirements.txt
+++ b/requirements/nlp-prop-requirements.txt
@@ -1,2 +1,1 @@
-optimum[onnxruntime]>=1.8.8
 fasttext>=0.8.0

--- a/tests/tabular/checks/model_evaluation/boosting_overfit_test.py
+++ b/tests/tabular/checks/model_evaluation/boosting_overfit_test.py
@@ -55,7 +55,7 @@ def test_boosting_xgb_classifier(iris_split_dataset_and_model_xgb):
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(0.9855, 0.001))
+    assert_that(mean(train_scores), close_to(0.99, 0.001))
     assert_that(mean(test_scores), close_to(0.985, 0.001))
     assert_that(result.display, has_length(greater_than(0)))
 
@@ -72,7 +72,7 @@ def test_boosting_xgb_classifier_without_display(iris_split_dataset_and_model_xg
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(0.9855, 0.001))
+    assert_that(mean(train_scores), close_to(0.99, 0.001))
     assert_that(mean(test_scores), close_to(0.985, 0.001))
     assert_that(result.display, has_length(0))
 
@@ -159,8 +159,8 @@ def test_boosting_regressor_xgb(diabetes_split_dataset_and_model_xgb):
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(-22.47, 0.01))
-    assert_that(mean(test_scores), close_to(-59.68, 0.01))
+    assert_that(mean(train_scores), close_to(-22.67, 0.01))
+    assert_that(mean(test_scores), close_to(-66.99, 0.01))
 
 
 def test_boosting_regressor_lgbm(diabetes_split_dataset_and_model_lgbm):

--- a/tests/tabular/checks/model_evaluation/boosting_overfit_test.py
+++ b/tests/tabular/checks/model_evaluation/boosting_overfit_test.py
@@ -55,7 +55,7 @@ def test_boosting_xgb_classifier(iris_split_dataset_and_model_xgb):
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(0.99, 0.001))
+    assert_that(mean(train_scores), close_to(0.9855, 0.001))
     assert_that(mean(test_scores), close_to(0.985, 0.001))
     assert_that(result.display, has_length(greater_than(0)))
 
@@ -72,7 +72,7 @@ def test_boosting_xgb_classifier_without_display(iris_split_dataset_and_model_xg
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(0.99, 0.001))
+    assert_that(mean(train_scores), close_to(0.9855, 0.001))
     assert_that(mean(test_scores), close_to(0.985, 0.001))
     assert_that(result.display, has_length(0))
 
@@ -146,6 +146,7 @@ def test_boosting_regressor(diabetes, diabetes_model):
     assert_that(mean(train_scores), close_to(-44.52, 0.01))
     assert_that(mean(test_scores), close_to(-59.35, 0.01))
 
+
 def test_boosting_regressor_xgb(diabetes_split_dataset_and_model_xgb):
     # Arrange
     train, test, model = diabetes_split_dataset_and_model_xgb
@@ -158,8 +159,8 @@ def test_boosting_regressor_xgb(diabetes_split_dataset_and_model_xgb):
     test_scores = result.value['test']
     assert_that(train_scores, has_length(20))
     assert_that(test_scores, has_length(20))
-    assert_that(mean(train_scores), close_to(-22.67, 0.01))
-    assert_that(mean(test_scores), close_to(-66.99, 0.01))
+    assert_that(mean(train_scores), close_to(-22.47, 0.01))
+    assert_that(mean(test_scores), close_to(-59.68, 0.01))
 
 
 def test_boosting_regressor_lgbm(diabetes_split_dataset_and_model_lgbm):
@@ -192,7 +193,6 @@ def test_boosting_regressor_cat(diabetes_split_dataset_and_model_cat):
     assert_that(test_scores, has_length(20))
     assert_that(mean(train_scores), close_to(-35.49, 0.01))
     assert_that(mean(test_scores), close_to(-59.04, 0.01))
-
 
 
 def test_boosting_classifier_with_metric(iris):

--- a/tests/tabular/conftest.py
+++ b/tests/tabular/conftest.py
@@ -226,7 +226,7 @@ def diabetes_split_dataset_and_model_custom(diabetes, diabetes_model):
 @pytest.fixture(scope='session')
 def diabetes_split_dataset_and_model_xgb(diabetes):
     train, test = diabetes
-    clf = XGBRegressor(random_state=0, n_estimators=20)
+    clf = XGBRegressor(random_state=0)
     clf.fit(train.data[train.features], train.data[train.label_name])
     return train, test, clf
 
@@ -311,7 +311,7 @@ def iris_split_dataset_and_model_custom(iris_split_dataset_and_model) -> Tuple[D
 def iris_split_dataset_and_model_xgb(iris_split_dataset) -> Tuple[Dataset, Dataset, XGBClassifier]:
     """Return Iris train and val datasets and trained AdaBoostClassifier model."""
     train_ds, test_ds = iris_split_dataset
-    clf = XGBClassifier(random_state=0, n_estimators=20)
+    clf = XGBClassifier(random_state=0)
     clf.fit(train_ds.features_columns, train_ds.label_col)
     return train_ds, test_ds, clf
 

--- a/tests/tabular/conftest.py
+++ b/tests/tabular/conftest.py
@@ -226,7 +226,7 @@ def diabetes_split_dataset_and_model_custom(diabetes, diabetes_model):
 @pytest.fixture(scope='session')
 def diabetes_split_dataset_and_model_xgb(diabetes):
     train, test = diabetes
-    clf = XGBRegressor(random_state=0)
+    clf = XGBRegressor(random_state=0, n_estimators=20)
     clf.fit(train.data[train.features], train.data[train.label_name])
     return train, test, clf
 
@@ -311,7 +311,7 @@ def iris_split_dataset_and_model_custom(iris_split_dataset_and_model) -> Tuple[D
 def iris_split_dataset_and_model_xgb(iris_split_dataset) -> Tuple[Dataset, Dataset, XGBClassifier]:
     """Return Iris train and val datasets and trained AdaBoostClassifier model."""
     train_ds, test_ds = iris_split_dataset
-    clf = XGBClassifier(random_state=0)
+    clf = XGBClassifier(random_state=0, n_estimators=20)
     clf.fit(train_ds.features_columns, train_ds.label_col)
     return train_ds, test_ds, clf
 


### PR DESCRIPTION
This pr contain two main contributions:

1. Models can be cached on cpu and then moved to relevant device before inference for nlp properties calculation - this to skip the time required to load the models from disc
2. Deepchecks now support huggingface based quantization for all relevant models

This pr relevant test were tested on both a GPU and a CPU only machines. Resolves https://linear.app/deepchecks/issue/LLM-533/release-memory-from-gpu-when-using-deepchecks-models