### PR TITLE
ci: Add Python 3.10 & 3.11 to CI test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"] #TODO: add 3.10 when upgrading torch to 1.11
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/makefile
+++ b/makefile
@@ -158,18 +158,18 @@ vision-torch-tf-setup: env
 		$(PIP) install -q \
 			"torch==2.4.1" "torchvision==0.19.1" \
 			--index-url https://download.pytorch.org/whl/cu118; \
-		$(PIP) install -q "tensorflow-gpu==2.11.0"; \
+		$(PIP) install -q "tensorflow-gpu==2.13.0"; \
 	elif [ $(OS) = "Linux" ]; \
 	then \
 		$(PIP) install -q \
 			"torch==2.4.1" "torchvision==0.19.1" \
 			--index-url https://download.pytorch.org/whl/cpu; \
-		$(PIP) install -q "tensorflow==2.11.0"; \
+		$(PIP) install -q "tensorflow==2.13.0"; \
 	else \
 		$(PIP) install -q \
 			"torch==2.4.1" "torchvision==0.19.1" \
 			--index-url https://download.pytorch.org/whl/cpu; \
-		$(PIP) install -q "tensorflow==2.11.0"; \
+		$(PIP) install -q "tensorflow==2.13.0"; \
 	fi;
 
 	@$(PIP) install -q "tensorflow-hub==0.12.0";

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -17,9 +17,11 @@ tox
 gower==0.0.5
 deepdiff<=6.3.1
 
-scikit-learn==1.0.2; python_version >= '3.7'
+scikit-learn==1.0.2; python_version < '3.10'
+scikit-learn==1.3.2; python_version >= '3.10'
 # pandas 1.3.5 is the last version to support Python 3.7
-pandas==1.3.5; python_version >= '3.7'
+pandas==1.3.5; python_version < '3.10'
+pandas==1.5.3; python_version >= '3.10'
 
 catboost; python_version >= '3.7'
 catboost<=1.2.2; python_version < '3.7'

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=1.1.5
 numpy>=1.19; python_version < '3.8'
 numpy>=1.22.2; python_version >= '3.8'
-scikit-learn>=0.23.2
+scikit-learn>=0.23.2,<1.4
 jsonpickle>=2
 PyNomaly==0.3.4
 

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     license_files=('LICENSE', ),
     url = 'https://github.com/deepchecks/deepchecks',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 ; ----------------------------------------------------------------------------
 ;
 [tox]
-envlist = python36,python37,python38,python39,python310
+envlist = python36,python37,python38,python39,python310,python311
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed


### PR DESCRIPTION
Add Python 3.10 and 3.11 to the GitHub Actions build workflow, tox envlist, and setup.py classifiers.

Dependency changes required for 3.10/3.11 compatibility:
- Pin scikit-learn<1.4 in requirements.txt to retain the max_error scorer (removed in 1.4)
- Bump dev-requirements scikit-learn to 1.3.2 for 3.10+ (1.0.2 has no wheels for 3.10/3.11)
- Bump dev-requirements pandas to 1.5.3 for 3.10+ (1.3.5 has no wheels for 3.10/3.11)
- Bump tensorflow from 2.11.0 to 2.13.0 in makefile (2.11.0 has no wheels for 3.10+)


Related to #2161


#### What does this implement/fix? Explain your changes.
Adds python 3.10 and 3.11 support and updates lib versions to enable support

#### Any other comments?



---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
