### PR TITLE
fix: use absolute values for feature correlation sorting and thresholds (#2802)

### DIFF
--- a/deepchecks/tabular/checks/data_integrity/feature_feature_correlation.py
+++ b/deepchecks/tabular/checks/data_integrity/feature_feature_correlation.py
@@ -105,7 +105,9 @@ class FeatureFeatureCorrelation(SingleDatasetCheck):
 
         # Display
         if context.with_display:
-            top_n_features = full_df.max(axis=1).sort_values(ascending=False).head(self.n_top_columns).index
+            temp_df = full_df.copy()
+            np.fill_diagonal(temp_df.values, np.nan)
+            top_n_features = temp_df.abs().max(axis=1).sort_values(ascending=False).head(self.n_top_columns).index
             top_n_df = full_df.loc[top_n_features, top_n_features].abs()
             num_nans = top_n_df.isna().sum().sum()
             top_n_df.fillna(0.0, inplace=True)
@@ -126,7 +128,7 @@ class FeatureFeatureCorrelation(SingleDatasetCheck):
     def add_condition_max_number_of_pairs_above_threshold(self, threshold: float = 0.9, n_pairs: int = 0):
         """Add condition that all pairwise correlations are less than threshold, except for the diagonal."""
         def condition(result):
-            results_ge = result[result > threshold].stack().index.to_list()
+            results_ge = result[result.abs() > threshold].stack().index.to_list()
             high_corr_pairs = [(i, j) for (i, j) in results_ge if i < j]  # remove diagonal and duplicate pairs
 
             if len(high_corr_pairs) > n_pairs:

--- a/tests/tabular/checks/integrity/feature_feature_correlation_test.py
+++ b/tests/tabular/checks/integrity/feature_feature_correlation_test.py
@@ -88,3 +88,30 @@ def test_feature_feature_correlation_fail_condition(adult_no_split):
                                        details=f'Correlation is greater than {threshold} for pairs {high_pairs}',
                                        name=f'Not more than {num_pairs} pairs are correlated above {threshold}')
             ))
+
+def test_feature_feature_correlation_negative_magnitude_condition():
+    # Create a mock dataset with an explicit, high-magnitude negative correlation
+    np.random.seed(42)
+    feature_x = np.random.randn(100)
+    # Inverse relationship guarantees a spearman correlation near -1.0
+    feature_y = -feature_x * 2 + np.random.randn(100) * 0.01
+    
+    df = pd.DataFrame({'feat_a': feature_x, 'feat_b': feature_y})
+    ds = Dataset(df, features=['feat_a', 'feat_b'])
+    
+    threshold = 0.9
+    num_pairs = 0  # 0 expected pairs means finding 1 high-magnitude pair will trigger a FAIL
+    
+    check = FeatureFeatureCorrelation()
+    result = check.add_condition_max_number_of_pairs_above_threshold(threshold, num_pairs).run(ds)
+    
+    # Expected pair sorted alphabetically by feature name based on the condition's internal (i < j) filter
+    expected_high_pairs = [('feat_a', 'feat_b')]
+    
+    assert_that(result.conditions_results, has_items(
+        equal_condition_result(is_pass=False,
+                               details=f'Correlation is greater than {threshold} for pairs {expected_high_pairs}',
+                               name=f'Not more than {num_pairs} pairs are correlated above {threshold}')
+    ))
+
+    


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2802

#### What does this implement/fix? Explain your changes.
This PR addresses two critical bugs within the `FeatureFeatureCorrelation` tabular check where features with high-magnitude negative correlations were omitted or inaccurately ranked, and threshold conditions failed to intercept strong inverse relationships.

**Changes implemented:**
* **Self-Correlation Filtering:** Modified the feature ranking display logic by instantiating a temporary copy of `full_df` and applying `np.fill_diagonal(temp_df.values, np.nan)`. This explicitly prevents the perfect $1.0$ diagonal self-correlation from drowning out actual top-correlated feature pairs during the `.max(axis=1)` calculation.
* **Magnitude-Based Sorting:** Injected `.abs()` into the sorting chain (`temp_df.abs().max(axis=1).sort_values(...)`) so that feature relationships are ranked purely by statistical strength/magnitude rather than direction, capturing critical inverse associations.
* **Absolute Threshold Evaluation:** Patched the underlying condition logic within `add_condition_max_number_of_pairs_above_threshold` to evaluate `result.abs() > threshold`, ensuring that high-magnitude negative correlation coefficients (e.g., $-0.95$) are correctly flagged against user-defined limits.

#### Any other comments?
Special thanks to @RakeshPardeshi for the initial diagnostic work on this issue.