### PR TITLE
Added support for filterting check results by name

### DIFF
--- a/deepchecks/core/suite.py
+++ b/deepchecks/core/suite.py
@@ -130,12 +130,12 @@ class SuiteResult(DisplayableResult):
             raise DeepchecksNotSupportedError('Either idx or names should be passed')
         if idx and names:
             raise DeepchecksNotSupportedError('Only one of idx or names should be passed')
-        output = []
-        for index, result in enumerate(self.results):
-            if idx and index in idx:
-                output.append(result)
-            elif names and result.get_header() in names:
-                output.append(result)
+
+        if names:
+            names = [name.lower().replace('_', ' ').strip() for name in names]
+            output = [result for name in names for result in self.results if result.get_header().lower() == name]
+        else:
+            output = [result for index, result in enumerate(self.results) if index in idx]
         return output
 
     def __repr__(self):

--- a/deepchecks/core/suite.py
+++ b/deepchecks/core/suite.py
@@ -110,7 +110,22 @@ class SuiteResult(DisplayableResult):
         'check_types.CheckResult',
         'check_types.CheckFailure'
     ]]:
-        """Select results either by indexes or result header names."""
+        """Select results either by indexes or result header names.
+
+        Parameters
+        ----------
+        idx : Set[int], default None
+            The list of indexes to filter the check results from the results list. If
+            names is None, then this parameter is required.
+        names : Set[str], default None
+            The list of names denoting the header of the check results. If idx is None,
+            this parameter is required. Both idx and names cannot be passed.
+
+        Returns
+        -------
+        List[Union['check_types.CheckResult', 'check_types.CheckFailure']] :
+            A list of check results filtered either by the indexes or by their names.
+        """
         if idx is None and names is None:
             raise DeepchecksNotSupportedError('Either idx or names should be passed')
         if idx and names:

--- a/deepchecks/core/suite.py
+++ b/deepchecks/core/suite.py
@@ -119,7 +119,7 @@ class SuiteResult(DisplayableResult):
         for index, result in enumerate(self.results):
             if idx and index in idx:
                 output.append(result)
-            elif names and (result.get_header() in names or result.get_metadata()['name'] in names):
+            elif names and result.get_header() in names:
                 output.append(result)
         return output
 

--- a/deepchecks/core/suite.py
+++ b/deepchecks/core/suite.py
@@ -119,7 +119,7 @@ class SuiteResult(DisplayableResult):
         for index, result in enumerate(self.results):
             if idx and index in idx:
                 output.append(result)
-            elif names and result.get_header() in names:
+            elif names and (result.get_header() in names or result.get_metadata()['name'] in names):
                 output.append(result)
         return output
 

--- a/deepchecks/core/suite.py
+++ b/deepchecks/core/suite.py
@@ -106,14 +106,20 @@ class SuiteResult(DisplayableResult):
             else:
                 raise TypeError(f'Unknown type of result - {type(result).__name__}')
 
-    def select_results(self, idx: Set[int]) -> List[Union[
+    def select_results(self, idx: Set[int] = None, names: Set[str] = None) -> List[Union[
         'check_types.CheckResult',
         'check_types.CheckFailure'
     ]]:
-        """Select results by indexes."""
+        """Select results either by indexes or result header names."""
+        if idx is None and names is None:
+            raise DeepchecksNotSupportedError('Either idx or names should be passed')
+        if idx and names:
+            raise DeepchecksNotSupportedError('Only one of idx or names should be passed')
         output = []
         for index, result in enumerate(self.results):
-            if index in idx:
+            if idx and index in idx:
+                output.append(result)
+            elif names and result.get_header() in names:
                 output.append(result)
         return output
 

--- a/tests/base/check_suite_test.py
+++ b/tests/base/check_suite_test.py
@@ -10,17 +10,17 @@
 #
 """suites tests"""
 import random
-from typing import List
 
-from hamcrest import all_of, assert_that, calling, equal_to, has_entry, has_items, has_length, instance_of, is_, raises
+from hamcrest import all_of, assert_that, calling, equal_to, has_entry, has_length, instance_of, is_, raises
 
 from deepchecks import __version__
 from deepchecks.core import CheckFailure, CheckResult, ConditionCategory, ConditionResult, SuiteResult
-from deepchecks.core.errors import DeepchecksValueError, DeepchecksNotSupportedError
+from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError
 from deepchecks.core.suite import BaseSuite
-from deepchecks.tabular import SingleDatasetCheck, Suite, TrainTestCheck
+from deepchecks.tabular import Dataset, SingleDatasetCheck, Suite, TrainTestCheck
 from deepchecks.tabular import checks as tabular_checks
-from deepchecks.tabular.suites import model_evaluation
+from deepchecks.tabular import datasets
+from deepchecks.tabular.suites import data_integrity, model_evaluation
 
 
 class SimpleDatasetCheck(SingleDatasetCheck):
@@ -71,23 +71,26 @@ def test_select_results_with_and_without_args_from_suite_result():
 
 def test_select_results_with_indexes_and_names_from_suite_result():
     # Arrange
-    result1 = CheckResult(0, 'check1')
-    result1.conditions_results = [ConditionResult(ConditionCategory.PASS)]
-    result2 = CheckResult(0, 'check2')
-    result2.conditions_results = [ConditionResult(ConditionCategory.PASS)]
-    result3 = CheckResult(0, 'check3')
-    result3.conditions_results = [ConditionResult(ConditionCategory.PASS)]
+    data = datasets.regression.avocado.load_data(data_format='DataFrame', as_train_test=False)
+    ds = Dataset(data, cat_features= ['type'], datetime_name='Date', label= 'AveragePrice')
+    integ_suite = data_integrity()
+    suite_result = integ_suite.run(ds)
 
     # Act & Assert
-    suite_results_by_indexes = SuiteResult('test', [result1, result2, result3]).select_results(idx=[0, 2])
-    suite_results_by_name = SuiteResult('test', [result1, result2, result3]).select_results(names=['check1'])
-    
-    assert_that(len(suite_results_by_name), equal_to(1))
-    assert_that(len(suite_results_by_indexes), equal_to(2))
-    assert_that(suite_results_by_name[0].get_header(), equal_to('check1'))
+    suite_results_by_indexes = suite_result.select_results(idx=[0, 2])
+    suite_results_by_name = suite_result.select_results(names=['Conflicting Labels - Train Dataset',
+                                                               'Outlier Sample Detection',
+                                                               'mixed_Nulls'])
 
-    assert_that(suite_results_by_indexes[0].get_header(), equal_to('check1'))
-    assert_that(suite_results_by_indexes[1].get_header(), equal_to('check3'))
+    assert_that(len(suite_results_by_indexes), equal_to(2))
+    assert_that(len(suite_results_by_name), equal_to(3))
+
+    assert_that(suite_results_by_indexes[0].get_header(), equal_to('Feature-Feature Correlation'))
+    assert_that(suite_results_by_indexes[1].get_header(), equal_to('Single Value in Column'))
+
+    assert_that(suite_results_by_name[0].get_header(), equal_to('Conflicting Labels - Train Dataset'))
+    assert_that(suite_results_by_name[1].get_header(), equal_to('Outlier Sample Detection'))
+    assert_that(suite_results_by_name[2].get_header(), equal_to('Mixed Nulls'))
 
 def test_add_check_to_the_suite():
     number_of_checks = random.randint(0, 50)

--- a/tests/nlp/utils/test_properties.py
+++ b/tests/nlp/utils/test_properties.py
@@ -12,15 +12,15 @@
 import os
 import pathlib
 import timeit
+import uuid
 
 import numpy as np
 import pytest
-import uuid
 from hamcrest import *
 
 from deepchecks.core.errors import DeepchecksValueError
-from deepchecks.nlp.utils.text_properties import (_sample_for_property, calculate_builtin_properties,
-                                                  english_text, TOXICITY_MODEL_NAME_ONNX)
+from deepchecks.nlp.utils.text_properties import (TOXICITY_MODEL_NAME_ONNX, _sample_for_property,
+                                                  calculate_builtin_properties, english_text)
 from deepchecks.nlp.utils.text_properties_models import MODELS_STORAGE, _get_transformer_model_and_tokenizer
 
 

--- a/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
+++ b/tests/tabular/checks/model_evaluation/confusion_matrix_report_test.py
@@ -10,7 +10,7 @@
 #
 """Contains unit tests for the confusion_matrix_report check."""
 import numpy as np
-from hamcrest import assert_that, calling, greater_than, has_length, raises, equal_to
+from hamcrest import assert_that, calling, equal_to, greater_than, has_length, raises
 
 from deepchecks.core.condition import ConditionCategory
 from deepchecks.core.errors import DeepchecksNotSupportedError, DeepchecksValueError, ModelValidationError


### PR DESCRIPTION
- Added implementation for fetching the check results by header name of the check. I have added this functionality in the same function and added checks in order to accept either indexes or names (one of them required always).
- Will be working on the other part of the task to figure out a way to know the row in the DF which causes any checks to fail so that user can know which data point is problematic.