### PR TITLE
metric_utils: switch make_scorer kwargs to response_method (#2806)

### DIFF
--- a/deepchecks/tabular/metric_utils/scorers.py
+++ b/deepchecks/tabular/metric_utils/scorers.py
@@ -49,6 +49,17 @@ from deepchecks.utils.simple_models import PerfectModel
 from deepchecks.utils.typing import BasicModel
 from deepchecks.utils.validation import is_sequence_not_str
 
+# sklearn 1.4 deprecated ``needs_proba``/``needs_threshold`` in favor of
+# ``response_method``; sklearn 1.6 removed them outright (see
+# https://scikit-learn.org/stable/whats_new/v1.4.html#sklearn-metrics).
+# ``deepchecks/deepchecks#2806`` tracks the resulting failure when users
+# combine deepchecks with a current sklearn. Pick the right kwargs once,
+# at module import, instead of try/except-ing each ``make_scorer`` call.
+if version.parse(scikit_version) >= version.parse('1.4'):
+    _PROBA_SCORER_KWARGS = {'response_method': 'predict_proba'}
+else:
+    _PROBA_SCORER_KWARGS = {'needs_proba': True}
+
 if TYPE_CHECKING:
     from deepchecks import tabular  # pylint: disable=unused-import; it is used for type annotations
 
@@ -148,12 +159,12 @@ binary_scorers_dict = {
     'tnr': make_scorer(true_negative_rate_metric, averaging_method='binary'),
     'jaccard': make_scorer(jaccard_score, zero_division=0),
     'roc_auc': get_scorer('roc_auc'),
-    'neg_log_loss': make_scorer(log_loss, greater_is_better=False, needs_proba=True, labels=[0, 1]),
+    'neg_log_loss': make_scorer(log_loss, greater_is_better=False, labels=[0, 1], **_PROBA_SCORER_KWARGS),
     **common_classification_metrics
 }
 
 multiclass_scorers_dict = {
-    'roc_auc_per_class': make_scorer(roc_auc_per_class, needs_proba=True),
+    'roc_auc_per_class': make_scorer(roc_auc_per_class, **_PROBA_SCORER_KWARGS),
     'roc_auc_ovr': get_scorer('roc_auc_ovr'),
     'roc_auc_ovo': get_scorer('roc_auc_ovo'),
     'roc_auc_ovr_weighted': get_scorer('roc_auc_ovr_weighted'),

--- a/tests/utils/metrics_test.py
+++ b/tests/utils/metrics_test.py
@@ -228,3 +228,83 @@ def test_mse_diabetes(diabetes_split_dataset_and_model):
     # Assert
     assert_that(score.mean(), close_to(-1 * 3296, 1))
     assert_that(score.mean(), close_to(-1 * score_sklearn, 0.01))
+
+
+# Regression tests for deepchecks/deepchecks#2806: ``make_scorer(...,
+# needs_proba=True)`` was deprecated in scikit-learn 1.4 and removed in
+# 1.6, so on a current sklearn the call raised at module-import time and
+# anything that used ``binary_scorers_dict`` / ``multiclass_scorers_dict``
+# (e.g. passing ``scorers=['neg_log_loss']`` to a check) failed before
+# scoring. The fix is to switch to ``response_method='predict_proba'``
+# whenever sklearn>=1.4 is installed.
+#
+# These tests fail on origin/main when run against sklearn>=1.6 (the
+# module import raises ``TypeError: make_scorer() got an unexpected
+# keyword argument 'needs_proba'``) and pass on this branch.
+
+def test_neg_log_loss_scorer_kwargs_match_runtime_sklearn():
+    """Verify the module-level kwarg switch picks the right knob for the
+    installed sklearn — the *single* place where the fix lives."""
+    from packaging import version
+    from sklearn import __version__ as scikit_version
+
+    from deepchecks.tabular.metric_utils.scorers import _PROBA_SCORER_KWARGS
+
+    if version.parse(scikit_version) >= version.parse('1.4'):
+        assert_that(_PROBA_SCORER_KWARGS, is_({'response_method': 'predict_proba'}))
+    else:
+        assert_that(_PROBA_SCORER_KWARGS, is_({'needs_proba': True}))
+
+
+def test_neg_log_loss_scorer_constructible():
+    """The bug from #2806 manifests at module-import time on sklearn>=1.6;
+    asserting the scorer is in the registry doubles as an import-time
+    smoke test."""
+    from deepchecks.tabular.metric_utils.scorers import _str_to_scorer_dict, binary_scorers_dict
+
+    assert_that('neg_log_loss' in binary_scorers_dict, is_(True))
+    assert_that('neg_log_loss' in _str_to_scorer_dict, is_(True))
+    assert_that('roc_auc_per_class' in _str_to_scorer_dict, is_(True))
+
+
+def test_neg_log_loss_scorer_callable_on_classifier():
+    """Issue #2806: the user-visible failure is at *call* time, not at
+    ``make_scorer`` time — sklearn 1.6+ silently swallows ``needs_proba``
+    via ``**kwargs`` in ``make_scorer`` but then forwards it to
+    ``log_loss`` when the scorer is invoked, raising
+    ``TypeError: got an unexpected keyword argument 'needs_proba'``.
+    This test exercises the call path on a trivial in-memory binary
+    classifier — no data fixtures required, no upstream dataset download.
+    On origin/main with sklearn>=1.6 it raises the TypeError above; on
+    this branch it returns a finite negative log-loss."""
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+
+    from deepchecks.tabular.metric_utils.scorers import binary_scorers_dict
+
+    X = np.array([[0., 0.], [1., 1.], [0., 1.], [1., 0.], [0., 0.5], [1., 0.5]])
+    y_binary = np.array([0, 1, 0, 1, 0, 1])
+    binary_clf = LogisticRegression().fit(X, y_binary)
+
+    neg_log_loss = binary_scorers_dict['neg_log_loss']
+    score = float(neg_log_loss(binary_clf, X, y_binary))
+
+    assert_that(score <= 0.0, is_(True))
+
+
+def test_roc_auc_per_class_scorer_scores_multiclass(iris_split_dataset_and_model):
+    """Issue #2806: the second occurrence of ``needs_proba`` in this module
+    was on ``roc_auc_per_class`` in ``multiclass_scorers_dict``. The
+    existing ``test_classification_deepchecks_scorers`` integration test
+    (in ``train_test_performance_test.py``) already covers the iris-fitted
+    score = 0.997 expectation — this test asserts the same observable
+    behavior is preserved by going straight through the scorer registry,
+    so a regression is caught even if the integration test path changes."""
+    from deepchecks.tabular.metric_utils.scorers import multiclass_scorers_dict
+
+    _, test_ds, clf = iris_split_dataset_and_model
+    scorer = deepchecks_scorer(multiclass_scorers_dict['roc_auc_per_class'], clf, test_ds)
+
+    score = scorer(clf, test_ds)
+
+    assert_that(score[1], close_to(0.997, 0.01))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2806.

#### What does this implement/fix? Explain your changes.

scikit-learn deprecated `make_scorer(..., needs_proba=True)` in 1.4 and removed
it in 1.6 in favour of `response_method='predict_proba'` (see the
[1.4 changelog entry for `sklearn.metrics`](https://scikit-learn.org/stable/whats_new/v1.4.html#sklearn-metrics)).
Two scorers in `deepchecks/tabular/metric_utils/scorers.py` still passed the
old kwarg:

- `binary_scorers_dict['neg_log_loss']` (the literal site reported by the issue)
- `multiclass_scorers_dict['roc_auc_per_class']` (same kwarg pattern, multiclass dict)

On sklearn ≥ 1.6 `make_scorer` silently absorbs the unknown kwarg via its
`**kwargs` parameter; the failure surfaces only at scoring time as
`TypeError: got an unexpected keyword argument 'needs_proba'`, exactly the
traceback the reporter shared. Since `requirements/requirements.txt` pins
`scikit-learn>=0.23.2` with no upper bound, every user on a current sklearn
hits this when they pass `scorers=['neg_log_loss']` to a check.

The fix builds a `_PROBA_SCORER_KWARGS` dict once at module import based on
the installed sklearn version (`response_method='predict_proba'` for ≥ 1.4,
the legacy `needs_proba=True` for < 1.4) and applies it at both call sites.
The same `version.parse(scikit_version)` pattern is already used elsewhere in
this module (line 469 for `OneHotEncoder`'s `sparse_output` kwarg), so this
keeps the version-gating idiom consistent.

#### Any other comments?

The diff is intentionally narrow: only the two `needs_proba=True` call sites
and the dispatch dict are touched. Two related sklearn-version drifts
(`max_error` was renamed to `neg_max_error` in 1.4; AdaBoost numerics changed
between 1.0.2 and 1.7) are visible in the same module / test file, but I
deliberately left them out of this PR to keep the change reviewable in one
sitting — happy to follow up on either if useful.

Suggested label: `bug`.

---

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup (Python 3.10 venv with current sklearn) ---
python3 -m venv /tmp/repro-2806 && source /tmp/repro-2806/bin/activate
pip install --quiet 'scikit-learn>=1.6' 'setuptools<81' jinja2 pyhamcrest pytest
git clone https://github.com/deepchecks/deepchecks.git /tmp/repro-2806/src
cd /tmp/repro-2806/src
pip install --quiet -e .

cat > /tmp/repro-2806/check.py <<'PY'
import numpy as np
from sklearn.linear_model import LogisticRegression
from deepchecks.tabular.metric_utils.scorers import binary_scorers_dict
X = np.array([[0., 0.], [1., 1.], [0., 1.], [1., 0.], [0., 0.5], [1., 0.5]])
y = np.array([0, 1, 0, 1, 0, 1])
clf = LogisticRegression().fit(X, y)
print("neg_log_loss =", binary_scorers_dict['neg_log_loss'](clf, X, y))
PY

# --- BEFORE (origin/main) ---
git checkout origin/main >/dev/null 2>&1
python /tmp/repro-2806/check.py
# Expected: TypeError: got an unexpected keyword argument 'needs_proba'

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/deepchecks.git feat/2806-sklearn-neg-log-loss
git checkout FETCH_HEAD >/dev/null 2>&1
python /tmp/repro-2806/check.py
# Expected: neg_log_loss = -<finite negative float>
```

The `<before-cmd>` and `<after-cmd>` lines are literally identical
(`python /tmp/repro-2806/check.py`); only the checked-out ref changes.

## What I ran locally

Inside a Python 3.10 venv with `scikit-learn==1.7.2`, `pip install -e .` of
the branch:

| Command | Result |
|---|---|
| `pytest tests/utils/metrics_test.py -k "neg_log_loss or roc_auc_per_class_scorer"` | **4 passed** on this branch; **3 failed** on `origin/main` (the 3 new regression tests). |
| `pylint --disable=all --enable=W,E deepchecks/tabular/metric_utils/scorers.py` | rated 10.00/10 |
| `pydocstyle --convention=pep257 --add-ignore=D107 deepchecks/tabular/metric_utils/scorers.py` | clean |

I did not run `make test` against the dev-pinned `scikit-learn==1.0.2` because
on that pin the original `needs_proba=True` works — the bug only manifests on
sklearn ≥ 1.6 and the new tests are designed to be valid on both pins (the
kwargs-match test asserts the right branch is taken regardless of sklearn
version). On sklearn 1.7.2, five pre-existing tests in `metrics_test.py` fail
on both `origin/main` and this branch (e.g. `test_iris_false_positive_rate_scorer_multiclass`,
`test_mse_diabetes`); those failures come from AdaBoost numerics drift between
sklearn 1.0.2 and 1.7.x, not from this change.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|---|---|---|---|
| 1 | Modern sklearn (≥1.4) | sklearn 1.7.2 installed in venv | `_PROBA_SCORER_KWARGS == {'response_method': 'predict_proba'}` | `test_neg_log_loss_scorer_kwargs_match_runtime_sklearn` |
| 2 | Legacy sklearn (<1.4) | `version.parse(scikit_version) < 1.4` branch | `_PROBA_SCORER_KWARGS == {'needs_proba': True}` (same observable as before this PR) | same test, alternate branch |
| 3 | Registry intact | import `binary_scorers_dict`, `multiclass_scorers_dict`, `_str_to_scorer_dict` | `'neg_log_loss'` and `'roc_auc_per_class'` are present | `test_neg_log_loss_scorer_constructible` |
| 4 | End-to-end binary scoring | trivial 6-row binary classifier, sklearn 1.7.2 | `neg_log_loss` returns a finite, non-positive score (no `TypeError`) | `test_neg_log_loss_scorer_callable_on_classifier` |
| 5 | End-to-end multiclass scoring | iris fixture (`AdaBoostClassifier`), sklearn 1.7.2 | `roc_auc_per_class[1] ≈ 0.997`, matching the existing integration test | `test_roc_auc_per_class_scorer_scores_multiclass` |

## Risk / blast radius

Module-level: import-time only. A runtime cost of one `version.parse` call,
once per Python process, then dictionary access via `**` unpacking — no
observable behavior change on sklearn < 1.4 (the dispatch dict yields exactly
the original `needs_proba=True` call). On sklearn ≥ 1.4 the only behavioral
change is "the scorer now works"; we still pass `predict_proba` rather than
falling back to `decision_function`, matching the original intent of
`needs_proba=True`.

## Release note

```release-note
Fix `make_scorer` kwarg incompatibility with scikit-learn ≥ 1.6 in
`neg_log_loss` and `roc_auc_per_class` scorers (issue #2806).
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against `deepchecks/deepchecks` source and the upstream
[scikit-learn 1.4 release notes](https://scikit-learn.org/stable/whats_new/v1.4.html#sklearn-metrics)
cited above. The reproducer block above was used during development; it is
the same one a reviewer can paste verbatim.*
