### PR TITLE
Update `MyModelWrapper` so that sklearn recognizes as a classifier.

### DIFF
--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -261,6 +261,7 @@ class DeepcheckScorer:
                 if len(data) > 1:
                     predictions = predictions.squeeze()
                 self.predictions = pd.Series(predictions, index=data.index)
+                self._estimator_type = "classifier"
 
             def predict(self, data: pd.DataFrame) -> np.ndarray:
                 """Convert labels to 0/1 if model is a binary classifier."""

--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -261,7 +261,7 @@ class DeepcheckScorer:
                 if len(data) > 1:
                     predictions = predictions.squeeze()
                 self.predictions = pd.Series(predictions, index=data.index)
-                self._estimator_type = "classifier"
+                self._estimator_type = 'classifier'
 
             def predict(self, data: pd.DataFrame) -> np.ndarray:
                 """Convert labels to 0/1 if model is a binary classifier."""


### PR DESCRIPTION
Update `MyModelWrapper` so that sklearn recognizes as a classifier.

#### Reference Issues/PRs
Fixes #2750 

#### What does this implement/fix? Explain your changes.

Adds/sets the `_estimator_type`  to `"classifier"` for the `MyModelWrapper` class that wraps classification models within the `DeepcheckScorer` class.  This ensures that scikit-learn treats wrapper as a classifier and does not raise a `ValueError` when calling scorer with `predict_proba` method.

#### Any other comments?



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
