### PR TITLE
fix(serialization): keep nested DataFrames structured in to_json

### DIFF
--- a/deepchecks/core/serialization/common.py
+++ b/deepchecks/core/serialization/common.py
@@ -95,11 +95,15 @@ def normalize_value(value: object) -> t.Any:
     Any of the basic builtin datatypes
     """
     if isinstance(value, pd.DataFrame):
-        return value.to_json(orient='records')
+        return value.to_dict(orient='records')
     elif isinstance(value, Styler):
-        return value.data.to_json(orient='records')
+        return value.data.to_dict(orient='records')
     elif isinstance(value, (np.generic, np.ndarray)):
         return un_numpy(value)
+    elif isinstance(value, dict):
+        return {key: normalize_value(item) for key, item in value.items()}
+    elif isinstance(value, (list, tuple)):
+        return [normalize_value(item) for item in value]
     else:
         return Pickler(unpicklable=False).flatten(value)
 

--- a/tests/serialization/test_normalize_value.py
+++ b/tests/serialization/test_normalize_value.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2021-2023 Deepchecks (https://www.deepchecks.com)
+#
+# This file is part of Deepchecks.
+# Deepchecks is distributed under the terms of the GNU Affero General
+# Public License (version 3 or later).
+# You should have received a copy of the GNU Affero General Public License
+# along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+#
+"""normalize_value serialization tests."""
+import json
+
+import pandas as pd
+from hamcrest import assert_that, equal_to, instance_of
+
+from deepchecks.core.serialization.common import normalize_value
+
+
+def test_normalize_value_keeps_nested_dataframe_structure():
+    """Nested CheckResult values (e.g. WeakSegmentsPerformance) must stay dict-shaped."""
+    weak_segments = pd.DataFrame({
+        'Score': [0.1, 0.2],
+        'Feature1': ['a', 'b'],
+    })
+    value = {
+        'weak_segments_list': weak_segments,
+        'avg_score': 0.42,
+    }
+
+    normalized = normalize_value(value)
+
+    assert_that(normalized, instance_of(dict))
+    assert_that(normalized['avg_score'], equal_to(0.42))
+    assert_that(normalized['weak_segments_list'], equal_to([
+        {'Score': 0.1, 'Feature1': 'a'},
+        {'Score': 0.2, 'Feature1': 'b'},
+    ]))
+    # Must be JSON-serializable without flattening nested structure into a string blob
+    dumped = json.dumps(normalized)
+    loaded = json.loads(dumped)
+    assert_that(loaded['weak_segments_list'][0]['Feature1'], equal_to('a'))
+
+
+def test_normalize_value_dataframe_returns_records_list():
+    df = pd.DataFrame({'x': [1], 'y': [2]})
+    assert_that(normalize_value(df), equal_to([{'x': 1, 'y': 2}]))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2804.

#### What does this implement/fix? Explain your changes.

`CheckResult.to_json()` serializes `value` via `normalize_value`. For nested values such as `WeakSegmentsPerformance` (`{'weak_segments_list': DataFrame, 'avg_score': float}`), the previous path only special-cased *top-level* DataFrames (as JSON **strings**) and handed nested containers to jsonpickle, which flattened the structure users expect.

This change:
- converts DataFrame / Styler values with `to_dict(orient='records')` (aligned with display JSON serialization)
- recursively normalizes `dict` / `list` / `tuple` containers so nested DataFrames stay structured

Adds `tests/serialization/test_normalize_value.py`.

#### Any other comments?

Full suite not run on this host (missing package deps); CI should execute serialization tests.

---
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/deepchecks/deepchecks/blob/main/CONTRIBUTING.rst
